### PR TITLE
fix(cac-types): add missing header fields to chunked message types

### DIFF
--- a/crates/cac/types/src/msgs.rs
+++ b/crates/cac/types/src/msgs.rs
@@ -1,7 +1,8 @@
 //! Protocol message types for communication between Garbler and Evaluator.
 //!
 //! All message types are designed to fit within the 4 MiB network frame limit.
-//! Large logical messages are split into chunks for transmission.
+//! Large logical messages are split into a header (containing metadata) and
+//! chunks (containing the bulk data) for transmission.
 
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid, Validate,
@@ -9,13 +10,26 @@ use ark_serialize::{
 };
 
 use crate::{
-    Adaptor, AdaptorMsgChunkWithdrawals, ChallengeIndices, CircuitInputShares,
+    Adaptor, AdaptorMsgChunkWithdrawals, AllGarblingTableCommitments, ChallengeIndices,
+    CircuitInputShares, OpenedGarblingSeeds, OpenedOutputShares, ReservedSetupInputShares,
     WideLabelWirePolynomialCommitments,
 };
 
 // ============================================================================
-// Message Types (all fit within 4 MiB frame limit)
+// Commit Message Types (Garbler -> Evaluator)
 // ============================================================================
+
+/// CommitMsgHeader: Garbler -> Evaluator
+///
+/// Header containing garbling table commitments for all circuits.
+/// Sent once before the commitment chunks.
+///
+/// Size: ~5.7 KB (fits in single frame)
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct CommitMsgHeader {
+    /// Commitments to all N_CIRCUITS garbling tables.
+    pub garbling_table_commitments: AllGarblingTableCommitments,
+}
 
 /// CommitMsgChunk: Garbler -> Evaluator (chunked by wire)
 ///
@@ -34,9 +48,13 @@ pub struct CommitMsgChunk {
     pub commitments: WideLabelWirePolynomialCommitments,
 }
 
+// ============================================================================
+// Challenge Message Type (Evaluator -> Garbler)
+// ============================================================================
+
 /// ChallengeMsg: Evaluator -> Garbler
 ///
-/// Evaluator's challenge after receiving commitment chunks.
+/// Evaluator's challenge after receiving commitment header and chunks.
 /// Selects which circuits to open for verification.
 ///
 /// Size: ~1.4 KB (fits in single frame, no chunking needed)
@@ -45,6 +63,29 @@ pub struct ChallengeMsg {
     /// Indices of circuits to open for verification.
     /// Size: N_OPEN_CIRCUITS (174 of 181)
     pub challenge_indices: ChallengeIndices,
+}
+
+// ============================================================================
+// Challenge Response Message Types (Garbler -> Evaluator)
+// ============================================================================
+
+/// ChallengeResponseMsgHeader: Garbler -> Evaluator
+///
+/// Header containing per-protocol data for the challenge response.
+/// Sent once before the challenge response chunks.
+///
+/// Size: ~12.4 KB (fits in single frame)
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ChallengeResponseMsgHeader {
+    /// Reserved input shares for setup input wires.
+    /// Size: N_SETUP_INPUT_WIRES (4) shares
+    pub reserved_setup_input_shares: ReservedSetupInputShares,
+    /// Output shares for all opened circuits.
+    /// Size: N_OPEN_CIRCUITS (174) shares
+    pub opened_output_shares: OpenedOutputShares,
+    /// Garbling seeds for all opened circuits.
+    /// Size: N_OPEN_CIRCUITS (174) seeds
+    pub opened_garbling_seeds: OpenedGarblingSeeds,
 }
 
 /// ChallengeResponseMsgChunk: Garbler -> Evaluator (chunked by circuit)
@@ -61,6 +102,10 @@ pub struct ChallengeResponseMsgChunk {
     /// Shares for all wires × all wide label values for this circuit.
     pub shares: CircuitInputShares,
 }
+
+// ============================================================================
+// Adaptor Message Type (Evaluator -> Garbler)
+// ============================================================================
 
 /// AdaptorMsgChunk: Evaluator -> Garbler (chunked by deposit wire)
 ///
@@ -90,12 +135,16 @@ pub struct AdaptorMsgChunk {
 /// Note: Acknowledgments are handled at the network layer, not here.
 /// Note: Garbling tables are transferred via bulk streams, not protocol messages.
 #[derive(Debug)]
-#[expect(clippy::large_enum_variant, reason = "AdaptorMsg")]
+#[expect(clippy::large_enum_variant, reason = "AdaptorMsgChunk is large")]
 pub enum Msg {
+    /// Commitment header (Garbler -> Evaluator)
+    CommitHeader(CommitMsgHeader),
     /// Commitment chunk (Garbler -> Evaluator)
     CommitChunk(CommitMsgChunk),
     /// Challenge message (Evaluator -> Garbler)
     Challenge(ChallengeMsg),
+    /// Challenge response header (Garbler -> Evaluator)
+    ChallengeResponseHeader(ChallengeResponseMsgHeader),
     /// Challenge response chunk (Garbler -> Evaluator)
     ChallengeResponseChunk(ChallengeResponseMsgChunk),
     /// Adaptor signatures chunk (Evaluator -> Garbler)
@@ -105,10 +154,12 @@ pub enum Msg {
 /// Message variant discriminant for serialization.
 #[repr(u8)]
 enum MsgVariant {
-    CommitChunk = 0,
-    Challenge = 1,
-    ChallengeResponseChunk = 2,
-    AdaptorChunk = 3,
+    CommitHeader = 0,
+    CommitChunk = 1,
+    Challenge = 2,
+    ChallengeResponseHeader = 3,
+    ChallengeResponseChunk = 4,
+    AdaptorChunk = 5,
 }
 
 impl TryFrom<u8> for MsgVariant {
@@ -116,10 +167,12 @@ impl TryFrom<u8> for MsgVariant {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(MsgVariant::CommitChunk),
-            1 => Ok(MsgVariant::Challenge),
-            2 => Ok(MsgVariant::ChallengeResponseChunk),
-            3 => Ok(MsgVariant::AdaptorChunk),
+            0 => Ok(MsgVariant::CommitHeader),
+            1 => Ok(MsgVariant::CommitChunk),
+            2 => Ok(MsgVariant::Challenge),
+            3 => Ok(MsgVariant::ChallengeResponseHeader),
+            4 => Ok(MsgVariant::ChallengeResponseChunk),
+            5 => Ok(MsgVariant::AdaptorChunk),
             _ => Err(SerializationError::InvalidData),
         }
     }
@@ -132,12 +185,21 @@ impl CanonicalSerialize for Msg {
         compress: Compress,
     ) -> Result<(), SerializationError> {
         match self {
+            Msg::CommitHeader(msg) => {
+                (MsgVariant::CommitHeader as u8).serialize_with_mode(&mut writer, compress)?;
+                msg.serialize_with_mode(&mut writer, compress)
+            }
             Msg::CommitChunk(msg) => {
                 (MsgVariant::CommitChunk as u8).serialize_with_mode(&mut writer, compress)?;
                 msg.serialize_with_mode(&mut writer, compress)
             }
             Msg::Challenge(msg) => {
                 (MsgVariant::Challenge as u8).serialize_with_mode(&mut writer, compress)?;
+                msg.serialize_with_mode(&mut writer, compress)
+            }
+            Msg::ChallengeResponseHeader(msg) => {
+                (MsgVariant::ChallengeResponseHeader as u8)
+                    .serialize_with_mode(&mut writer, compress)?;
                 msg.serialize_with_mode(&mut writer, compress)
             }
             Msg::ChallengeResponseChunk(msg) => {
@@ -154,8 +216,10 @@ impl CanonicalSerialize for Msg {
 
     fn serialized_size(&self, compress: Compress) -> usize {
         1 + match self {
+            Msg::CommitHeader(msg) => msg.serialized_size(compress),
             Msg::CommitChunk(msg) => msg.serialized_size(compress),
             Msg::Challenge(msg) => msg.serialized_size(compress),
+            Msg::ChallengeResponseHeader(msg) => msg.serialized_size(compress),
             Msg::ChallengeResponseChunk(msg) => msg.serialized_size(compress),
             Msg::AdaptorChunk(msg) => msg.serialized_size(compress),
         }
@@ -172,6 +236,10 @@ impl CanonicalDeserialize for Msg {
         let variant = MsgVariant::try_from(variant_byte)?;
 
         match variant {
+            MsgVariant::CommitHeader => {
+                let msg = CommitMsgHeader::deserialize_with_mode(&mut reader, compress, validate)?;
+                Ok(Msg::CommitHeader(msg))
+            }
             MsgVariant::CommitChunk => {
                 let msg = CommitMsgChunk::deserialize_with_mode(&mut reader, compress, validate)?;
                 Ok(Msg::CommitChunk(msg))
@@ -179,6 +247,14 @@ impl CanonicalDeserialize for Msg {
             MsgVariant::Challenge => {
                 let msg = ChallengeMsg::deserialize_with_mode(&mut reader, compress, validate)?;
                 Ok(Msg::Challenge(msg))
+            }
+            MsgVariant::ChallengeResponseHeader => {
+                let msg = ChallengeResponseMsgHeader::deserialize_with_mode(
+                    &mut reader,
+                    compress,
+                    validate,
+                )?;
+                Ok(Msg::ChallengeResponseHeader(msg))
             }
             MsgVariant::ChallengeResponseChunk => {
                 let msg = ChallengeResponseMsgChunk::deserialize_with_mode(
@@ -199,8 +275,10 @@ impl CanonicalDeserialize for Msg {
 impl Valid for Msg {
     fn check(&self) -> Result<(), SerializationError> {
         match self {
+            Msg::CommitHeader(msg) => msg.check(),
             Msg::CommitChunk(msg) => msg.check(),
             Msg::Challenge(msg) => msg.check(),
+            Msg::ChallengeResponseHeader(msg) => msg.check(),
             Msg::ChallengeResponseChunk(msg) => msg.check(),
             Msg::AdaptorChunk(msg) => msg.check(),
         }

--- a/crates/cac/types/src/protocol.rs
+++ b/crates/cac/types/src/protocol.rs
@@ -39,7 +39,8 @@ pub type AllPolynomialCommitments = (
 );
 
 /// Commitments for all `N_CIRCUITS` garbling tables.
-pub type AllGarblingTableCommitments = [GarblingTableCommitment; N_CIRCUITS];
+/// Uses HeapArray for serialization derive macro support.
+pub type AllGarblingTableCommitments = HeapArray<GarblingTableCommitment, N_CIRCUITS>;
 /// Commitments for opened garbling tables.
 pub type OpenedGarblingTableCommitments = [GarblingTableCommitment; N_OPEN_CIRCUITS];
 /// Commitments for eval garbling tables.
@@ -75,21 +76,23 @@ pub type ReservedInputShares = CircuitInputShares;
 pub type OpenedInputShares = [CircuitInputShares; N_OPEN_CIRCUITS];
 
 /// Reserved input shares for wide labels corresponding to agreed setup inputs, for each setup input
-/// wire.
-pub type ReservedSetupInputShares = [Share; N_SETUP_INPUT_WIRES];
+/// wire. Uses HeapArray for serialization derive macro support.
+pub type ReservedSetupInputShares = HeapArray<Share, N_SETUP_INPUT_WIRES>;
 /// Reserved input shares for all wide label values corresponding to deposit input wires.
 pub type ReservedDepositInputShares = [WideLabelWireShares; N_DEPOSIT_INPUT_WIRES];
 /// Reserved input shares for all wide labels corresponding to withdrawal input wires.
 pub type ReservedWithdrawalInputShares = [WideLabelWireShares; N_WITHDRAWAL_INPUT_WIRES];
 /// Shares for value 0 output wire for for all opened indices.
-pub type OpenedOutputShares = [CircuitOutputShare; N_OPEN_CIRCUITS];
+/// Uses HeapArray for serialization derive macro support.
+pub type OpenedOutputShares = HeapArray<CircuitOutputShare, N_OPEN_CIRCUITS>;
 
 /// Seed for garbling table generation.
 pub type GarblingSeed = Seed;
 /// Seeds for garbling table generation for all indices.
 pub type AllGarblingSeeds = [GarblingSeed; N_CIRCUITS];
 /// Seeds for garbling table generation for all opened indices.
-pub type OpenedGarblingSeeds = [GarblingSeed; N_OPEN_CIRCUITS];
+/// Uses HeapArray for serialization derive macro support.
+pub type OpenedGarblingSeeds = HeapArray<GarblingSeed, N_OPEN_CIRCUITS>;
 /// Seeds for garbling table generation for evaluation indices.
 pub type EvalGarblingSeeds = [GarblingSeed; N_EVAL_CIRCUITS];
 

--- a/crates/cac/types/src/serde_tests.rs
+++ b/crates/cac/types/src/serde_tests.rs
@@ -14,10 +14,11 @@ use mosaic_vs3::{Index, Point, Polynomial, PolynomialCommitment, Scalar, Share};
 use proptest::prelude::*;
 
 use crate::{
-    Adaptor, AdaptorMsgChunk, AdaptorMsgChunkWithdrawals, ChallengeIndices, ChallengeMsg,
-    ChallengeResponseMsgChunk, CircuitInputShares, CommitMsgChunk, DepositId, Msg, PubKey,
-    SecretKey, Sighash, Signature, WideLabelWireAdaptors, WideLabelWirePolynomialCommitments,
-    WideLabelWireShares,
+    Adaptor, AdaptorMsgChunk, AdaptorMsgChunkWithdrawals, AllGarblingTableCommitments,
+    ChallengeIndices, ChallengeMsg, ChallengeResponseMsgChunk, ChallengeResponseMsgHeader,
+    CircuitInputShares, CommitMsgChunk, CommitMsgHeader, DepositId, Msg, OpenedGarblingSeeds,
+    OpenedOutputShares, PubKey, ReservedSetupInputShares, SecretKey, Sighash, Signature,
+    WideLabelWireAdaptors, WideLabelWirePolynomialCommitments, WideLabelWireShares,
 };
 
 /// Helper to perform a serialization roundtrip and verify equality.
@@ -197,11 +198,42 @@ fn arb_adaptor_msg_chunk() -> impl Strategy<Value = AdaptorMsgChunk> {
     })
 }
 
+/// Generate a CommitMsgHeader with random garbling table commitments.
+fn arb_commit_msg_header() -> impl Strategy<Value = CommitMsgHeader> {
+    any::<u64>().prop_map(|seed| {
+        let bytes: [u8; 32] = std::array::from_fn(|i| ((seed >> (i % 8)) & 0xff) as u8);
+        let commitment: Byte32 = bytes.into();
+
+        CommitMsgHeader {
+            garbling_table_commitments: AllGarblingTableCommitments::new(|_| commitment),
+        }
+    })
+}
+
+/// Generate a ChallengeResponseMsgHeader with random data.
+fn arb_challenge_response_msg_header() -> impl Strategy<Value = ChallengeResponseMsgHeader> {
+    any::<u64>().prop_map(|seed| {
+        let bytes: [u8; 32] = std::array::from_fn(|i| ((seed >> (i % 8)) & 0xff) as u8);
+        let single_scalar = Scalar::from_le_bytes_mod_order(&bytes);
+        let idx = Index::new(1).unwrap_or(Index::reserved());
+        let share = Share::new(idx, single_scalar);
+        let seed_bytes: Byte32 = bytes.into();
+
+        ChallengeResponseMsgHeader {
+            reserved_setup_input_shares: ReservedSetupInputShares::new(|_| share.clone()),
+            opened_output_shares: OpenedOutputShares::new(|_| share.clone()),
+            opened_garbling_seeds: OpenedGarblingSeeds::new(|_| seed_bytes),
+        }
+    })
+}
+
 /// Generate a random Msg variant.
 fn arb_msg() -> impl Strategy<Value = Msg> {
     prop_oneof![
+        arb_commit_msg_header().prop_map(Msg::CommitHeader),
         arb_commit_msg_chunk().prop_map(Msg::CommitChunk),
         arb_challenge_msg().prop_map(Msg::Challenge),
+        arb_challenge_response_msg_header().prop_map(Msg::ChallengeResponseHeader),
         arb_challenge_response_msg_chunk().prop_map(Msg::ChallengeResponseChunk),
         arb_adaptor_msg_chunk().prop_map(Msg::AdaptorChunk),
     ]
@@ -350,8 +382,10 @@ proptest! {
 
         // Check variant matches
         match (&msg, &recovered) {
+            (Msg::CommitHeader(_), Msg::CommitHeader(_)) => {}
             (Msg::CommitChunk(_), Msg::CommitChunk(_)) => {}
             (Msg::Challenge(_), Msg::Challenge(_)) => {}
+            (Msg::ChallengeResponseHeader(_), Msg::ChallengeResponseHeader(_)) => {}
             (Msg::ChallengeResponseChunk(_), Msg::ChallengeResponseChunk(_)) => {}
             (Msg::AdaptorChunk(_), Msg::AdaptorChunk(_)) => {}
             _ => panic!("variant mismatch after roundtrip"),
@@ -586,6 +620,141 @@ fn test_invalid_scalar_deserialization_fails() {
             .is_err(),
         "scalar >= field order should fail deserialization with validation"
     );
+}
+
+// =============================================================================
+// Tests for frame size limits (4 MiB)
+// =============================================================================
+
+/// Maximum frame size for network transmission (4 MiB).
+const MAX_FRAME_SIZE: usize = 4 * 1024 * 1024;
+
+/// Helper to check that a message fits within the frame limit.
+fn assert_fits_in_frame<T: CanonicalSerialize>(msg: &T, name: &str, compress: Compress) {
+    let size = msg.serialized_size(compress);
+    assert!(
+        size <= MAX_FRAME_SIZE,
+        "{} serialized size ({} bytes, {} mode) exceeds 4 MiB frame limit ({} bytes)",
+        name,
+        size,
+        if compress == Compress::Yes {
+            "compressed"
+        } else {
+            "uncompressed"
+        },
+        MAX_FRAME_SIZE
+    );
+}
+
+#[test]
+fn test_commit_msg_header_fits_in_frame() {
+    // CommitMsgHeader contains N_CIRCUITS (181) garbling table commitments (32 bytes each)
+    // Expected size: ~5.7 KB
+    let header = CommitMsgHeader {
+        garbling_table_commitments: AllGarblingTableCommitments::new(|_| [0u8; 32].into()),
+    };
+
+    assert_fits_in_frame(&header, "CommitMsgHeader", Compress::Yes);
+    assert_fits_in_frame(&header, "CommitMsgHeader", Compress::No);
+
+    // Verify actual size is what we expect (sanity check)
+    let size = header.serialized_size(Compress::No);
+    assert!(
+        size < 10 * 1024,
+        "CommitMsgHeader should be ~5.7 KB, got {} bytes",
+        size
+    );
+}
+
+#[test]
+fn test_challenge_response_msg_header_fits_in_frame() {
+    // ChallengeResponseMsgHeader contains:
+    // - N_SETUP_INPUT_WIRES (4) shares (~160 bytes)
+    // - N_OPEN_CIRCUITS (174) output shares (~6.8 KB)
+    // - N_OPEN_CIRCUITS (174) seeds (~5.4 KB)
+    // Expected total: ~12.4 KB
+    let scalar = Scalar::from_le_bytes_mod_order(&[1u8; 32]);
+    let idx = Index::new(1).expect("valid index");
+    let share = Share::new(idx, scalar);
+
+    let header = ChallengeResponseMsgHeader {
+        reserved_setup_input_shares: ReservedSetupInputShares::new(|_| share.clone()),
+        opened_output_shares: OpenedOutputShares::new(|_| share.clone()),
+        opened_garbling_seeds: OpenedGarblingSeeds::new(|_| [0u8; 32].into()),
+    };
+
+    assert_fits_in_frame(&header, "ChallengeResponseMsgHeader", Compress::Yes);
+    assert_fits_in_frame(&header, "ChallengeResponseMsgHeader", Compress::No);
+
+    // Verify actual size is what we expect (sanity check)
+    let size = header.serialized_size(Compress::No);
+    assert!(
+        size < 20 * 1024,
+        "ChallengeResponseMsgHeader should be ~12.4 KB, got {} bytes",
+        size
+    );
+}
+
+#[test]
+fn test_challenge_msg_fits_in_frame() {
+    // ChallengeMsg contains N_OPEN_CIRCUITS (174) indices
+    // Expected size: ~1.4 KB
+    let msg = ChallengeMsg {
+        challenge_indices: ChallengeIndices::new(|i| Index::new(i + 1).expect("valid index")),
+    };
+
+    assert_fits_in_frame(&msg, "ChallengeMsg", Compress::Yes);
+    assert_fits_in_frame(&msg, "ChallengeMsg", Compress::No);
+
+    let size = msg.serialized_size(Compress::No);
+    assert!(
+        size < 5 * 1024,
+        "ChallengeMsg should be ~1.4 KB, got {} bytes",
+        size
+    );
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(3))]
+
+    #[test]
+    fn test_commit_msg_chunk_fits_in_frame(chunk in arb_commit_msg_chunk()) {
+        // CommitMsgChunk: ~1.4 MB compressed, ~2.76 MB uncompressed
+        assert_fits_in_frame(&chunk, "CommitMsgChunk", Compress::Yes);
+        assert_fits_in_frame(&chunk, "CommitMsgChunk", Compress::No);
+    }
+
+    #[test]
+    fn test_challenge_response_msg_chunk_fits_in_frame(chunk in arb_challenge_response_msg_chunk()) {
+        // ChallengeResponseMsgChunk: ~1.68 MB per chunk
+        assert_fits_in_frame(&chunk, "ChallengeResponseMsgChunk", Compress::Yes);
+        assert_fits_in_frame(&chunk, "ChallengeResponseMsgChunk", Compress::No);
+    }
+
+    #[test]
+    fn test_adaptor_msg_chunk_fits_in_frame(chunk in arb_adaptor_msg_chunk()) {
+        // AdaptorMsgChunk: ~1.6 MB uncompressed
+        assert_fits_in_frame(&chunk, "AdaptorMsgChunk", Compress::Yes);
+        assert_fits_in_frame(&chunk, "AdaptorMsgChunk", Compress::No);
+    }
+
+    #[test]
+    fn test_commit_msg_header_fits_in_frame_proptest(header in arb_commit_msg_header()) {
+        assert_fits_in_frame(&header, "CommitMsgHeader", Compress::Yes);
+        assert_fits_in_frame(&header, "CommitMsgHeader", Compress::No);
+    }
+
+    #[test]
+    fn test_challenge_response_msg_header_fits_in_frame_proptest(header in arb_challenge_response_msg_header()) {
+        assert_fits_in_frame(&header, "ChallengeResponseMsgHeader", Compress::Yes);
+        assert_fits_in_frame(&header, "ChallengeResponseMsgHeader", Compress::No);
+    }
+
+    #[test]
+    fn test_all_msg_variants_fit_in_frame(msg in arb_msg()) {
+        assert_fits_in_frame(&msg, "Msg", Compress::Yes);
+        assert_fits_in_frame(&msg, "Msg", Compress::No);
+    }
 }
 
 #[test]

--- a/crates/cac/types/src/state_machine/evaluator/input.rs
+++ b/crates/cac/types/src/state_machine/evaluator/input.rs
@@ -1,9 +1,10 @@
 use mosaic_vs3::Index;
 
 use crate::{
-    ChallengeResponseMsgChunk, CircuitOutputShare, CommitMsgChunk, CompletedSignatures,
-    DepositAdaptors, DepositId, DepositInputs, GarblingTableCommitment, SecretKey, Seed,
-    SetupInputs, Sighashes, WithdrawalAdaptors, WithdrawalInputs,
+    ChallengeResponseMsgChunk, ChallengeResponseMsgHeader, CircuitOutputShare, CommitMsgChunk,
+    CommitMsgHeader, CompletedSignatures, DepositAdaptors, DepositId, DepositInputs,
+    GarblingTableCommitment, SecretKey, Seed, SetupInputs, Sighashes, WithdrawalAdaptors,
+    WithdrawalInputs,
 };
 
 /// Evaluator state machine inputs.
@@ -12,10 +13,14 @@ use crate::{
 pub enum Input {
     /// Initialize evaluator state machine.
     Init(EvaluatorInitData),
+    /// Commit message header received.
+    RecvCommitMsgHeader(CommitMsgHeader),
     /// Commit message chunk received.
     RecvCommitMsgChunk(CommitMsgChunk),
     /// Challenge message was acked by peer.
     ChallengeMsgAcked,
+    /// Challenge response message header received.
+    RecvChallengeResponseMsgHeader(ChallengeResponseMsgHeader),
     /// Challenge response message chunk received.
     RecvChallengeResponseMsgChunk(ChallengeResponseMsgChunk),
     /// Opened input shares verification failure message or None.

--- a/crates/cac/types/src/state_machine/garbler/input.rs
+++ b/crates/cac/types/src/state_machine/garbler/input.rs
@@ -18,11 +18,15 @@ pub enum Input {
     SharesGenerated(Index, Box<CircuitInputShares>, Box<CircuitOutputShare>),
     /// Garbling table commitment generated.
     TableCommitmentGenerated(Index, GarblingTableCommitment),
-    /// Commit message was acked by peer.
+    /// Commit message header was acked by peer.
+    CommitHeaderAcked,
+    /// Commit message (all chunks) was acked by peer.
     CommitMsgAcked,
     /// Challenge message received.
     RecvChallengeMsg(ChallengeMsg),
-    /// Challenge response message was acked by peer.
+    /// Challenge response message header was acked by peer.
+    ChallengeResponseHeaderAcked,
+    /// Challenge response message (all chunks) was acked by peer.
     ChallengeResponseAcked,
     /// Garbling table generated with specified seed was transferred to the other party.
     GarblingTableTransferred(GarblingSeed, GarblingTableCommitment),


### PR DESCRIPTION
## Summary

Add `CommitMsgHeader` and `ChallengeResponseMsgHeader` to include fields that were missing from the chunked message types introduced in beb5aa3.

## Problem

The chunking PR (`beb5aa3`) split large messages into chunks for network transmission but omitted several required fields:

### `CommitMsg` → `CommitMsgChunk`
- ❌ Missing: `garbling_table_commitments` (`AllGarblingTableCommitments`)

### `ChallengeResponseMsg` → `ChallengeResponseMsgChunk`
- ❌ Missing: `reserved_setup_input_shares` (`ReservedSetupInputShares`)
- ❌ Missing: `opened_output_shares` (`OpenedOutputShares`)
- ❌ Missing: `opened_garbling_seeds` (`OpenedGarblingSeeds`)

## Solution

Add separate header message types that contain the missing fields. These are small enough to fit in a single frame:

| Header Type | Size | Contents |
|-------------|------|----------|
| `CommitMsgHeader` | ~5.7 KB | `garbling_table_commitments` |
| `ChallengeResponseMsgHeader` | ~12.4 KB | `reserved_setup_input_shares`, `opened_output_shares`, `opened_garbling_seeds` |

## Changes

### Message Types (`msgs.rs`)
- Add `CommitMsgHeader` struct
- Add `ChallengeResponseMsgHeader` struct
- Add `CommitHeader` and `ChallengeResponseHeader` variants to `Msg` enum
- Update serialization discriminants

### Protocol Types (`protocol.rs`)
- Update type aliases to use `HeapArray` for serialization derive macro support:
  - `AllGarblingTableCommitments`
  - `ReservedSetupInputShares`
  - `OpenedOutputShares`
  - `OpenedGarblingSeeds`

### State Machine Inputs
- **Evaluator**: Add `RecvCommitMsgHeader`, `RecvChallengeResponseMsgHeader`
- **Garbler**: Add `CommitHeaderAcked`, `ChallengeResponseHeaderAcked`

### Tests (`serde_tests.rs`)
- Add 9 new frame size limit tests verifying all message types fit within 4 MiB
- Add property-based tests for header message roundtrips
- Update `test_msg_enum_roundtrip` to include new variants

## Protocol Flow (Updated)

```
Garbler                              Evaluator
   |                                    |
   |-- CommitMsgHeader ---------------->|
   |-- CommitMsgChunk[0..172] --------->|
   |                                    |
   |<-------------- ChallengeMsg -------|
   |                                    |
   |-- ChallengeResponseMsgHeader ----->|
   |-- ChallengeResponseMsgChunk[0..174]|
   |                                    |
```

## Testing

```bash
cargo test -p mosaic-cac-types --lib
# 40 tests pass, including 9 new frame limit tests
```

## Follow-up

- #72 - State machine updates in `cac-protocol` to handle header messages

Closes #70