### PR TITLE
chore: don't use type alias for `ChaCha20Rng`

### DIFF
--- a/crates/cac/protocol/src/garbler/tests.rs
+++ b/crates/cac/protocol/src/garbler/tests.rs
@@ -8,7 +8,7 @@ use mosaic_cac_types::{
 };
 use mosaic_common::constants::{N_CIRCUITS, N_INPUT_WIRES, N_SETUP_INPUT_WIRES};
 use mosaic_storage_inmemory::garbler::StoredGarblerState;
-use rand_chacha::{ChaChaRng, rand_core::SeedableRng};
+use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
 use super::stf::{handle_action_result, handle_event, restore};
 
@@ -32,7 +32,7 @@ fn sample_adaptor() -> Adaptor {
 async fn test_handle_init() {
     let mut state = StoredGarblerState::default();
 
-    let mut rng = ChaChaRng::seed_from_u64(0);
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
     let seed = rand_byte_array(&mut rng).into();
     let setup_inputs = rand_byte_array(&mut rng);
 
@@ -64,7 +64,7 @@ async fn test_deposit_init() {
         .await
         .unwrap();
 
-    let mut rng = ChaChaRng::seed_from_u64(0);
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
     let deposit_id = rand_byte_array(&mut rng).into();
 
     let keypair = KeyPair::rand(&mut rng);
@@ -158,7 +158,7 @@ async fn test_reject_mismatched_adaptor_chunk_deposit_id() {
 #[tokio::test]
 async fn restore_sending_commit_replays_only_unacked_header_and_chunks() {
     let mut state = StoredGarblerState::default();
-    let mut rng = ChaChaRng::seed_from_u64(7);
+    let mut rng = ChaCha20Rng::seed_from_u64(7);
     let poly_commitment = Polynomial::rand(&mut rng).commit();
     let wire_commitments = HeapArray::from_elem(poly_commitment.clone());
     let output_polynomial_commitment = HeapArray::from_elem(poly_commitment);

--- a/crates/cac/protocol/src/tests.rs
+++ b/crates/cac/protocol/src/tests.rs
@@ -38,7 +38,7 @@ use mosaic_job_executors::{
 use mosaic_net_svc_api::PeerId;
 use mosaic_storage_api::{StorageProvider, TableMetadata, TableReader, TableStore, TableWriter};
 use mosaic_storage_inmemory::{evaluator::StoredEvaluatorState, garbler::StoredGarblerState};
-use rand_chacha::{ChaCha20Rng, ChaChaRng, rand_core::SeedableRng};
+use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
 use crate::{
     evaluator, garbler,
@@ -326,7 +326,7 @@ async fn test_e2e() {
     };
 
     let mut garb_state = StoredGarblerState::default();
-    let mut garb_rng = ChaChaRng::seed_from_u64(42);
+    let mut garb_rng = ChaCha20Rng::seed_from_u64(42);
     let mut eval_state = StoredEvaluatorState::default();
     let mut eval_rng = ChaCha20Rng::seed_from_u64(43);
 

--- a/crates/rpc/service/src/default.rs
+++ b/crates/rpc/service/src/default.rs
@@ -729,7 +729,7 @@ fn derive_deposit_keypair(base_seed: Seed, deposit_id: &DepositId) -> (SecretKey
     let stage = format!("deposit:{}", deposit_id.0.to_hex());
     let seed = derive_stage_seed(base_seed, &stage);
 
-    let mut rng = rand_chacha::ChaChaRng::from_seed(seed.to_bytes());
+    let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed.to_bytes());
     let keypair = KeyPair::rand(&mut rng);
 
     (keypair.secret_key(), keypair.public_key())

--- a/crates/rpc/service/src/tests.rs
+++ b/crates/rpc/service/src/tests.rs
@@ -18,7 +18,7 @@ use mosaic_storage_api::{Commit, StorageProviderMut};
 use mosaic_storage_inmemory::InMemoryStorageProvider;
 use mosaic_vs3::{Index, Polynomial, Share};
 use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
+use rand_chacha::ChaCha20Rng;
 
 use crate::{
     DefaultMosaicApi, DepositStatus, EvaluatorDepositInit, EvaluatorWithdrawalData,
@@ -31,7 +31,7 @@ use crate::{
 // ---------------------------------------------------------------------------
 
 struct TestHarness {
-    api: DefaultMosaicApi<InMemoryStorageProvider, ChaChaRng>,
+    api: DefaultMosaicApi<InMemoryStorageProvider, ChaCha20Rng>,
     storage: InMemoryStorageProvider,
     rx: kanal::AsyncReceiver<StateMachineExecutorInput>,
     peer_id: PeerId,
@@ -46,7 +46,7 @@ impl TestHarness {
     fn with_peers(other_peer_ids: Vec<PeerId>) -> Self {
         let storage = InMemoryStorageProvider::new();
         let (tx, rx) = kanal::bounded_async::<StateMachineExecutorInput>(16);
-        let rng = ChaChaRng::seed_from_u64(42);
+        let rng = ChaCha20Rng::seed_from_u64(42);
         let own_peer_id = PeerId::from([0u8; 32]);
         let peer_id = *other_peer_ids.first().unwrap_or(&PeerId::from([1u8; 32]));
         let api = DefaultMosaicApi::new(own_peer_id, other_peer_ids, tx, storage.clone(), rng);
@@ -106,7 +106,7 @@ impl TestHarness {
     }
 
     async fn add_garbler_deposit(&self, deposit_id: DepositId, step: garbler::DepositStep) {
-        let mut rng = ChaChaRng::seed_from_u64(99);
+        let mut rng = ChaCha20Rng::seed_from_u64(99);
         let keypair = KeyPair::rand(&mut rng);
         let deposit_state = garbler::DepositState {
             step,
@@ -121,7 +121,7 @@ impl TestHarness {
     }
 
     async fn add_evaluator_deposit(&self, deposit_id: DepositId, step: evaluator::DepositStep) {
-        let mut rng = ChaChaRng::seed_from_u64(100);
+        let mut rng = ChaCha20Rng::seed_from_u64(100);
         let keypair = KeyPair::rand(&mut rng);
         let deposit_state = evaluator::DepositState {
             step,
@@ -446,7 +446,7 @@ async fn init_garbler_deposit_dispatches_correct_input() {
     h.setup_garbler(garbler::Step::SetupComplete).await;
 
     let deposit_id = test_deposit_id(1);
-    let mut rng = ChaChaRng::seed_from_u64(77);
+    let mut rng = ChaCha20Rng::seed_from_u64(77);
     let keypair = KeyPair::rand(&mut rng);
     let internal_pk = keypair.public_key();
     let adaptor_pk = try_into_x_only_pubkey(internal_pk).unwrap();
@@ -484,7 +484,7 @@ async fn init_garbler_deposit_rejects_wrong_step() {
     let deposit_id = test_deposit_id(1);
     let init = GarblerDepositInit {
         adaptor_pk: try_into_x_only_pubkey(
-            KeyPair::rand(&mut ChaChaRng::seed_from_u64(0)).public_key(),
+            KeyPair::rand(&mut ChaCha20Rng::seed_from_u64(0)).public_key(),
         )
         .unwrap(),
         sighashes: test_sighashes(),
@@ -514,7 +514,7 @@ async fn init_garbler_deposit_rejects_duplicate_deposit() {
 
     let init = GarblerDepositInit {
         adaptor_pk: try_into_x_only_pubkey(
-            KeyPair::rand(&mut ChaChaRng::seed_from_u64(0)).public_key(),
+            KeyPair::rand(&mut ChaCha20Rng::seed_from_u64(0)).public_key(),
         )
         .unwrap(),
         sighashes: test_sighashes(),
@@ -977,7 +977,7 @@ async fn sign_with_fault_secret_signs_when_successful() {
     .await;
 
     // Write a fault secret share
-    let scalar = ark_ff::UniformRand::rand(&mut ChaChaRng::seed_from_u64(123));
+    let scalar = ark_ff::UniformRand::rand(&mut ChaCha20Rng::seed_from_u64(123));
     let share = Share::new(Index::new(1).unwrap(), scalar);
     {
         let mut session = h.storage.evaluator_state_mut(&h.peer_id).await.unwrap();
@@ -1022,7 +1022,7 @@ async fn sign_with_fault_secret_signs_with_tweak() {
     })
     .await;
 
-    let scalar = ark_ff::UniformRand::rand(&mut ChaChaRng::seed_from_u64(123));
+    let scalar = ark_ff::UniformRand::rand(&mut ChaCha20Rng::seed_from_u64(123));
     let share = Share::new(Index::new(1).unwrap(), scalar);
     {
         let mut session = h.storage.evaluator_state_mut(&h.peer_id).await.unwrap();
@@ -1192,7 +1192,7 @@ async fn get_fault_secret_pubkey_returns_pubkey_from_commitment() {
     let h = TestHarness::new();
     h.setup_garbler(garbler::Step::SetupComplete).await;
 
-    let mut rng = ChaChaRng::seed_from_u64(200);
+    let mut rng = ChaCha20Rng::seed_from_u64(200);
     let polynomial = Polynomial::rand(&mut rng);
     let commitment = polynomial.commit();
     let output_commitment = HeapArray::from_vec(vec![commitment.clone()]);
@@ -1328,7 +1328,7 @@ async fn init_evaluator_deposit_sk_matches_get_adaptor_pubkey() {
 async fn dispatch_returns_executor_error_when_channel_closed() {
     let storage = InMemoryStorageProvider::new();
     let (tx, rx) = kanal::bounded_async::<StateMachineExecutorInput>(16);
-    let rng = ChaChaRng::seed_from_u64(42);
+    let rng = ChaCha20Rng::seed_from_u64(42);
     let peer_id = PeerId::from([1u8; 32]);
 
     let api = DefaultMosaicApi::new(
@@ -1350,7 +1350,7 @@ async fn dispatch_returns_executor_error_when_channel_closed() {
             .await
             .unwrap();
 
-        let mut rng2 = ChaChaRng::seed_from_u64(99);
+        let mut rng2 = ChaCha20Rng::seed_from_u64(99);
         let keypair = KeyPair::rand(&mut rng2);
         session
             .put_deposit(

--- a/crates/storage/kvstore/src/evaluator.rs
+++ b/crates/storage/kvstore/src/evaluator.rs
@@ -706,7 +706,7 @@ mod tests {
         },
     };
     use mosaic_vs3::{Index, Polynomial, PolynomialCommitment, Scalar, Share, gen_mul};
-    use rand_chacha::{ChaChaRng, rand_core::SeedableRng};
+    use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
     use super::*;
     use crate::{btreemap::BTreeMapKvStore, kvstore::test_utils::FdbSizeGuardedKvStore};
@@ -731,7 +731,7 @@ mod tests {
     }
 
     fn polynomial_commitment(seed: u64) -> PolynomialCommitment {
-        let mut rng = ChaChaRng::seed_from_u64(seed);
+        let mut rng = ChaCha20Rng::seed_from_u64(seed);
         let poly = Polynomial::rand(&mut rng);
         poly.commit()
     }

--- a/crates/storage/kvstore/src/garbler.rs
+++ b/crates/storage/kvstore/src/garbler.rs
@@ -658,7 +658,7 @@ mod tests {
         },
     };
     use mosaic_vs3::{Index, Polynomial, PolynomialCommitment, Scalar, Share, gen_mul};
-    use rand_chacha::{ChaChaRng, rand_core::SeedableRng};
+    use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
     use super::*;
     use crate::{btreemap::BTreeMapKvStore, kvstore::test_utils::FdbSizeGuardedKvStore};
@@ -683,7 +683,7 @@ mod tests {
     }
 
     fn polynomial_commitment(seed: u64) -> PolynomialCommitment {
-        let mut rng = ChaChaRng::seed_from_u64(seed);
+        let mut rng = ChaCha20Rng::seed_from_u64(seed);
         let poly = Polynomial::rand(&mut rng);
         poly.commit()
     }


### PR DESCRIPTION
## Description

Moves from the type alias `ChaChaRng` to the actual type `ChaCha20Rng`. This protects us against any future changes to this type alias, which may not be stable.

In practice, all supported reduced-round `ChaChaRng` variants are [secure](https://eprint.iacr.org/2019/1492) for our purposes. However, this keeps determinism and is a good belt-and-suspenders practice.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

N/A

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

N/A
