### PR TITLE
chore: ensure consistent use of `OsRng`

### DIFF
--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -365,7 +365,7 @@ pub(crate) async fn handle_generate_deposit_adaptors<SP: StorageProvider, TS: Ta
 
     let sk = deposit_state.sk.0;
     let pk = deposit_state.sk.to_pubkey().0;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     // Generate one adaptor per deposit wire, using the share commitment at
     // reserved index (= zeroth polynomial coefficient) for the wire's input value.
@@ -425,7 +425,7 @@ pub(crate) async fn handle_generate_withdrawal_adaptors_chunk<
 
     let sk = deposit_state.sk.0;
     let pk = deposit_state.sk.to_pubkey().0;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     // Each chunk covers WITHDRAWAL_WIRES_PER_ADAPTOR_CHUNK consecutive withdrawal wires.
     let chunk_offset = chunk_idx.get() as usize * WITHDRAWAL_WIRES_PER_ADAPTOR_CHUNK;

--- a/crates/net/svc/src/tls.rs
+++ b/crates/net/svc/src/tls.rs
@@ -331,7 +331,7 @@ mod tests {
     use super::*;
 
     fn generate_test_key() -> SigningKey {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rngs::OsRng;
         let mut bytes = [0u8; 32];
         rand::RngCore::fill_bytes(&mut rng, &mut bytes);
         SigningKey::from_bytes(&bytes)


### PR DESCRIPTION
## Description

Moves all uses of `thread_rng` to `OsRng` for consistency. This is a non-critical change since `thread_rng` uses a CSPRNG seeded by `OsRng` entropy. It is strictly a performance regression, but in practice it should be negligible.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

If this is expected to incur a meaningful performance hit, we can reconsider the change.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

N/A