### PR TITLE
feat: use KDF mode for BLAKE3 seed derivation

### DIFF
--- a/crates/cac/protocol/src/common.rs
+++ b/crates/cac/protocol/src/common.rs
@@ -29,8 +29,19 @@ pub(crate) fn get_eval_commitments(
     })
 }
 
-/// derive stage seed
-pub fn derive_stage_seed(base_seed: Seed, stage: &str) -> Seed {
-    let seed = blake3::derive_key(stage, base_seed.as_bytes());
+/// Derive a high-entropy stage seed.
+///
+/// This is done using BLAKE3 in KDF mode, with the `stage` used as static context and the
+/// high-entropy 32-byte `base_seed` as key material. You can optionally supply `dynamic` context
+/// data (which may be low entropy) that is included with the key material, per the BLAKE3
+/// specification. This is useful for cases where a stage needs more differentiation than a single
+/// static context can provide.
+pub fn derive_stage_seed(base_seed: Seed, stage: &str, dynamic: Option<&[u8]>) -> Seed {
+    let key_material = if let Some(bytes) = dynamic {
+        [base_seed.as_bytes(), bytes].concat()
+    } else {
+        base_seed.as_bytes().to_vec()
+    };
+    let seed = blake3::derive_key(stage, &key_material);
     Seed::from(seed)
 }

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -1073,7 +1073,7 @@ fn is_valid_commit_chunk(commit_msg: &CommitMsgChunk) -> bool {
 }
 
 fn sample_challenge_indices(base_seed: Seed) -> ChallengeIndices {
-    let seed = derive_stage_seed(base_seed, SEED_CONTEXT_SAMPLE_CHALLENGE_INDICES);
+    let seed = derive_stage_seed(base_seed, SEED_CONTEXT_SAMPLE_CHALLENGE_INDICES, None);
     let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed.into());
     let sampled_indices = rand::seq::index::sample(&mut rng, N_CIRCUITS, N_OPEN_CIRCUITS); // samples N_OPEN_CIRCUITS many values from the domain [0, N_CIRCUITS]
     let mut challenge_indices: ChallengeIndices = HeapArray::from_vec(

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -1023,11 +1023,11 @@ async fn build_commit_msg_header<S: StateRead>(state: &S) -> SMResult<CommitMsgH
 }
 
 fn generate_polynomial_seed(base_seed: Seed) -> Seed {
-    derive_stage_seed(base_seed, SEED_CONTEXT_GENERATE_POLYNOMIAL)
+    derive_stage_seed(base_seed, SEED_CONTEXT_GENERATE_POLYNOMIAL, None)
 }
 
 fn generate_garbling_table_seeds(base_seed: Seed) -> AllGarblingSeeds {
-    let stage_seed = derive_stage_seed(base_seed, SEED_CONTEXT_GENERATE_GARBLING_TABLE_SEEDS);
+    let stage_seed = derive_stage_seed(base_seed, SEED_CONTEXT_GENERATE_GARBLING_TABLE_SEEDS, None);
     let mut rng = ChaCha20Rng::from_seed(stage_seed.into()); // modify base seed ?
     let garbling_seeds = (0..N_CIRCUITS)
         .map(|_| {

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -80,4 +80,4 @@ pub const SEED_CONTEXT_GENERATE_POLYNOMIAL: &str = "generate_polynomial";
 pub const SEED_CONTEXT_GENERATE_GARBLING_TABLE_SEEDS: &str = "generate_garbling_table_seeds";
 /// Seed derivation context for (indexed) deposit keypairs
 /// This _MUST_ be used with a distinct deposit index
-pub const SEED_CONTEXT_INDEXED_DEPOSIT_KEYPAIR: &str = "deposit_";
+pub const SEED_CONTEXT_INDEXED_DEPOSIT_KEYPAIR: &str = "deposit";

--- a/crates/rpc/service/src/default.rs
+++ b/crates/rpc/service/src/default.rs
@@ -726,12 +726,11 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> DefaultMosaicApi<S
 }
 
 fn derive_deposit_keypair(base_seed: Seed, deposit_id: &DepositId) -> (SecretKey, PubKey) {
-    let stage = format!(
-        "{}{}",
+    let seed = derive_stage_seed(
+        base_seed,
         SEED_CONTEXT_INDEXED_DEPOSIT_KEYPAIR,
-        deposit_id.0.to_hex()
+        Some(deposit_id.0.as_bytes()),
     );
-    let seed = derive_stage_seed(base_seed, &stage);
 
     let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed.to_bytes());
     let keypair = KeyPair::rand(&mut rng);


### PR DESCRIPTION
## Description

Moves seed derivation from BLAKE3's keyed hash mode to its key derivation mode.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

Ensure that this design, which appends (optional) dynamic context to the key material, does not introduce the possibility of input collisions.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #124.