### PR TITLE
ci: safely ignore RUSTSEC-2026-0049 vulnerability

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,5 @@
+[advisories]
+# This vulnerability does not apply:
+# - The `reqwest` dependency doesn't use the affected package: https://github.com/seanmonstar/reqwest/pull/2987
+# - This codebase uses pinned keys instead of a certificate chain
+ignore = ['RUSTSEC-2026-0049']


### PR DESCRIPTION
## Description

We can safely ignore [`RUSTSEC-2026-0049`](https://rustsec.org/advisories/RUSTSEC-2026-0049):
- The `reqwest` dependency [doesn't use the affected package](https://github.com/seanmonstar/reqwest/pull/2987)
- The codebase uses pinned keys that aren't affected by the vulnerability

This PR adds an override to the security CI workflow.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [x] Security fix

## Notes to Reviewers

Confirm that the vulnerability does not apply.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #132.
