### PR TITLE
BulkSender should retry table transfer for PeerFinished Network Error

### DIFF
--- a/crates/job/api/src/lib.rs
+++ b/crates/job/api/src/lib.rs
@@ -83,6 +83,8 @@ pub enum CircuitError {
     SetupFailed(String),
     /// Processing a chunk failed.
     ChunkFailed(String),
+    /// Peer not ready to receive payload
+    PeerNotReady,
 }
 
 /// A block of circuit gate data shared across concurrent sessions via [`Arc`].

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -16,7 +16,7 @@ use mosaic_common::constants::{
 };
 use mosaic_heap_array::HeapArray;
 use mosaic_job_api::{ActionCompletion, CircuitError, HandlerOutcome};
-use mosaic_net_svc_api::PeerId;
+use mosaic_net_svc_api::{PeerId, StreamClosed};
 use mosaic_storage_api::{StorageProvider, table_store::TableStore};
 use mosaic_vs3::{Index, Polynomial, PolynomialCommitment, Share};
 
@@ -590,10 +590,15 @@ pub(crate) async fn setup_transfer_session<SP: StorageProvider, TS: TableStore>(
 
     const MAX_CHUNK: usize = 2 * 1024 * 1024; // 2 MiB — well under 4 MiB frame limit
     for chunk in translation_bytes.chunks(MAX_CHUNK) {
-        let _ = stream
-            .write(chunk.to_vec())
-            .await
-            .map_err(|e| CircuitError::SetupFailed(format!("translation send: {e:?}")))?;
+        let _ = stream.write(chunk.to_vec()).await.map_err(|e| {
+            match e {
+                // Retry if PeerFinished error was sent. The PeerFinished error could have been
+                // thrown because sender tried sending prematurely and stream was closed by the
+                // receiver
+                StreamClosed::PeerFinished => CircuitError::PeerNotReady,
+                _ => CircuitError::SetupFailed(format!("translation send: {e:?}")),
+            }
+        })?;
     }
 
     Ok(TransferSession::new(

--- a/crates/job/scheduler/src/garbling/mod.rs
+++ b/crates/job/scheduler/src/garbling/mod.rs
@@ -405,11 +405,22 @@ async fn coordinator_loop(
                         });
                     }
                     Err(CircuitError::StorageUnavailable) => {
-                        // Transient — data not yet written by STF. Keep for retry.
+                        // Transient — data not yet written by STF. Keep for
+                        // retry.
                         tracing::debug!(
                             peer = ?job.peer_id,
                             action = ?job.action,
                             "session storage unavailable — will retry next pass"
+                        );
+                        pending_retry.push(job);
+                    }
+                    Err(CircuitError::PeerNotReady) => {
+                        // Transient — waiting for peer; Keep for
+                        // retry.
+                        tracing::debug!(
+                            peer = ?job.peer_id,
+                            action = ?job.action,
+                            "peer not ready — will retry next pass"
                         );
                         pending_retry.push(job);
                     }


### PR DESCRIPTION
## Description

While transferring tables, if Garbler (bulksender) receives a network error, then he does not retry the connection. It could be the case that the evaluator (bulkreceiver) may not be able to receive at that time.
Fix involves checking if the error received is 'PeerFinished', only in such case does the calling function return retry-able error.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Fixes #134 
