### PR TITLE
refactor(protocol): e2e test to use existing btreemap storage provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "mosaic-net-svc-api",
  "mosaic-storage-api",
  "mosaic-storage-inmemory",
+ "mosaic-storage-kvstore",
  "mosaic-storage-s3",
  "mosaic-vs3",
  "object_store",
@@ -2323,7 +2324,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "thiserror 2.0.18",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/crates/cac/protocol/Cargo.toml
+++ b/crates/cac/protocol/Cargo.toml
@@ -32,9 +32,9 @@ mosaic-net-svc-api.workspace = true
 mosaic-net-svc.workspace = true
 mosaic-net-client.workspace = true
 mosaic-common = { workspace = true, features = ["reduced-circuits"] }
-mosaic-storage-s3.workspace = true 
+mosaic-storage-s3.workspace = true
+mosaic-storage-kvstore.workspace = true 
 
-tracing.workspace = true
 tokio = { version = "1", features = ["rt", "macros"] }
 ed25519-dalek = "2.2"
 ckt-fmtv5-types.workspace = true

--- a/crates/cac/protocol/src/tests.rs
+++ b/crates/cac/protocol/src/tests.rs
@@ -9,11 +9,12 @@ use mosaic_cac_types::{
         evaluator::{
             DepositStep as EvalDepositStep, EvaluatorDepositInitData,
             EvaluatorDisputedWithdrawalData, EvaluatorInitData, EvaluatorTrackedActionTypes,
-            Input as EvalInput, Step as EvalStep,
+            Input as EvalInput, StateRead as EvalStateRead, Step as EvalStep,
         },
         garbler::{
             DepositStep as GarbDepositStep, GarblerDepositInitData, GarblerInitData,
-            GarblerTrackedActionTypes, Input as GarbInput, Step as GarbStep,
+            GarblerTrackedActionTypes, Input as GarbInput, StateRead as GarblerStateRead,
+            Step as GarbStep,
         },
     },
 };
@@ -31,8 +32,7 @@ use mosaic_job_executors::{
 };
 use mosaic_net_client::NetClient;
 use mosaic_net_svc_api::PeerId;
-use mosaic_storage_api::StorageProvider;
-use mosaic_storage_inmemory::{evaluator::StoredEvaluatorState, garbler::StoredGarblerState};
+use mosaic_storage_kvstore::btreemap::BTreeMapStorageProvider;
 use mosaic_storage_s3::S3TableStore;
 use object_store::{ObjectStore, local::LocalFileSystem};
 use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
@@ -301,19 +301,25 @@ mod netcl {
     }
 }
 
-async fn handle_init_garbler(
-    garb_state: &mut StoredGarblerState,
+async fn handle_init_garbler<SP: StorageProvider + StorageProviderMut>(
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
             GarblerTrackedActionTypes,
         >,
     >,
+    eval_peer_id: &PeerId,
     garb_seed: Seed,
     setup_inputs: SetupInputs,
 ) {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(eval_peer_id)
+        .await
+        .unwrap();
     garbler::GarblerSM::stf(
-        garb_state,
+        &mut garb_state,
         fasm::Input::Normal(GarbInput::Init(GarblerInitData {
             seed: garb_seed,
             setup_inputs,
@@ -324,19 +330,25 @@ async fn handle_init_garbler(
     .unwrap();
 }
 
-async fn handle_init_evaluator(
-    eval_state: &mut StoredEvaluatorState,
+async fn handle_init_evaluator<SP: StorageProvider + StorageProviderMut>(
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
             EvaluatorTrackedActionTypes,
         >,
     >,
+    garbler_peer_id: PeerId,
     eval_seed: Seed,
     setup_inputs: SetupInputs,
 ) {
+    let mut eval_state = eval_exec
+        .storage
+        .evaluator_state_mut(&garbler_peer_id)
+        .await
+        .unwrap();
     evaluator::EvaluatorSM::stf(
-        eval_state,
+        &mut eval_state,
         fasm::Input::Normal(EvalInput::Init(EvaluatorInitData {
             seed: eval_seed,
             setup_inputs,
@@ -348,17 +360,22 @@ async fn handle_init_evaluator(
     assert_eq!(eval_actions.len(), 0); // Step Waiting For Commit
 }
 
-async fn handle_garbler_prepares_commit_msg(
-    garb_state: &mut StoredGarblerState,
+async fn handle_garbler_prepares_commit_msg<SP: StorageProvider + StorageProviderMut>(
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    garbler_peer_id: PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
             GarblerTrackedActionTypes,
         >,
     >,
-    garbler_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
     eval_peer_id: PeerId,
 ) {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(&garbler_peer_id)
+        .await
+        .unwrap();
     assert_eq!(garb_actions.len(), 1 + N_INPUT_WIRES); //  Action::GeneratePolynomialCommitments: [Output, Inputs..]
     let mut results = mock_dispatch_garbler(garb_actions, garbler_exec, &eval_peer_id).await;
     assert_eq!(results.len(), N_INPUT_WIRES + 1); // ActionResult::PolynomialCommitmentsGenerated: [Output, Inputs..]
@@ -369,14 +386,12 @@ async fn handle_garbler_prepares_commit_msg(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
     // returns Action::GenerateShares
     assert_eq!(garb_actions.len(), N_CIRCUITS + 1);
-
-    garbler_exec.storage.garb_state = garb_state.clone();
 
     let mut results = mock_dispatch_garbler(garb_actions, garbler_exec, &eval_peer_id).await;
     while let Some(completion) = results.pop() {
@@ -386,14 +401,13 @@ async fn handle_garbler_prepares_commit_msg(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
 
     assert_eq!(garb_actions.len(), N_CIRCUITS); // [Action::GenerateTableCommitment; N_CIRCUITS]
 
-    garbler_exec.storage.garb_state = garb_state.clone();
     let mut results = mock_dispatch_garbler(garb_actions, garbler_exec, &eval_peer_id).await;
     assert_eq!(results.len(), N_CIRCUITS); // GarblerActionResult::TableCommitmentGenerated
 
@@ -404,22 +418,21 @@ async fn handle_garbler_prepares_commit_msg(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
     assert_eq!(garb_actions.len(), 1 + N_INPUT_WIRES); // Action::SendCommitMsgHeader + Action::SendCommitMsgChunk
 }
 
-async fn handlle_garbler_transfers_commit_msg(
-    garb_state: &mut StoredGarblerState,
+async fn handlle_garbler_transfers_commit_msg<SP: StorageProvider + StorageProviderMut>(
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
             GarblerTrackedActionTypes,
         >,
     >,
-    garbler_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
     eval_peer_id: PeerId,
     net_client_evaluator: NetClient,
 ) -> (Vec<EvalInput>, Vec<ActionCompletion>) {
@@ -427,12 +440,11 @@ async fn handlle_garbler_transfers_commit_msg(
     let encl = net_client_evaluator.clone();
     let commit_msg_listener = tokio::spawn(async move { handle_receive_commit_msg(encl).await });
 
-    tracing::info!("send commit msg");
+    println!("send commit msg");
     // sends commit msg header then chunks; evaluator should have been listening
-    garbler_exec.storage.garb_state = garb_state.clone();
     let garb_results = mock_dispatch_garbler(garb_actions, garbler_exec, &eval_peer_id).await;
 
-    tracing::info!("receive commit msg");
+    println!("receive commit msg");
     // Evaluator reads
     let eval_inputs = commit_msg_listener.await.unwrap();
     assert_eq!(eval_inputs.len(), 1 + N_INPUT_WIRES);
@@ -440,8 +452,9 @@ async fn handlle_garbler_transfers_commit_msg(
     (eval_inputs, garb_results)
 }
 
-async fn handle_garbler_waits_for_challenge(
-    garb_state: &mut StoredGarblerState,
+async fn handle_garbler_waits_for_challenge<SP: StorageProvider + StorageProviderMut>(
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    eval_peer_id: &PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
@@ -450,6 +463,11 @@ async fn handle_garbler_waits_for_challenge(
     >,
     garb_results: &mut Vec<ActionCompletion>,
 ) {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(eval_peer_id)
+        .await
+        .unwrap();
     while let Some(completion) = garb_results.pop() {
         let (action_id, action_result) = completion.as_garbler().unwrap();
         let tracked_input: fasm::Input<GarblerTrackedActionTypes, GarbInput> =
@@ -457,15 +475,16 @@ async fn handle_garbler_waits_for_challenge(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
     assert_eq!(garb_actions.len(), 0); // Step: WaitForChallenge; No Action // network ack
 }
 
-async fn handle_evaluator_prepares_challenge(
-    eval_state: &mut StoredEvaluatorState,
+async fn handle_evaluator_prepares_challenge<SP: StorageProvider + StorageProviderMut>(
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    garbler_peer_id: &PeerId,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
@@ -474,23 +493,27 @@ async fn handle_evaluator_prepares_challenge(
     >,
     eval_inputs: &mut Vec<EvalInput>,
 ) {
+    let mut eval_state = eval_exec
+        .storage
+        .evaluator_state_mut(garbler_peer_id)
+        .await
+        .unwrap();
     while let Some(ei) = eval_inputs.pop() {
-        evaluator::EvaluatorSM::stf(eval_state, fasm::Input::Normal(ei), eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, fasm::Input::Normal(ei), eval_actions)
             .await
             .unwrap();
     }
     assert_eq!(eval_actions.len(), 1); // SendChallenge
 }
 
-async fn handle_evaluator_transfers_challenge_msg(
-    eval_state: &mut StoredEvaluatorState,
+async fn handle_evaluator_transfers_challenge_msg<SP: StorageProvider + StorageProviderMut>(
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
             EvaluatorTrackedActionTypes,
         >,
     >,
-    eval_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
     garbler_peer_id: PeerId,
     net_client_garbler: NetClient,
 ) -> (GarbInput, Vec<ActionCompletion>) {
@@ -498,16 +521,16 @@ async fn handle_evaluator_transfers_challenge_msg(
     let challenge_msg_listener = tokio::spawn(async move { handle_receive_challenge(&ncl).await });
 
     // Evaluator sends challenge over network
-    tracing::info!("mock_dispatch_evaluator; send_challenge");
-    eval_exec.storage.eval_state = eval_state.clone();
+    println!("mock_dispatch_evaluator; send_challenge");
     let eval_results = mock_dispatch_evaluator(eval_actions, eval_exec, &garbler_peer_id).await;
 
     let garb_inputs = challenge_msg_listener.await.unwrap(); // ChallengeMsg
     (garb_inputs, eval_results)
 }
 
-async fn handle_evaluator_waits_for_challenge_response(
-    eval_state: &mut StoredEvaluatorState,
+async fn handle_evaluator_waits_for_challenge_response<SP: StorageProvider + StorageProviderMut>(
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    garbler_peer_id: &PeerId,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
@@ -517,6 +540,11 @@ async fn handle_evaluator_waits_for_challenge_response(
     eval_results: &mut Vec<ActionCompletion>,
 ) {
     // eval's tx is acked
+    let mut eval_state = eval_exec
+        .storage
+        .evaluator_state_mut(garbler_peer_id)
+        .await
+        .unwrap();
     while let Some(completion) = eval_results.pop() {
         let (action_id, action_result) = completion.as_evaluator().unwrap();
         let tracked_input: fasm::Input<EvaluatorTrackedActionTypes, EvalInput> =
@@ -524,15 +552,16 @@ async fn handle_evaluator_waits_for_challenge_response(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
     assert_eq!(eval_actions.len(), 0); // Challenge was acked; step WaitingForChallengeResponse
 }
 
-async fn handle_garbler_prepares_challenge_response(
-    garb_state: &mut StoredGarblerState,
+async fn handle_garbler_prepares_challenge_response<SP: StorageProvider + StorageProviderMut>(
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    eval_peer_id: PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
@@ -541,21 +570,29 @@ async fn handle_garbler_prepares_challenge_response(
     >,
     garb_inputs: GarbInput,
 ) {
-    garbler::GarblerSM::stf(garb_state, fasm::Input::Normal(garb_inputs), garb_actions)
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(&eval_peer_id)
         .await
         .unwrap();
+    garbler::GarblerSM::stf(
+        &mut garb_state,
+        fasm::Input::Normal(garb_inputs),
+        garb_actions,
+    )
+    .await
+    .unwrap();
     assert_eq!(garb_actions.len(), 1 + N_OPEN_CIRCUITS); // Challenge Response Header + Challenge Response Chunks (one chunk for each circuit)
 }
 
-async fn handle_garbler_transfers_challenge_response(
-    garb_state: &mut StoredGarblerState,
+async fn handle_garbler_transfers_challenge_response<SP: StorageProvider + StorageProviderMut>(
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
             GarblerTrackedActionTypes,
         >,
     >,
-    garbler_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
     eval_peer_id: PeerId,
     net_client_evaluator: NetClient,
 ) -> (Vec<EvalInput>, Vec<ActionCompletion>) {
@@ -563,7 +600,6 @@ async fn handle_garbler_transfers_challenge_response(
     let challenge_response_listener =
         tokio::spawn(async move { handle_receive_challenge_response(encl).await });
 
-    garbler_exec.storage.garb_state = garb_state.clone();
     let garb_results = mock_dispatch_garbler(garb_actions, garbler_exec, &eval_peer_id).await;
 
     let eval_inputs = challenge_response_listener.await.unwrap();
@@ -571,8 +607,9 @@ async fn handle_garbler_transfers_challenge_response(
     (eval_inputs, garb_results)
 }
 
-async fn handle_garbler_prepares_for_table_transfer(
-    garb_state: &mut StoredGarblerState,
+async fn handle_garbler_prepares_for_table_transfer<SP: StorageProviderMut + StorageProvider>(
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    eval_peer_id: PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
@@ -581,6 +618,11 @@ async fn handle_garbler_prepares_for_table_transfer(
     >,
     garb_results: &mut Vec<ActionCompletion>,
 ) {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(&eval_peer_id)
+        .await
+        .unwrap();
     while let Some(completion) = garb_results.pop() {
         let (action_id, action_result) = completion.as_garbler().unwrap();
         let tracked_input: fasm::Input<GarblerTrackedActionTypes, GarbInput> =
@@ -588,37 +630,40 @@ async fn handle_garbler_prepares_for_table_transfer(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
     assert_eq!(garb_actions.len(), N_EVAL_CIRCUITS); //  Step::TransferringGarblingTables; Action::TransferGarblingTable
 }
 
-async fn handle_evaluator_processes_challenge_response(
-    eval_state: &mut StoredEvaluatorState,
+async fn handle_evaluator_processes_challenge_response<SP: StorageProvider + StorageProviderMut>(
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
             EvaluatorTrackedActionTypes,
         >,
     >,
-    eval_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
     eval_inputs: &mut Vec<EvalInput>,
     garbler_peer_id: PeerId,
 ) {
     // Evaluator receives challenge response
+    let mut eval_state = eval_exec
+        .storage
+        .evaluator_state_mut(&garbler_peer_id)
+        .await
+        .unwrap();
     while let Some(ei) = eval_inputs.pop() {
-        evaluator::EvaluatorSM::stf(eval_state, fasm::Input::Normal(ei), eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, fasm::Input::Normal(ei), eval_actions)
             .await
             .unwrap();
     }
     assert_eq!(eval_actions.len(), 1); // Step::VerifyingOpenedInputShares; Action::VerifyOpenedInputShares
 
-    tracing::info!("mock_dispatch_evaluator; verify shares");
-    eval_exec.storage.eval_state = eval_state.clone();
+    println!("mock_dispatch_evaluator; verify shares");
     let mut eval_results = mock_dispatch_evaluator(eval_actions, eval_exec, &garbler_peer_id).await;
-    tracing::info!("shares verified");
+    println!("shares verified");
     assert_eq!(eval_results.len(), 1); // ActionResult::VerifyOpenedInputSharesResult
     while let Some(completion) = eval_results.pop() {
         let (action_id, action_result) = completion.as_evaluator().unwrap();
@@ -627,14 +672,13 @@ async fn handle_evaluator_processes_challenge_response(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
     assert_eq!(eval_actions.len(), N_OPEN_CIRCUITS); // Action::GenerateTableCommitment(index, seed), Step::VerifyingTableCommitments
 
-    tracing::info!("mock_dispatch_evaluator; generate table commitment");
-    eval_exec.storage.eval_state = eval_state.clone();
+    println!("mock_dispatch_evaluator; generate table commitment");
     let mut eval_results = mock_dispatch_evaluator(eval_actions, eval_exec, &garbler_peer_id).await;
     assert_eq!(eval_results.len(), N_OPEN_CIRCUITS); // ActionResult::TableCommitmentGenerated
     while let Some(completion) = eval_results.pop() {
@@ -644,15 +688,16 @@ async fn handle_evaluator_processes_challenge_response(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
     assert_eq!(eval_actions.len(), N_EVAL_CIRCUITS); // Step::ReceivingGarblingTables, Action::ReceiveGarblingTable
 }
 
-async fn handle_evaluator_processes_table(
-    eval_state: &mut StoredEvaluatorState,
+async fn handle_evaluator_processes_table<SP: StorageProvider + StorageProviderMut>(
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    garbler_peer_id: &PeerId,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
@@ -662,6 +707,11 @@ async fn handle_evaluator_processes_table(
     eval_results: &mut Vec<ActionCompletion>,
 ) {
     // process receipt
+    let mut eval_state = eval_exec
+        .storage
+        .evaluator_state_mut(garbler_peer_id)
+        .await
+        .unwrap();
     while let Some(completion) = eval_results.pop() {
         let (action_id, action_result) = completion.as_evaluator().unwrap();
         let tracked_input: fasm::Input<EvaluatorTrackedActionTypes, EvalInput> =
@@ -669,19 +719,20 @@ async fn handle_evaluator_processes_table(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
     assert_eq!(eval_actions.len(), N_EVAL_CIRCUITS); // Step::SetupComplete, Action::SendTableTransferReceipt
     assert_eq!(
-        eval_state.clone().state.unwrap().step,
+        eval_state.get_root_state().await.unwrap().unwrap().step,
         EvalStep::SetupComplete
     );
 }
 
-async fn handle_garbler_waits_for_receipt(
-    garb_state: &mut StoredGarblerState,
+async fn handle_garbler_waits_for_receipt<SP: StorageProvider + StorageProviderMut>(
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    eval_peer_id: PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
@@ -690,6 +741,11 @@ async fn handle_garbler_waits_for_receipt(
     >,
     garb_results: &mut Vec<ActionCompletion>,
 ) {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(&eval_peer_id)
+        .await
+        .unwrap();
     while let Some(completion) = garb_results.pop() {
         let (action_id, action_result) = completion.as_garbler().unwrap();
         let tracked_input: fasm::Input<GarblerTrackedActionTypes, GarbInput> =
@@ -697,22 +753,21 @@ async fn handle_garbler_waits_for_receipt(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
     assert_eq!(garb_actions.len(), 0); // step: waiting for table transfer receipt
 }
 
-async fn handle_evaluator_transfers_receipt(
+async fn handle_evaluator_transfers_receipt<SP: StorageProvider + StorageProviderMut>(
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
             EvaluatorTrackedActionTypes,
         >,
     >,
-    eval_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
-    eval_state: &mut StoredEvaluatorState,
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
     garbler_peer_id: PeerId,
     net_client_gabler: NetClient,
 ) -> (Vec<GarbInput>, Vec<ActionCompletion>) {
@@ -724,8 +779,6 @@ async fn handle_evaluator_transfers_receipt(
     });
 
     // evaluator sends table receipt
-    eval_exec.storage.eval_state = eval_state.clone();
-
     let eval_results = mock_dispatch_evaluator(eval_actions, eval_exec, &garbler_peer_id).await;
     assert_eq!(eval_results.len(), N_EVAL_CIRCUITS); // ActionResult::GarblingTableTransferReceiptAcked
     // garbler received table transfer receipts
@@ -734,9 +787,10 @@ async fn handle_evaluator_transfers_receipt(
     (garb_inputs, eval_results)
 }
 
-async fn handle_evaluator_consumes_receipt_ack(
+async fn handle_evaluator_consumes_receipt_ack<SP: StorageProvider + StorageProviderMut>(
     eval_results: &mut Vec<ActionCompletion>,
-    eval_state: &mut StoredEvaluatorState,
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    garbler_peer_id: &PeerId,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
@@ -745,6 +799,11 @@ async fn handle_evaluator_consumes_receipt_ack(
     >,
 ) {
     // Stf ignores ack as state has been transitioned to SetupComplete already
+    let mut eval_state = eval_exec
+        .storage
+        .evaluator_state_mut(garbler_peer_id)
+        .await
+        .unwrap();
     while let Some(completion) = eval_results.pop() {
         let (action_id, action_result) = completion.as_evaluator().unwrap();
         let tracked_input: fasm::Input<EvaluatorTrackedActionTypes, EvalInput> =
@@ -752,20 +811,21 @@ async fn handle_evaluator_consumes_receipt_ack(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
     assert_eq!(eval_actions.len(), 0);
     assert_eq!(
-        eval_state.clone().state.unwrap().step,
+        eval_state.get_root_state().await.unwrap().unwrap().step,
         EvalStep::SetupComplete
     );
 }
 
-async fn handle_garbler_consumes_receipt_ack(
+async fn handle_garbler_consumes_receipt_ack<SP: StorageProvider + StorageProviderMut>(
     garb_inputs: &mut Vec<GarbInput>,
-    garb_state: &mut StoredGarblerState,
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    eval_peer_id: PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
@@ -773,24 +833,30 @@ async fn handle_garbler_consumes_receipt_ack(
         >,
     >,
 ) {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(&eval_peer_id)
+        .await
+        .unwrap();
     while let Some(input) = garb_inputs.pop() {
-        garbler::GarblerSM::stf(garb_state, fasm::Input::Normal(input), garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, fasm::Input::Normal(input), garb_actions)
             .await
             .unwrap();
     }
     assert_eq!(garb_actions.len(), 0); // setup complete
     assert_eq!(
-        garb_state.clone().state.unwrap().step,
+        garb_state.get_root_state().await.unwrap().unwrap().step,
         GarbStep::SetupComplete
     );
 }
 
-async fn handle_garbler_inits_deposit(
+async fn handle_garbler_inits_deposit<SP: StorageProvider + StorageProviderMut>(
     sighashes: Sighashes,
     deposit_inputs: DepositInputs,
     eval_pubkey: PubKey,
     deposit_id: DepositId,
-    garb_state: &mut StoredGarblerState,
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    eval_peer_id: PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
@@ -798,13 +864,18 @@ async fn handle_garbler_inits_deposit(
         >,
     >,
 ) {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(&eval_peer_id)
+        .await
+        .unwrap();
     let deposit_input: GarblerDepositInitData = GarblerDepositInitData {
         pk: eval_pubkey,
         sighashes: HeapArray::from_vec(sighashes.to_vec()),
         deposit_inputs,
     };
     garbler::GarblerSM::stf(
-        garb_state,
+        &mut garb_state,
         fasm::Input::Normal(GarbInput::DepositInit(deposit_id, deposit_input)),
         garb_actions,
     )
@@ -813,30 +884,33 @@ async fn handle_garbler_inits_deposit(
     assert_eq!(garb_actions.len(), 0);
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn handle_evaluator_inits_deposit(
+async fn handle_evaluator_inits_deposit<SP: StorageProvider + StorageProviderMut>(
     sighashes: Sighashes,
     eval_sk: SecretKey,
     deposit_inputs: DepositInputs,
     deposit_id: DepositId,
-    eval_state: &mut StoredEvaluatorState,
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    garbler_peer_id: &PeerId,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
             EvaluatorTrackedActionTypes,
         >,
     >,
-    eval_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
-    garbler_peer_id: PeerId,
 ) {
     let deposit_input: EvaluatorDepositInitData = EvaluatorDepositInitData {
         sk: eval_sk,
         sighashes: HeapArray::from_vec(sighashes.to_vec()),
         deposit_inputs,
     };
+    let mut eval_state = eval_exec
+        .storage
+        .evaluator_state_mut(garbler_peer_id)
+        .await
+        .unwrap();
 
     evaluator::EvaluatorSM::stf(
-        eval_state,
+        &mut eval_state,
         fasm::Input::Normal(EvalInput::DepositInit(deposit_id, deposit_input)),
         eval_actions,
     )
@@ -844,9 +918,7 @@ async fn handle_evaluator_inits_deposit(
     .unwrap();
     assert_eq!(eval_actions.len(), 1 + N_ADAPTOR_MSG_CHUNKS); // Action::GenerateDepositAdaptors + [Action::GenerateWithdrawalAdaptorsChunk]
 
-    eval_exec.storage.eval_state = eval_state.clone();
-
-    let mut eval_results = mock_dispatch_evaluator(eval_actions, eval_exec, &garbler_peer_id).await;
+    let mut eval_results = mock_dispatch_evaluator(eval_actions, eval_exec, garbler_peer_id).await;
     while let Some(completion) = eval_results.pop() {
         let (action_id, action_result) = completion.as_evaluator().unwrap();
         let tracked_input: fasm::Input<EvaluatorTrackedActionTypes, EvalInput> =
@@ -854,16 +926,15 @@ async fn handle_evaluator_inits_deposit(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
     assert_eq!(eval_actions.len(), N_DEPOSIT_INPUT_WIRES); //  Action::DepositSendAdaptorMsgChunk
 }
 
-async fn handle_evaluator_sends_adaptors(
-    eval_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
-    eval_state: &mut StoredEvaluatorState,
+async fn handle_evaluator_sends_adaptors<SP: StorageProvider + StorageProviderMut>(
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
@@ -874,14 +945,13 @@ async fn handle_evaluator_sends_adaptors(
     garbler_peer_id: PeerId,
     net_client_gabler: NetClient,
 ) -> (Vec<GarbInput>, Vec<ActionCompletion>) {
-    tracing::info!("handle_receive_adaptor_msg_chunks");
+    println!("handle_receive_adaptor_msg_chunks");
     // adaptor chunks listener
     let ncl = net_client_gabler.clone();
     let challenge_msg_listener =
         tokio::spawn(async move { handle_receive_adaptor_msg_chunks(&ncl, deposit_id).await });
 
     // send adaptor msg chunks
-    eval_exec.storage.eval_state = eval_state.clone();
     let eval_results = mock_dispatch_evaluator(eval_actions, eval_exec, &garbler_peer_id).await;
     assert_eq!(eval_results.len(), N_DEPOSIT_INPUT_WIRES); // ActionResult::DepositAdaptorChunkSent
 
@@ -892,8 +962,9 @@ async fn handle_evaluator_sends_adaptors(
     (garb_inputs, eval_results)
 }
 
-async fn handle_evaluator_is_deposit_ready(
-    eval_state: &mut StoredEvaluatorState,
+async fn handle_evaluator_is_deposit_ready<SP: StorageProvider + StorageProviderMut>(
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    garbler_peer_id: &PeerId,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
@@ -903,6 +974,11 @@ async fn handle_evaluator_is_deposit_ready(
     deposit_id: DepositId,
     eval_results: &mut Vec<ActionCompletion>,
 ) {
+    let mut eval_state = eval_exec
+        .storage
+        .evaluator_state_mut(garbler_peer_id)
+        .await
+        .unwrap();
     while let Some(completion) = eval_results.pop() {
         let (action_id, action_result) = completion.as_evaluator().unwrap();
         let tracked_input: fasm::Input<EvaluatorTrackedActionTypes, EvalInput> =
@@ -910,7 +986,7 @@ async fn handle_evaluator_is_deposit_ready(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
@@ -918,11 +994,9 @@ async fn handle_evaluator_is_deposit_ready(
 
     assert_eq!(
         eval_state
-            .deposits
-            .get(&deposit_id)
+            .get_deposit(&deposit_id)
+            .await
             .unwrap()
-            .state
-            .as_ref()
             .unwrap()
             .step,
         EvalDepositStep::DepositReady
@@ -930,18 +1004,22 @@ async fn handle_evaluator_is_deposit_ready(
     // assert evaluator is deposit ready
 }
 
-async fn handle_garbler_verifies_adaptors(
-    garbler_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
-    garb_state: &mut StoredGarblerState,
+async fn handle_garbler_verifies_adaptors<SP: StorageProvider + StorageProviderMut>(
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    eval_peer_id: PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
             GarblerTrackedActionTypes,
         >,
     >,
-    eval_peer_id: PeerId,
     deposit_id: DepositId,
 ) {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(&eval_peer_id)
+        .await
+        .unwrap();
     let mut garb_results = mock_dispatch_garbler(garb_actions, garbler_exec, &eval_peer_id).await;
     // results ActionResult::DepositAdaptorVerificationResult
     while let Some(completion) = garb_results.pop() {
@@ -951,29 +1029,31 @@ async fn handle_garbler_verifies_adaptors(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
     assert_eq!(garb_actions.len(), 0);
     assert_eq!(
         garb_state
-            .deposits
-            .get(&deposit_id)
+            .get_deposit(&deposit_id)
+            .await
             .unwrap()
-            .state
-            .as_ref()
             .unwrap()
             .step,
         GarbDepositStep::DepositReady
     );
     // garbler is deposit ready
-    tracing::info!("garbler is deposit ready");
+    println!("garbler is deposit ready");
     // garbler is deposit ready
-    tracing::info!("garbler is deposit ready");
+    println!("garbler is deposit ready");
 }
 
-async fn handle_garbler_starts_adaptor_verification_job(
+async fn handle_garbler_starts_adaptor_verification_job<
+    SP: StorageProvider + StorageProviderMut,
+>(
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    eval_peer_id: PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
@@ -981,31 +1061,39 @@ async fn handle_garbler_starts_adaptor_verification_job(
         >,
     >,
     garb_inputs: &mut Vec<GarbInput>,
-    garb_state: &mut StoredGarblerState,
 ) {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(&eval_peer_id)
+        .await
+        .unwrap();
     while let Some(ei) = garb_inputs.pop() {
-        garbler::GarblerSM::stf(garb_state, fasm::Input::Normal(ei), garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, fasm::Input::Normal(ei), garb_actions)
             .await
             .unwrap();
     }
     assert_eq!(garb_actions.len(), 1); // DepositStep::VerifyingAdaptors
 }
 
-async fn handle_garbler_completes_signatures(
-    garbler_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
+async fn handle_garbler_completes_signatures<SP: StorageProvider + StorageProviderMut>(
+    garbler_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    eval_peer_id: PeerId,
     garb_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
             GarblerTrackedActionTypes,
         >,
     >,
-    garb_state: &mut StoredGarblerState,
     deposit_id: DepositId,
     withdrawal_input: WithdrawalInputs,
-    eval_peer_id: PeerId,
 ) -> CompletedSignatures {
+    let mut garb_state = garbler_exec
+        .storage
+        .garbler_state_mut(&eval_peer_id)
+        .await
+        .unwrap();
     garbler::GarblerSM::stf(
-        garb_state,
+        &mut garb_state,
         fasm::Input::Normal(GarbInput::DisputedWithdrawal(deposit_id, withdrawal_input)),
         garb_actions,
     )
@@ -1013,7 +1101,6 @@ async fn handle_garbler_completes_signatures(
     .unwrap();
     assert_eq!(garb_actions.len(), 1); // Action::CompleteAdaptorSignatures
 
-    garbler_exec.storage.garb_state = garb_state.clone();
     let mut garb_results = mock_dispatch_garbler(garb_actions, garbler_exec, &eval_peer_id).await; // ActionResult::AdaptorSignaturesCompleted
     assert_eq!(garb_results.len(), 1);
 
@@ -1024,30 +1111,27 @@ async fn handle_garbler_completes_signatures(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
     assert_eq!(garb_actions.len(), 0); // Setup Consumed
     assert_eq!(
-        garb_state.clone().state.as_ref().unwrap().step,
+        garb_state.get_root_state().await.unwrap().unwrap().step,
         GarbStep::SetupConsumed { deposit_id }
     );
 
-    let on_chain_sigs = garb_state
-        .deposits
-        .get(&deposit_id)
+    garb_state
+        .get_completed_signatures(&deposit_id)
+        .await
         .unwrap()
-        .completed_sigs
-        .as_ref()
-        .unwrap();
-    on_chain_sigs.clone()
+        .unwrap()
 }
 
-async fn handle_evaluator_finds_fault_secret(
-    eval_exec: &mut MosaicExecutor<DummyStorageProvider, S3TableStore>,
+async fn handle_evaluator_finds_fault_secret<SP: StorageProvider + StorageProviderMut>(
+    eval_exec: &mut MosaicExecutor<SP, S3TableStore>,
+    garbler_peer_id: &PeerId,
     on_chain_sigs: CompletedSignatures,
-    eval_state: &mut StoredEvaluatorState,
     eval_actions: &mut Vec<
         actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
@@ -1055,13 +1139,17 @@ async fn handle_evaluator_finds_fault_secret(
         >,
     >,
     deposit_id: DepositId,
-    garbler_peer_id: PeerId,
 ) {
+    let mut eval_state = eval_exec
+        .storage
+        .evaluator_state_mut(garbler_peer_id)
+        .await
+        .unwrap();
     let eval_disputed_withdrawal = EvaluatorDisputedWithdrawalData {
         signatures: on_chain_sigs.clone(),
     };
     evaluator::EvaluatorSM::stf(
-        eval_state,
+        &mut eval_state,
         fasm::Input::Normal(EvalInput::DisputedWithdrawal(
             deposit_id,
             eval_disputed_withdrawal,
@@ -1072,9 +1160,8 @@ async fn handle_evaluator_finds_fault_secret(
     .unwrap();
     assert_eq!(eval_actions.len(), N_EVAL_CIRCUITS); // Action::EvaluateGarblingTable
 
-    tracing::info!("evaluate garbling table");
-    eval_exec.storage.eval_state = eval_state.clone();
-    let mut eval_results = mock_dispatch_evaluator(eval_actions, eval_exec, &garbler_peer_id).await;
+    println!("evaluate garbling table");
+    let mut eval_results = mock_dispatch_evaluator(eval_actions, eval_exec, garbler_peer_id).await;
     assert_eq!(eval_results.len(), N_EVAL_CIRCUITS);
     while let Some(completion) = eval_results.pop() {
         let (action_id, action_result) = completion.as_evaluator().unwrap();
@@ -1083,7 +1170,7 @@ async fn handle_evaluator_finds_fault_secret(
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
@@ -1091,6 +1178,8 @@ async fn handle_evaluator_finds_fault_secret(
 }
 
 use fasm::StateMachine;
+use mosaic_storage_api::{StorageProvider, StorageProviderMut};
+
 #[tokio::test]
 // OPTIONAL steps to generate v5c file yourself:
 // 1. clone: g16 repo and switch to branch test/simple_circuit_postaudit
@@ -1141,10 +1230,8 @@ async fn test_e2e() {
     for (iter, (setup_inputs, deposit_inputs, withdrawal_input, reveals_secret)) in
         test_vector.into_iter().enumerate()
     {
-        tracing::info!("ITERATION {}", iter + 1);
-        let mut garb_state = StoredGarblerState::default();
+        println!("ITERATION {}", iter + 1);
         let mut garb_rng = ChaCha20Rng::seed_from_u64(42);
-        let mut eval_state = StoredEvaluatorState::default();
         let mut eval_rng = ChaCha20Rng::seed_from_u64(43);
 
         let temp_dir = temp_dir();
@@ -1166,24 +1253,25 @@ async fn test_e2e() {
         let eval_seed = rand_byte_array(&mut eval_rng).into();
 
         // Run Garbler STF
-        let sp: DummyStorageProvider = DummyStorageProvider {
-            garb_state: garb_state.clone(),
-            eval_state: eval_state.clone(),
-        };
-        let mut garbler_exec =
-            MosaicExecutor::new(net_client_gabler.clone(), sp, ts, circuit_path.clone());
-
-        let sp: DummyStorageProvider = DummyStorageProvider {
-            garb_state: garb_state.clone(),
-            eval_state: eval_state.clone(),
-        };
+        let garb_storage = BTreeMapStorageProvider::new();
+        let mut garbler_exec = MosaicExecutor::new(
+            net_client_gabler.clone(),
+            garb_storage.clone(),
+            ts,
+            circuit_path.clone(),
+        );
 
         let prefix = "evaluating-tables";
         let local = LocalFileSystem::new_with_prefix(temp_dir.clone()).unwrap();
         let ts = S3TableStore::new(Arc::new(local) as Arc<dyn ObjectStore>, prefix);
 
-        let mut eval_exec =
-            MosaicExecutor::new(net_client_evaluator.clone(), sp, ts, circuit_path.clone());
+        let eval_storage = BTreeMapStorageProvider::new();
+        let mut eval_exec = MosaicExecutor::new(
+            net_client_evaluator.clone(),
+            eval_storage.clone(),
+            ts,
+            circuit_path.clone(),
+        );
 
         let mut garb_actions: Vec<
             actions::Action<
@@ -1200,40 +1288,62 @@ async fn test_e2e() {
             >,
         > = Vec::new();
 
-        handle_init_garbler(&mut garb_state, &mut garb_actions, garb_seed, setup_inputs).await;
-
-        handle_init_evaluator(&mut eval_state, &mut eval_actions, eval_seed, setup_inputs).await;
-
-        handle_garbler_prepares_commit_msg(
-            &mut garb_state,
-            &mut garb_actions,
+        handle_init_garbler(
             &mut garbler_exec,
+            &mut garb_actions,
+            &eval_peer_id,
+            garb_seed,
+            setup_inputs,
+        )
+        .await;
+
+        handle_init_evaluator(
+            &mut eval_exec,
+            &mut eval_actions,
+            garbler_peer_id,
+            eval_seed,
+            setup_inputs,
+        )
+        .await;
+
+        println!("garbler prepares commit msg");
+        handle_garbler_prepares_commit_msg(
+            &mut garbler_exec,
+            eval_peer_id,
+            &mut garb_actions,
             eval_peer_id,
         )
         .await;
 
-        tracing::info!("spawn commit msg listener");
+        println!("spawn commit msg listener");
         let (mut eval_inputs, mut garb_results) = handlle_garbler_transfers_commit_msg(
-            &mut garb_state,
             &mut garb_actions,
             &mut garbler_exec,
             eval_peer_id,
             net_client_evaluator.clone(),
         )
         .await;
+        println!("commit msg prepared");
 
-        // garbler waits for challenge
-        handle_garbler_waits_for_challenge(&mut garb_state, &mut garb_actions, &mut garb_results)
-            .await;
+        handle_garbler_waits_for_challenge(
+            &mut garbler_exec,
+            &eval_peer_id,
+            &mut garb_actions,
+            &mut garb_results,
+        )
+        .await;
 
-        //Evaluator receives commit msg
-        handle_evaluator_prepares_challenge(&mut eval_state, &mut eval_actions, &mut eval_inputs)
-            .await;
+        handle_evaluator_prepares_challenge(
+            &mut eval_exec,
+            &garbler_peer_id,
+            &mut eval_actions,
+            &mut eval_inputs,
+        )
+        .await;
 
-        tracing::info!("Evaluator Wants to Send Challenge; Garbler should be listening");
+        println!("Evaluator Wants to Send Challenge; Garbler should be listening");
 
         let (garb_inputs, mut eval_results) = handle_evaluator_transfers_challenge_msg(
-            &mut eval_state,
             &mut eval_actions,
             &mut eval_exec,
             garbler_peer_id,
@@ -1241,38 +1351,41 @@ async fn test_e2e() {
         )
         .await;
 
-        // evaluator waits for challenge response
         handle_evaluator_waits_for_challenge_response(
-            &mut eval_state,
+            &mut eval_exec,
+            &garbler_peer_id,
             &mut eval_actions,
             &mut eval_results,
         )
         .await;
 
-        // garbler processes challenge and prepares challenge response
-        handle_garbler_prepares_challenge_response(&mut garb_state, &mut garb_actions, garb_inputs)
-            .await;
+        handle_garbler_prepares_challenge_response(
+            &mut garbler_exec,
+            eval_peer_id,
+            &mut garb_actions,
+            garb_inputs,
+        )
+        .await;
 
         let (mut eval_inputs, mut garb_results) = handle_garbler_transfers_challenge_response(
-            &mut garb_state,
             &mut garb_actions,
             &mut garbler_exec,
             eval_peer_id,
-            net_client_evaluator,
+            net_client_evaluator.clone(),
         )
         .await;
 
         handle_garbler_prepares_for_table_transfer(
-            &mut garb_state,
+            &mut garbler_exec,
+            eval_peer_id,
             &mut garb_actions,
             &mut garb_results,
         )
         .await;
 
         handle_evaluator_processes_challenge_response(
-            &mut eval_state,
-            &mut eval_actions,
             &mut eval_exec,
+            &mut eval_actions,
             &mut eval_inputs,
             garbler_peer_id,
         )
@@ -1280,13 +1393,11 @@ async fn test_e2e() {
 
         // Table Transfer
         let (mut garb_results, mut eval_results) = {
-            garbler_exec.storage.garb_state = garb_state.clone();
             // transfer tables background
             let tx = tokio::spawn(async move {
                 mock_dispatch_garbler(&mut garb_actions, &garbler_exec, &eval_peer_id).await
             });
             // evaluator receives table
-            eval_exec.storage.eval_state = eval_state.clone();
             let eval_results =
                 mock_dispatch_evaluator(&mut eval_actions, &eval_exec, &garbler_peer_id).await;
             assert_eq!(eval_results.len(), N_EVAL_CIRCUITS);
@@ -1296,18 +1407,35 @@ async fn test_e2e() {
             (garb_results, eval_results)
         };
 
-        // process table and prepare receipt
-        handle_evaluator_processes_table(&mut eval_state, &mut eval_actions, &mut eval_results)
-            .await;
+        handle_evaluator_processes_table(
+            &mut eval_exec,
+            &garbler_peer_id,
+            &mut eval_actions,
+            &mut eval_results,
+        )
+        .await;
 
         let mut garb_actions = vec![];
-        handle_garbler_waits_for_receipt(&mut garb_state, &mut garb_actions, &mut garb_results)
-            .await;
+        let prefix = "garbling-tables";
+        let local = LocalFileSystem::new_with_prefix(temp_dir.clone()).unwrap();
+        let ts = S3TableStore::new(Arc::new(local) as Arc<dyn ObjectStore>, prefix);
+        let mut garbler_exec = MosaicExecutor::new(
+            net_client_gabler.clone(),
+            garb_storage,
+            ts,
+            circuit_path.clone(),
+        );
+        handle_garbler_waits_for_receipt(
+            &mut garbler_exec,
+            eval_peer_id,
+            &mut garb_actions,
+            &mut garb_results,
+        )
+        .await;
 
         let (mut garb_inputs, mut eval_results) = handle_evaluator_transfers_receipt(
             &mut eval_actions,
             &mut eval_exec,
-            &mut eval_state,
             garbler_peer_id,
             net_client_gabler.clone(),
         )
@@ -1315,15 +1443,21 @@ async fn test_e2e() {
 
         handle_evaluator_consumes_receipt_ack(
             &mut eval_results,
-            &mut eval_state,
+            &mut eval_exec,
+            &garbler_peer_id,
             &mut eval_actions,
         )
         .await;
 
-        handle_garbler_consumes_receipt_ack(&mut garb_inputs, &mut garb_state, &mut garb_actions)
-            .await;
+        handle_garbler_consumes_receipt_ack(
+            &mut garb_inputs,
+            &mut garbler_exec,
+            eval_peer_id,
+            &mut garb_actions,
+        )
+        .await;
 
-        tracing::info!("setup complete");
+        println!("setup complete");
 
         let deposit_id = {
             let mut empty: [u8; 32] = [0; 32];
@@ -1339,7 +1473,8 @@ async fn test_e2e() {
             deposit_inputs,
             eval_keypair.public_key(),
             deposit_id,
-            &mut garb_state,
+            &mut garbler_exec,
+            eval_peer_id,
             &mut garb_actions,
         )
         .await;
@@ -1349,16 +1484,14 @@ async fn test_e2e() {
             eval_keypair.secret_key(),
             deposit_inputs,
             deposit_id,
-            &mut eval_state,
-            &mut eval_actions,
             &mut eval_exec,
-            garbler_peer_id,
+            &garbler_peer_id,
+            &mut eval_actions,
         )
         .await;
 
         let (mut garb_inputs, mut eval_results) = handle_evaluator_sends_adaptors(
             &mut eval_exec,
-            &mut eval_state,
             &mut eval_actions,
             deposit_id,
             garbler_peer_id,
@@ -1367,7 +1500,8 @@ async fn test_e2e() {
         .await;
 
         handle_evaluator_is_deposit_ready(
-            &mut eval_state,
+            &mut eval_exec,
+            &garbler_peer_id,
             &mut eval_actions,
             deposit_id,
             &mut eval_results,
@@ -1375,57 +1509,50 @@ async fn test_e2e() {
         .await;
 
         handle_garbler_starts_adaptor_verification_job(
+            &mut garbler_exec,
+            eval_peer_id,
             &mut garb_actions,
             &mut garb_inputs,
-            &mut garb_state,
         )
         .await;
 
-        let sp = DummyStorageProvider {
-            garb_state: garb_state.clone(),
-            eval_state: eval_state.clone(),
-        };
-        let prefix = "garbling-tables";
-        let local = LocalFileSystem::new_with_prefix(temp_dir.clone()).unwrap();
-        let ts = S3TableStore::new(Arc::new(local) as Arc<dyn ObjectStore>, prefix);
-        let mut garbler_exec =
-            MosaicExecutor::new(net_client_gabler.clone(), sp, ts, circuit_path.clone());
         handle_garbler_verifies_adaptors(
             &mut garbler_exec,
-            &mut garb_state,
-            &mut garb_actions,
             eval_peer_id,
+            &mut garb_actions,
             deposit_id,
         )
         .await;
 
-        tracing::info!("Withdrawal Stage");
+        println!("Withdrawal Stage");
         // STARTING WITHDRAWAL STAGE for Disputed Withdrawal
 
-        tracing::info!("Withdrawal Stage");
+        println!("Withdrawal Stage");
         // STARTING WITHDRAWAL STAGE for Disputed Withdrawal
 
         let on_chain_sigs = handle_garbler_completes_signatures(
             &mut garbler_exec,
+            eval_peer_id,
             &mut garb_actions,
-            &mut garb_state,
             deposit_id,
             withdrawal_input,
-            eval_peer_id,
         )
         .await;
 
         handle_evaluator_finds_fault_secret(
             &mut eval_exec,
+            &garbler_peer_id,
             on_chain_sigs,
-            &mut eval_state,
             &mut eval_actions,
             deposit_id,
-            garbler_peer_id,
         )
         .await;
 
-        match eval_state.clone().state.unwrap().step {
+        let eval_state = eval_storage
+            .evaluator_state(&garbler_peer_id)
+            .await
+            .unwrap();
+        match eval_state.get_root_state().await.unwrap().unwrap().step {
             EvalStep::SetupConsumed {
                 deposit_id: deposit_idx,
                 slash,
@@ -1433,7 +1560,6 @@ async fn test_e2e() {
                 assert_eq!(deposit_id, deposit_idx);
                 assert_eq!(slash.is_some(), reveals_secret);
                 if reveals_secret {
-                    use mosaic_cac_types::state_machine::evaluator::StateRead;
                     let output_poly_commit = eval_state
                         .get_output_polynomial_commitment()
                         .await
@@ -1450,42 +1576,18 @@ async fn test_e2e() {
     }
 }
 
-struct DummyStorageProvider {
-    garb_state: StoredGarblerState,
-    eval_state: StoredEvaluatorState,
-}
-
-impl StorageProvider for DummyStorageProvider {
-    type GarblerState = StoredGarblerState;
-    type EvaluatorState = StoredEvaluatorState;
-
-    async fn garbler_state(
-        &self,
-        _peer_id: &PeerId,
-    ) -> mosaic_storage_api::StorageProviderResult<Self::GarblerState> {
-        Ok(self.garb_state.clone())
-    }
-
-    async fn evaluator_state(
-        &self,
-        _peer_id: &PeerId,
-    ) -> mosaic_storage_api::StorageProviderResult<Self::EvaluatorState> {
-        Ok(self.eval_state.clone())
-    }
-}
-
 use mosaic_cac_types::state_machine::{
     evaluator::Action as EvaluatorAction, garbler::Action as GarblerAction,
 };
 
-async fn mock_dispatch_garbler(
+async fn mock_dispatch_garbler<SP: StorageProvider + StorageProviderMut>(
     actions: &mut Vec<
         fasm::actions::Action<
             mosaic_cac_types::state_machine::garbler::UntrackedAction,
             GarblerTrackedActionTypes,
         >,
     >,
-    exec: &MosaicExecutor<DummyStorageProvider, S3TableStore>,
+    exec: &MosaicExecutor<SP, S3TableStore>,
     peer_id: &PeerId,
 ) -> Vec<mosaic_job_api::ActionCompletion> {
     let mut garb_results = vec![];
@@ -1543,7 +1645,7 @@ async fn mock_dispatch_garbler(
                         exec.complete_adaptor_signatures(peer_id, *deposit_id).await
                     }
                     _ => {
-                        tracing::info!("unhandled garbler action variant {:?}", action);
+                        println!("unhandled garbler action variant {:?}", action);
                         HandlerOutcome::Retry
                     }
                 }
@@ -1561,14 +1663,14 @@ async fn mock_dispatch_garbler(
 }
 
 use mosaic_job_api::ExecuteEvaluatorJob;
-async fn mock_dispatch_evaluator(
+async fn mock_dispatch_evaluator<SP: StorageProvider + StorageProviderMut>(
     actions: &mut Vec<
         fasm::actions::Action<
             mosaic_cac_types::state_machine::evaluator::UntrackedAction,
             EvaluatorTrackedActionTypes,
         >,
     >,
-    exec: &MosaicExecutor<DummyStorageProvider, S3TableStore>,
+    exec: &MosaicExecutor<SP, S3TableStore>,
     peer_id: &PeerId,
 ) -> Vec<ActionCompletion> {
     let mut eval_results = vec![];


### PR DESCRIPTION
## Description

Refactor e2e test to use existing BtreemapStorageProvider.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
