### PR TITLE
run restore on all stf periodically

### DIFF
--- a/bin/mosaic/config/config.a.toml
+++ b/bin/mosaic/config/config.a.toml
@@ -62,6 +62,7 @@ chunk_timeout_secs = 30
 
 [sm_executor]
 command_queue_size = 256
+restore_interval_secs = 60
 
 [rpc]
 bind_addr = "127.0.0.1:8000"

--- a/bin/mosaic/config/config.b.toml
+++ b/bin/mosaic/config/config.b.toml
@@ -62,6 +62,7 @@ chunk_timeout_secs = 30
 
 [sm_executor]
 command_queue_size = 256
+restore_interval_secs = 60
 
 [rpc]
 bind_addr = "127.0.0.1:8001"

--- a/bin/mosaic/config/config.c.toml
+++ b/bin/mosaic/config/config.c.toml
@@ -62,6 +62,7 @@ chunk_timeout_secs = 30
 
 [sm_executor]
 command_queue_size = 256
+restore_interval_secs = 60
 
 [rpc]
 bind_addr = "127.0.0.1:8002"

--- a/bin/mosaic/config/config.d.toml
+++ b/bin/mosaic/config/config.d.toml
@@ -62,6 +62,7 @@ chunk_timeout_secs = 30
 
 [sm_executor]
 command_queue_size = 256
+restore_interval_secs = 60
 
 [rpc]
 bind_addr = "127.0.0.1:8003"

--- a/bin/mosaic/config/config.e.toml
+++ b/bin/mosaic/config/config.e.toml
@@ -62,6 +62,7 @@ chunk_timeout_secs = 30
 
 [sm_executor]
 command_queue_size = 256
+restore_interval_secs = 60
 
 [rpc]
 bind_addr = "127.0.0.1:8004"

--- a/bin/mosaic/config/config.example.toml
+++ b/bin/mosaic/config/config.example.toml
@@ -48,6 +48,7 @@ chunk_timeout_secs = 30
 
 [sm_executor]
 command_queue_size = 256
+restore_interval_secs = 600
 
 [rpc]
 bind_addr = "127.0.0.1:8000"

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -70,6 +70,7 @@ impl MosaicConfig {
         SmExecutorConfig {
             command_queue_size: self.sm_executor.command_queue_size,
             known_peers,
+            restore_interval_secs: self.sm_executor.restore_interval_secs,
         }
     }
 
@@ -352,6 +353,8 @@ impl Default for GarblingSection {
 pub(crate) struct SmExecutorSection {
     #[serde(default = "default_command_queue_size")]
     pub(crate) command_queue_size: usize,
+    /// Seconds between periodic `restore_known_peers` calls. Omitted or `0` disables.
+    pub(crate) restore_interval_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/sm-executor-api/src/config.rs
+++ b/crates/sm-executor-api/src/config.rs
@@ -7,6 +7,9 @@ pub struct SmExecutorConfig {
     pub command_queue_size: usize,
     /// Peers to restore at startup.
     pub known_peers: Vec<PeerId>,
+    /// Interval in seconds between periodic `restore_known_peers` runs.
+    /// `None` or `Some(0)` disables periodic restore.
+    pub restore_interval_secs: Option<u64>,
 }
 
 impl Default for SmExecutorConfig {
@@ -14,6 +17,7 @@ impl Default for SmExecutorConfig {
         Self {
             command_queue_size: 256,
             known_peers: Vec::new(),
+            restore_interval_secs: None,
         }
     }
 }

--- a/crates/sm-executor/src/lib.rs
+++ b/crates/sm-executor/src/lib.rs
@@ -138,6 +138,13 @@ async fn recv_shutdown(
     }
 }
 
+async fn restore_timer_tick(interval: Option<std::time::Duration>) {
+    match interval {
+        Some(dur) => monoio::time::sleep(dur).await,
+        None => std::future::pending().await,
+    }
+}
+
 /// SM executor.
 #[derive(Debug)]
 pub struct SmExecutor<S>
@@ -196,6 +203,7 @@ where
             .name("sm-executor".to_string())
             .spawn(move || {
                 let mut runtime = monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
+                    .enable_timer()
                     .build()
                     .expect("failed to build sm-executor monoio runtime");
                 let result = runtime.block_on(self.run_inner(Some(shutdown_rx)));
@@ -224,6 +232,12 @@ where
             tracing::info!("sm executor starting");
             self.restore_known_peers().await?;
             tracing::info!("sm executor restore completed; entering main loop");
+
+            let restore_interval = self
+                .config
+                .restore_interval_secs
+                .filter(|&s| s > 0)
+                .map(std::time::Duration::from_secs);
 
             loop {
                 monoio::select! {
@@ -299,6 +313,16 @@ where
                                 tracing::error!(source = "command", "executor command channel closed; stopping sm executor");
                                 return Err(SmExecutorError::SourceClosed("executor command channel"));
                             }
+                        }
+                    }
+                    _ = restore_timer_tick(restore_interval) => {
+                        tracing::info!(source = "restore_tick", "periodic restore_known_peers triggered");
+                        if let Err(err) = self.restore_known_peers().await {
+                            if Self::is_fatal_processing_error(&err) {
+                                tracing::error!(source = "restore_tick", error = ?err, "fatal error during periodic restore; stopping sm executor");
+                                return Err(err);
+                            }
+                            tracing::warn!(source = "restore_tick", error = ?err, "periodic restore_known_peers failed; will retry at next interval");
                         }
                     }
                 }
@@ -1082,6 +1106,7 @@ mod tests {
         F: Future<Output = ()> + 'static,
     {
         monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
+            .enable_timer()
             .build()
             .expect("build monoio runtime")
             .block_on(future);
@@ -1309,6 +1334,7 @@ mod tests {
             let config = SmExecutorConfig {
                 command_queue_size: 8,
                 known_peers: vec![peer_id],
+                restore_interval_secs: None,
             };
             let (executor, _handle) = SmExecutor::new(config, provider, job_handle, net_client);
 
@@ -1359,6 +1385,7 @@ mod tests {
             let config = SmExecutorConfig {
                 command_queue_size: 8,
                 known_peers: vec![peer_id],
+                restore_interval_secs: None,
             };
             let (executor, _handle) = SmExecutor::new(config, provider, job_handle, net_client);
 


### PR DESCRIPTION
## Description
Run stf::restore() periodically on all state machines based on configured time interval.

This is a catch-all to resolve any lost actions that prevent the stf from continuing execution. 
Equivalent to periodically restarting the mosaic node.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers
Job scheduler does not currently dedupe actions. With periodic restores, this can potentially cause duplicate job runs, although it will not impact the correctness of the process, just some inefficiency.


<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
