### PR TITLE
challenge response completion idempotency

### DIFF
--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -6,7 +6,7 @@ use mosaic_cac_types::{
     ChallengeResponseMsgChunk, ChallengeResponseMsgHeader, CommitMsgChunk, CommitMsgHeader,
     CompletedSignatures, DepositAdaptors, DepositId, GarblingTableCommitment, HeapArray, Index,
     OpenedGarblingTableCommitments, PubKey, ReservedSetupInputShares, Seed, SetupInputs,
-    TableTransferReceiptMsg, TableTransferRequestMsg, WideLabelWirePolynomialCommitments,
+    TableTransferReceiptMsg, WideLabelWirePolynomialCommitments,
     WideLabelZerothPolynomialCoefficients, WithdrawalAdaptors, WithdrawalAdaptorsChunk,
     WithdrawalInputs, state_machine::evaluator::*,
 };
@@ -582,7 +582,7 @@ async fn handle_commit_msg_header<S: StateMut>(
     match &mut state.step {
         Step::WaitingForCommit { header, chunks, .. } => {
             if *header {
-                warn!("evaluator received duplicate commit header, ack and ignore");
+                debug!("evaluator received duplicate commit header, ack and ignore");
                 return Ok(());
             }
 
@@ -637,7 +637,7 @@ async fn handle_commit_msg_header<S: StateMut>(
             post_handle_commit_msg(state, artifact_store, actions).await
         }
         step if step.phase() > StepPhase::WaitingForCommit => {
-            warn!("evaluator received commit header after completion, ack and ignore");
+            debug!("evaluator received commit header after completion, ack and ignore");
             Ok(())
         }
         _ => Err(SMError::UnexpectedInput),
@@ -659,7 +659,7 @@ async fn handle_commit_msg_chunk<S: StateMut>(
                 }
                 Some(true) => {
                     // already seen chunk
-                    warn!(%chunk_idx, "evaluator received duplicate commit chunk, ack and ignore");
+                    debug!(%chunk_idx, "evaluator received duplicate commit chunk, ack and ignore");
                     return Ok(());
                 }
                 None => {
@@ -699,7 +699,7 @@ async fn handle_commit_msg_chunk<S: StateMut>(
             post_handle_commit_msg(root_state, state, actions).await
         }
         step if step.phase() > StepPhase::WaitingForCommit => {
-            warn!("evaluator received commit chunk after completion, ack and ignore");
+            debug!("evaluator received commit chunk after completion, ack and ignore");
             Ok(())
         }
         _ => Err(SMError::UnexpectedInput),
@@ -744,7 +744,7 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
             remaining_chunks,
         } => {
             if *header {
-                warn!("evaluator received duplicate challenge response header, ack and ignore");
+                debug!("evaluator received duplicate challenge response header, ack and ignore");
                 return Ok(());
             }
 
@@ -789,7 +789,7 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
             post_handle_challenge_response(root_state, state, actions).await
         }
         step if step.phase() > StepPhase::WaitingForChallengeResponse => {
-            warn!("evaluator received challenge response header after completion, ack and ignore");
+            debug!("evaluator received challenge response header after completion, ack and ignore");
             Ok(())
         }
         _ => Err(SMError::UnexpectedInput),
@@ -807,6 +807,18 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
             header,
             remaining_chunks,
         } => {
+            let challenge_idxs = state
+                .get_challenge_indices()
+                .await
+                .require("expected challenge indices")?;
+
+            if !challenge_idxs
+                .iter()
+                .any(|idx| idx.get() == response_msg_chunk.circuit_index as usize)
+            {
+                return Err(SMError::InvalidInputData);
+            }
+
             let chunk_idx = (response_msg_chunk.circuit_index as usize)
                 .checked_sub(1)
                 .unwrap();
@@ -815,8 +827,11 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
                     // expected chunk
                 }
                 Some(false) => {
-                    // already seen chunk
-                    warn!(%chunk_idx, "evaluator received duplicate commit chunk, ack and ignore");
+                    // already seen expected chunk
+                    debug!(
+                        %chunk_idx,
+                        "evaluator received duplicate challenge response chunk, ack and ignore"
+                    );
                     return Ok(());
                 }
                 None => {
@@ -847,7 +862,7 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
             post_handle_challenge_response(root_state, state, actions).await
         }
         step if step.phase() > StepPhase::WaitingForChallengeResponse => {
-            warn!("evaluator received challenge response chunk after completion, ack and ignore");
+            debug!("evaluator received challenge response chunk after completion, ack and ignore");
             Ok(())
         }
         _ => Err(SMError::UnexpectedInput),

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -17,6 +17,7 @@ use mosaic_common::constants::{
 };
 use mosaic_vs3::{Share, interpolate};
 use rand::SeedableRng;
+use tracing::{debug, info, warn};
 
 use super::emit;
 use crate::{
@@ -46,6 +47,7 @@ pub(crate) async fn handle_event<S: StateMut>(
     match input {
         Input::Init(data) => match root_state.step {
             Step::Uninit => {
+                info!("evaluator init: waiting for commit");
                 root_state.config = Some(Config {
                     seed: data.seed,
                     setup_inputs: data.setup_inputs,
@@ -55,7 +57,13 @@ pub(crate) async fn handle_event<S: StateMut>(
                     chunks: HeapArray::from_elem(false),
                 };
             }
-            _ => return Err(SMError::UnexpectedInput),
+            _ => {
+                warn!(
+                    step = root_state.step.step_name(),
+                    "evaluator init in unexpected step"
+                );
+                return Err(SMError::UnexpectedInput);
+            }
         },
         Input::RecvCommitMsgHeader(commit_msg_header) => {
             handle_commit_msg_header(&mut root_state, state, commit_msg_header, actions).await?;
@@ -91,10 +99,11 @@ pub(crate) async fn handle_event<S: StateMut>(
                     .map_err(SMError::storage)?
                     .is_some()
                 {
-                    // deposit already exists
+                    warn!(%deposit_id, "evaluator deposit already exists");
                     return Err(SMError::deposit_already_exists(deposit_id));
                 }
 
+                info!(%deposit_id, "evaluator initializing deposit, generating adaptors");
                 let deposit_state = DepositState {
                     step: DepositStep::GeneratingAdaptors {
                         deposit: false,
@@ -136,6 +145,7 @@ pub(crate) async fn handle_event<S: StateMut>(
 
                 match deposit_state.step {
                     DepositStep::DepositReady => {
+                        info!(%deposit_id, "evaluator deposit undisputed withdrawal");
                         deposit_state.step = DepositStep::WithdrawnUndisputed;
                     }
                     _ => return Err(SMError::UnexpectedInput),
@@ -155,6 +165,7 @@ pub(crate) async fn handle_event<S: StateMut>(
 
                     match deposit_state.step {
                         DepositStep::DepositReady => {
+                            info!(%deposit_id, "evaluator disputed withdrawal, evaluating tables");
                             state
                                 .put_completed_signatures(&deposit_id, &signatures)
                                 .await
@@ -266,10 +277,12 @@ pub(crate) async fn handle_action_result<S: StateMut>(
         ActionResult::VerifyOpenedInputSharesResult(failure) => match root_state.step {
             Step::VerifyingOpenedInputShares => {
                 if let Some(failure_reason) = failure {
+                    warn!(reason = %failure_reason, "evaluator opened input shares verification failed, aborting");
                     root_state.step = Step::Aborted {
                         reason: format!("invalid opened input shares: {}", failure_reason),
                     };
                 } else {
+                    info!("evaluator opened input shares verified, verifying table commitments");
                     let opened_indices = state
                         .get_challenge_indices()
                         .await
@@ -339,8 +352,10 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                                 .map_err(SMError::storage)?;
 
                             *deposit = true;
+                            debug!(%deposit_id, "evaluator deposit adaptors generated");
 
                             if withdrawal_chunks.all() {
+                                info!(%deposit_id, "all adaptors generated, sending");
                                 deposit_state.step = DepositStep::SendingAdaptors {
                                     acked: HeapArray::from_elem(false),
                                 };
@@ -405,8 +420,10 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                             .map_err(SMError::storage)?;
 
                         withdrawal_chunks[chunk_idx.get() as usize] = true;
+                        debug!(%deposit_id, chunk = chunk_idx.get(), done = withdrawal_chunks.count_ones(), total = withdrawal_chunks.len(), "evaluator withdrawal adaptor chunk generated");
 
                         if *deposit && withdrawal_chunks.all() {
+                            info!(%deposit_id, "all adaptors generated, sending");
                             deposit_state.step = DepositStep::SendingAdaptors {
                                 acked: HeapArray::from_elem(false),
                             };
@@ -458,8 +475,10 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                         }
 
                         acked[idx] = true;
+                        debug!(%deposit_id, chunk = idx, done = acked.count_ones(), total = acked.len(), "evaluator adaptor chunk sent");
 
                         if acked.all() {
+                            info!(%deposit_id, "all adaptor chunks sent, deposit ready");
                             deposit_state.step = DepositStep::DepositReady;
                         }
                     }
@@ -486,6 +505,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     };
 
                     evaluated[idx] = true;
+                    debug!(%commitment, done = evaluated.count_ones(), total = evaluated.len(), "evaluator table evaluation result");
 
                     let success = if let Some(output_share) = output_share {
                         // output_share is Some only if the evaluation yielded False value as result
@@ -527,6 +547,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     };
 
                     if success || evaluated.all() {
+                        info!(%deposit_id, success, "evaluator table evaluations complete, setup consumed");
                         root_state.step = Step::SetupConsumed {
                             deposit_id: *deposit_id,
                             success,
@@ -561,6 +582,7 @@ async fn handle_commit_msg_header<S: StateMut>(
     match &mut state.step {
         Step::WaitingForCommit { header, chunks, .. } => {
             if !is_valid_commit_header(&commit_msg_header) {
+                warn!("evaluator received invalid commit msg header, aborting");
                 state.step = Step::Aborted {
                     reason: "invalid commit msg header".into(),
                 };
@@ -601,6 +623,7 @@ async fn handle_commit_msg_header<S: StateMut>(
                 .map_err(SMError::storage)?;
 
             *header = true;
+            debug!("evaluator commit msg header received");
 
             if !chunks.all() {
                 return Ok(());
@@ -621,6 +644,7 @@ async fn handle_commit_msg_chunk<S: StateMut>(
     match &mut root_state.step {
         Step::WaitingForCommit { header, chunks } => {
             if !is_valid_commit_chunk(&commit_msg_chunk) {
+                warn!("evaluator received invalid commit msg chunk, aborting");
                 root_state.step = Step::Aborted {
                     reason: "invalid commit msg chunk".into(),
                 };
@@ -643,6 +667,12 @@ async fn handle_commit_msg_chunk<S: StateMut>(
             };
 
             chunks[chunk_idx] = true;
+            debug!(
+                wire = chunk_idx,
+                done = chunks.count_ones(),
+                total = chunks.len(),
+                "evaluator commit msg chunk received"
+            );
 
             state
                 .put_input_polynomial_commitment_zeroth_coeffs(
@@ -685,6 +715,7 @@ async fn post_handle_commit_msg<S: StateMut>(
         .await
         .map_err(SMError::storage)?;
 
+    info!("evaluator commit msg complete, sending challenge");
     root_state.step = Step::WaitingForChallengeResponse {
         header: false,
         chunks: HeapArray::from_elem(false),
@@ -704,6 +735,7 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
     match &mut root_state.step {
         Step::WaitingForChallengeResponse { header, chunks } => {
             if !is_valid_challenge_response_header(&response_msg_header) {
+                warn!("evaluator received invalid challenge response header, aborting");
                 root_state.step = Step::Aborted {
                     reason: "invalid challenge response message header".into(),
                 };
@@ -740,6 +772,7 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
                 .map_err(SMError::storage)?;
 
             *header = true;
+            debug!("evaluator challenge response header received");
             if chunks.count_ones() != N_CHALLENGE_RESPONSE_CHUNKS {
                 return Ok(());
             }
@@ -764,6 +797,10 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
                 .require("expected challenge indices")?;
 
             if !is_valid_challenge_response_chunk(&response_msg_chunk, &challenge_idxs) {
+                warn!(
+                    circuit_index = response_msg_chunk.circuit_index,
+                    "evaluator received invalid challenge response chunk, aborting"
+                );
                 root_state.step = Step::Aborted {
                     reason: "invalid challenge response message".into(),
                 };
@@ -777,6 +814,12 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
                 return Err(SMError::InvalidInputData);
             }
             chunks[chunk_idx] = true;
+            debug!(
+                circuit_index = response_msg_chunk.circuit_index,
+                done = chunks.count_ones(),
+                total = chunks.len(),
+                "evaluator challenge response chunk received"
+            );
 
             state
                 .put_opened_input_shares_chunk(
@@ -815,6 +858,7 @@ async fn post_handle_challenge_response<S: StateMut>(
     if let Some(failure_reason) =
         verify_opened_output_shares(&opened_output_shares, &output_polynomial_commitment)
     {
+        warn!(reason = %failure_reason, "evaluator opened output share verification failed, aborting");
         root_state.step = Step::Aborted {
             reason: format!(
                 "opened output share verification failed: {}",
@@ -840,6 +884,7 @@ async fn post_handle_challenge_response<S: StateMut>(
         &config.setup_inputs,
         &setup_wire_zeroth_coefficients,
     ) {
+        warn!(reason = %failure_reason, "evaluator reserved input share verification failed, aborting");
         root_state.step = Step::Aborted {
             reason: format!(
                 "reserved input share verification failed: {}",
@@ -849,6 +894,7 @@ async fn post_handle_challenge_response<S: StateMut>(
         return Ok(());
     }
 
+    info!("evaluator challenge response verified, verifying opened input shares");
     root_state.step = Step::VerifyingOpenedInputShares;
 
     emit(actions, Action::VerifyOpenedInputShares);
@@ -880,6 +926,7 @@ async fn handle_table_commitment_generated<S: StateMut>(
 
             let expected_commitment = opened_commitments[idx];
             if table_commitment != expected_commitment {
+                warn!(%index, "evaluator table commitment mismatch, aborting");
                 root_state.step = Step::Aborted {
                     reason: format!("invalid table seed for index {}", index),
                 };
@@ -887,8 +934,10 @@ async fn handle_table_commitment_generated<S: StateMut>(
             }
 
             verified[idx] = true;
+            debug!(%index, done = verified.count_ones(), total = verified.len(), "evaluator table commitment verified");
 
             if verified.all() {
+                info!("all table commitments verified, requesting garbling tables");
                 let eval_indices = get_eval_indices(opened_indices);
                 debug_assert!(is_sorted(&eval_indices));
 
@@ -936,6 +985,7 @@ async fn handle_table_received<S: StateMut>(
 
             let expected_commitment = eval_commitments[pos];
             if table_commitment != expected_commitment {
+                warn!(%index, "evaluator received garbling table with mismatched commitment, aborting");
                 root_state.step = Step::Aborted {
                     reason: format!("invalid table for index {}", index),
                 };
@@ -948,8 +998,10 @@ async fn handle_table_received<S: StateMut>(
             );
 
             received[pos] = true;
+            debug!(%index, done = received.count_ones(), total = received.len(), "evaluator garbling table received");
 
             if received.all() {
+                info!("all garbling tables received, setup complete");
                 root_state.step = Step::SetupComplete;
             }
 
@@ -972,6 +1024,11 @@ pub(crate) async fn restore<S: StateRead>(
         .await
         .map_err(SMError::storage)?
         .unwrap_or_default();
+
+    info!(
+        step = root_state.step.step_name(),
+        "evaluator restoring state"
+    );
 
     match &root_state.step {
         Step::Uninit => {}

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -5,10 +5,10 @@ use mosaic_cac_types::{
     AdaptorMsgChunk, AllGarblingTableCommitments, ChallengeIndices, ChallengeMsg,
     ChallengeResponseMsgChunk, ChallengeResponseMsgHeader, CommitMsgChunk, CommitMsgHeader,
     CompletedSignatures, DepositAdaptors, DepositId, GarblingTableCommitment, HeapArray, Index,
-    OpenedGarblingTableCommitments, OpenedOutputShares, OutputPolynomialCommitment, PubKey,
-    ReservedSetupInputShares, Seed, SetupInputs, TableTransferReceiptMsg,
-    WideLabelWirePolynomialCommitments, WideLabelZerothPolynomialCoefficients, WithdrawalAdaptors,
-    WithdrawalAdaptorsChunk, WithdrawalInputs, state_machine::evaluator::*,
+    OpenedGarblingTableCommitments, PubKey, ReservedSetupInputShares, Seed, SetupInputs,
+    TableTransferReceiptMsg, TableTransferRequestMsg, WideLabelWirePolynomialCommitments,
+    WideLabelZerothPolynomialCoefficients, WithdrawalAdaptors, WithdrawalAdaptorsChunk,
+    WithdrawalInputs, state_machine::evaluator::*,
 };
 use mosaic_common::constants::{
     N_ADAPTOR_MSG_CHUNKS, N_CHALLENGE_RESPONSE_CHUNKS, N_CIRCUITS, N_DEPOSIT_INPUT_WIRES,
@@ -581,6 +581,11 @@ async fn handle_commit_msg_header<S: StateMut>(
 ) -> SMResult<()> {
     match &mut state.step {
         Step::WaitingForCommit { header, chunks, .. } => {
+            if *header {
+                warn!("evaluator received duplicate commit header, ack and ignore");
+                return Ok(());
+            }
+
             if !is_valid_commit_header(&commit_msg_header) {
                 warn!("evaluator received invalid commit msg header, aborting");
                 state.step = Step::Aborted {
@@ -631,6 +636,17 @@ async fn handle_commit_msg_header<S: StateMut>(
 
             post_handle_commit_msg(state, artifact_store, actions).await
         }
+        Step::WaitingForChallengeResponse { .. }
+        | Step::VerifyingOpenedInputShares
+        | Step::VerifyingTableCommitments { .. }
+        | Step::ReceivingGarblingTables { .. }
+        | Step::SetupComplete
+        | Step::EvaluatingTables { .. }
+        | Step::SetupConsumed { .. }
+        | Step::Aborted { .. } => {
+            warn!("evaluator received commit header after completion, ack and ignore");
+            Ok(())
+        }
         _ => Err(SMError::UnexpectedInput),
     }
 }
@@ -643,14 +659,6 @@ async fn handle_commit_msg_chunk<S: StateMut>(
 ) -> SMResult<()> {
     match &mut root_state.step {
         Step::WaitingForCommit { header, chunks } => {
-            if !is_valid_commit_chunk(&commit_msg_chunk) {
-                warn!("evaluator received invalid commit msg chunk, aborting");
-                root_state.step = Step::Aborted {
-                    reason: "invalid commit msg chunk".into(),
-                };
-                return Ok(());
-            }
-
             let chunk_idx = commit_msg_chunk.wire_index as usize;
             match chunks.get(chunk_idx) {
                 Some(false) => {
@@ -658,7 +666,8 @@ async fn handle_commit_msg_chunk<S: StateMut>(
                 }
                 Some(true) => {
                     // already seen chunk
-                    return Err(SMError::InvalidInputData);
+                    warn!(%chunk_idx, "evaluator received duplicate commit chunk, ack and ignore");
+                    return Ok(());
                 }
                 None => {
                     // unexpected chunk idx
@@ -696,6 +705,17 @@ async fn handle_commit_msg_chunk<S: StateMut>(
 
             post_handle_commit_msg(root_state, state, actions).await
         }
+        Step::WaitingForChallengeResponse { .. }
+        | Step::VerifyingOpenedInputShares
+        | Step::VerifyingTableCommitments { .. }
+        | Step::ReceivingGarblingTables { .. }
+        | Step::SetupComplete
+        | Step::EvaluatingTables { .. }
+        | Step::SetupConsumed { .. }
+        | Step::Aborted { .. } => {
+            warn!("evaluator received commit chunk after completion, ack and ignore");
+            Ok(())
+        }
         _ => Err(SMError::UnexpectedInput),
     }
 }
@@ -718,7 +738,7 @@ async fn post_handle_commit_msg<S: StateMut>(
     info!("evaluator commit msg complete, sending challenge");
     root_state.step = Step::WaitingForChallengeResponse {
         header: false,
-        chunks: HeapArray::from_elem(false),
+        remaining_chunks: get_remaining_challenge_response_chunks(&challenge_indices),
     };
 
     let challenge_msg = ChallengeMsg { challenge_indices };
@@ -733,14 +753,17 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
     actions: &mut ActionContainer,
 ) -> SMResult<()> {
     match &mut root_state.step {
-        Step::WaitingForChallengeResponse { header, chunks } => {
-            if !is_valid_challenge_response_header(&response_msg_header) {
-                warn!("evaluator received invalid challenge response header, aborting");
-                root_state.step = Step::Aborted {
-                    reason: "invalid challenge response message header".into(),
-                };
+        Step::WaitingForChallengeResponse {
+            header,
+            remaining_chunks,
+        } => {
+            if *header {
+                warn!("evaluator received duplicate challenge response header, ack and ignore");
                 return Ok(());
             }
+
+            // NOTE: header validity is checked after header and all chunks are received.
+
             let challenge_idxs = state
                 .get_challenge_indices()
                 .await
@@ -773,11 +796,21 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
 
             *header = true;
             debug!("evaluator challenge response header received");
-            if chunks.count_ones() != N_CHALLENGE_RESPONSE_CHUNKS {
+            if remaining_chunks.count_ones() > 0 {
                 return Ok(());
             }
 
             post_handle_challenge_response(root_state, state, actions).await
+        }
+        Step::VerifyingOpenedInputShares
+        | Step::VerifyingTableCommitments { .. }
+        | Step::ReceivingGarblingTables { .. }
+        | Step::SetupComplete
+        | Step::EvaluatingTables { .. }
+        | Step::SetupConsumed { .. }
+        | Step::Aborted { .. } => {
+            warn!("evaluator received challenge response header after completion, ack and ignore");
+            Ok(())
         }
         _ => Err(SMError::UnexpectedInput),
     }
@@ -790,34 +823,32 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
     actions: &mut ActionContainer,
 ) -> SMResult<()> {
     match &mut root_state.step {
-        Step::WaitingForChallengeResponse { header, chunks } => {
-            let challenge_idxs = state
-                .get_challenge_indices()
-                .await
-                .require("expected challenge indices")?;
-
-            if !is_valid_challenge_response_chunk(&response_msg_chunk, &challenge_idxs) {
-                warn!(
-                    circuit_index = response_msg_chunk.circuit_index,
-                    "evaluator received invalid challenge response chunk, aborting"
-                );
-                root_state.step = Step::Aborted {
-                    reason: "invalid challenge response message".into(),
-                };
-                return Ok(());
-            }
-
+        Step::WaitingForChallengeResponse {
+            header,
+            remaining_chunks,
+        } => {
             let chunk_idx = (response_msg_chunk.circuit_index as usize)
                 .checked_sub(1)
                 .unwrap();
-            if chunks[chunk_idx] {
-                return Err(SMError::InvalidInputData);
-            }
-            chunks[chunk_idx] = true;
+            match remaining_chunks.get(chunk_idx) {
+                Some(true) => {
+                    // expected chunk
+                }
+                Some(false) => {
+                    // already seen chunk
+                    warn!(%chunk_idx, "evaluator received duplicate commit chunk, ack and ignore");
+                    return Ok(());
+                }
+                None => {
+                    // unexpected chunk idx
+                    return Err(SMError::InvalidInputData);
+                }
+            };
+            remaining_chunks[chunk_idx] = false;
             debug!(
                 circuit_index = response_msg_chunk.circuit_index,
-                done = chunks.count_ones(),
-                total = chunks.len(),
+                remaining = remaining_chunks.count_ones(),
+                total = remaining_chunks.len(),
                 "evaluator challenge response chunk received"
             );
 
@@ -829,11 +860,21 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
                 .await
                 .map_err(SMError::storage)?;
 
-            if !*header || chunks.count_ones() != N_CHALLENGE_RESPONSE_CHUNKS {
+            if !*header || remaining_chunks.count_ones() > 0 {
                 return Ok(());
             }
 
             post_handle_challenge_response(root_state, state, actions).await
+        }
+        Step::VerifyingOpenedInputShares
+        | Step::VerifyingTableCommitments { .. }
+        | Step::ReceivingGarblingTables { .. }
+        | Step::SetupComplete
+        | Step::EvaluatingTables { .. }
+        | Step::SetupConsumed { .. }
+        | Step::Aborted { .. } => {
+            warn!("evaluator received challenge response chunk after completion, ack and ignore");
+            Ok(())
         }
         _ => Err(SMError::UnexpectedInput),
     }
@@ -845,29 +886,6 @@ async fn post_handle_challenge_response<S: StateMut>(
     actions: &mut ActionContainer,
 ) -> SMResult<()> {
     // all chunks received
-    let opened_output_shares = state
-        .get_opened_output_shares()
-        .await
-        .require("expected opened output shares")?;
-
-    let output_polynomial_commitment = state
-        .get_output_polynomial_commitment()
-        .await
-        .require("expected output polynomial commitment")?;
-
-    if let Some(failure_reason) =
-        verify_opened_output_shares(&opened_output_shares, &output_polynomial_commitment)
-    {
-        warn!(reason = %failure_reason, "evaluator opened output share verification failed, aborting");
-        root_state.step = Step::Aborted {
-            reason: format!(
-                "opened output share verification failed: {}",
-                failure_reason
-            ),
-        };
-        return Ok(());
-    }
-
     let config = require_config(root_state)?;
     let reserved_setup_input_shares = state
         .get_reserved_setup_input_shares()
@@ -1033,11 +1051,14 @@ pub(crate) async fn restore<S: StateRead>(
     match &root_state.step {
         Step::Uninit => {}
         Step::WaitingForCommit { .. } => {}
-        Step::WaitingForChallengeResponse { header, chunks } => {
+        Step::WaitingForChallengeResponse {
+            header,
+            remaining_chunks,
+        } => {
             // Replay challenge send only if no response material was observed yet.
             // Once any response data is stored, re-sending can cause duplicate
             // challenge handling on the garbler side.
-            if !header && chunks.iter().all(|seen| !*seen) {
+            if !header && remaining_chunks.count_ones() == N_CHALLENGE_RESPONSE_CHUNKS {
                 let challenge_indices = state
                     .get_challenge_indices()
                     .await
@@ -1192,11 +1213,6 @@ fn is_valid_commit_header(commit_header: &CommitMsgHeader) -> bool {
     PubKey(poly).valid()
 }
 
-#[expect(unused_variables)]
-fn is_valid_commit_chunk(commit_msg: &CommitMsgChunk) -> bool {
-    true // validated when challenge response is received
-}
-
 fn sample_challenge_indices(base_seed: Seed) -> ChallengeIndices {
     let seed = derive_stage_seed(base_seed, SEED_CONTEXT_SAMPLE_CHALLENGE_INDICES, None);
     let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed.into());
@@ -1209,29 +1225,6 @@ fn sample_challenge_indices(base_seed: Seed) -> ChallengeIndices {
     );
     challenge_indices.sort_by_key(|k| k.get());
     challenge_indices
-}
-
-#[expect(unused_variables)]
-fn is_valid_challenge_response_header(response_msg_header: &ChallengeResponseMsgHeader) -> bool {
-    true // validated by jobs
-}
-
-fn is_valid_challenge_response_chunk(
-    response_msg_chunk: &ChallengeResponseMsgChunk,
-    challenge_idxs: &ChallengeIndices,
-) -> bool {
-    challenge_idxs
-        .iter()
-        .any(|x| x.get() == response_msg_chunk.circuit_index as usize)
-}
-
-/// Verify opened output shares against polynomial commitments and return failure reason or None.
-#[expect(unused_variables)]
-fn verify_opened_output_shares(
-    opened_output_shares: &OpenedOutputShares,
-    output_polynomial_commitment: &OutputPolynomialCommitment,
-) -> Option<String> {
-    None
 }
 
 /// Verify reserved setup input shares and return failure reason or None.
@@ -1260,6 +1253,20 @@ fn get_opened_commitments(
         let seed_idx = challenge_indices[i].get() - 1;
         garbling_commitments[seed_idx]
     })
+}
+
+/// Returns a boolean mask over chunks, where `true` marks chunks that still
+/// need to be received. Challenge indices are 1-based, so each is decremented
+/// by 1 to map to the 0-based chunk index.
+pub(super) fn get_remaining_challenge_response_chunks(
+    challenge_indices: &ChallengeIndices,
+) -> HeapArray<bool, N_CIRCUITS> {
+    let mut remaining_chunks = HeapArray::from_elem(false);
+    challenge_indices.iter().for_each(|challenge_idx| {
+        let chunk_idx = challenge_idx.get().checked_sub(1).expect("non zero");
+        remaining_chunks[chunk_idx] = true;
+    });
+    remaining_chunks
 }
 
 fn is_sorted<T: Ord>(slice: &[T]) -> bool {

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -636,14 +636,7 @@ async fn handle_commit_msg_header<S: StateMut>(
 
             post_handle_commit_msg(state, artifact_store, actions).await
         }
-        Step::WaitingForChallengeResponse { .. }
-        | Step::VerifyingOpenedInputShares
-        | Step::VerifyingTableCommitments { .. }
-        | Step::ReceivingGarblingTables { .. }
-        | Step::SetupComplete
-        | Step::EvaluatingTables { .. }
-        | Step::SetupConsumed { .. }
-        | Step::Aborted { .. } => {
+        step if step.phase() > StepPhase::WaitingForCommit => {
             warn!("evaluator received commit header after completion, ack and ignore");
             Ok(())
         }
@@ -705,14 +698,7 @@ async fn handle_commit_msg_chunk<S: StateMut>(
 
             post_handle_commit_msg(root_state, state, actions).await
         }
-        Step::WaitingForChallengeResponse { .. }
-        | Step::VerifyingOpenedInputShares
-        | Step::VerifyingTableCommitments { .. }
-        | Step::ReceivingGarblingTables { .. }
-        | Step::SetupComplete
-        | Step::EvaluatingTables { .. }
-        | Step::SetupConsumed { .. }
-        | Step::Aborted { .. } => {
+        step if step.phase() > StepPhase::WaitingForCommit => {
             warn!("evaluator received commit chunk after completion, ack and ignore");
             Ok(())
         }
@@ -802,13 +788,7 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
 
             post_handle_challenge_response(root_state, state, actions).await
         }
-        Step::VerifyingOpenedInputShares
-        | Step::VerifyingTableCommitments { .. }
-        | Step::ReceivingGarblingTables { .. }
-        | Step::SetupComplete
-        | Step::EvaluatingTables { .. }
-        | Step::SetupConsumed { .. }
-        | Step::Aborted { .. } => {
+        step if step.phase() > StepPhase::WaitingForChallengeResponse => {
             warn!("evaluator received challenge response header after completion, ack and ignore");
             Ok(())
         }
@@ -866,13 +846,7 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
 
             post_handle_challenge_response(root_state, state, actions).await
         }
-        Step::VerifyingOpenedInputShares
-        | Step::VerifyingTableCommitments { .. }
-        | Step::ReceivingGarblingTables { .. }
-        | Step::SetupComplete
-        | Step::EvaluatingTables { .. }
-        | Step::SetupConsumed { .. }
-        | Step::Aborted { .. } => {
+        step if step.phase() > StepPhase::WaitingForChallengeResponse => {
             warn!("evaluator received challenge response chunk after completion, ack and ignore");
             Ok(())
         }

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -9,6 +9,7 @@ use mosaic_common::constants::N_EVAL_CIRCUITS;
 use mosaic_storage_inmemory::evaluator::StoredEvaluatorState;
 
 use super::stf::restore;
+use crate::evaluator::stf::get_remaining_challenge_response_chunks;
 
 #[tokio::test]
 async fn restore_evaluating_tables_replays_only_pending_tables() {
@@ -117,12 +118,13 @@ async fn restore_waiting_for_challenge_response_replays_only_before_receipt() {
         .expect("store challenge indices");
 
     let mut actions = Vec::new();
+    let all_chunks_remaining = get_remaining_challenge_response_chunks(&challenge_indices);
     state
         .put_root_state(&EvaluatorState {
             config: None,
             step: Step::WaitingForChallengeResponse {
                 header: false,
-                chunks: HeapArray::from_elem(false),
+                remaining_chunks: all_chunks_remaining,
             },
         })
         .await
@@ -144,14 +146,18 @@ async fn restore_waiting_for_challenge_response_replays_only_before_receipt() {
     }
 
     actions.clear();
-    let mut received_chunks = HeapArray::from_elem(false);
-    received_chunks[0] = true;
+    let mut remaining_chunks = get_remaining_challenge_response_chunks(&challenge_indices);
+    let remaining_idx = remaining_chunks
+        .iter()
+        .position(|&v| v)
+        .expect("must exist");
+    remaining_chunks[remaining_idx] = false;
     state
         .put_root_state(&EvaluatorState {
             config: None,
             step: Step::WaitingForChallengeResponse {
                 header: true,
-                chunks: received_chunks,
+                remaining_chunks,
             },
         })
         .await

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -397,6 +397,10 @@ async fn duplicate_challenge_response_chunk_is_ack_and_ignore() {
     let first_challenge_idx = challenge_indices[0].get() - 1;
     remaining[first_challenge_idx] = false;
     state
+        .put_challenge_indices(&challenge_indices)
+        .await
+        .unwrap();
+    state
         .put_root_state(&EvaluatorState {
             config: None,
             step: Step::WaitingForChallengeResponse {
@@ -419,6 +423,41 @@ async fn duplicate_challenge_response_chunk_is_ack_and_ignore() {
     .await;
 
     assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn unchallenged_in_range_challenge_response_chunk_is_invalid() {
+    let mut state = StoredEvaluatorState::default();
+    let challenge_indices = ChallengeIndices::new(|i| Index::new((i * 2) + 1).unwrap());
+    let remaining = get_remaining_challenge_response_chunks(&challenge_indices);
+    state
+        .put_challenge_indices(&challenge_indices)
+        .await
+        .unwrap();
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::WaitingForChallengeResponse {
+                header: false,
+                remaining_chunks: remaining,
+            },
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeResponseMsgChunk(dummy_challenge_response_chunk(2)),
+        &mut actions,
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(crate::error::SMError::InvalidInputData)),
+        "unchallenged in-range chunk must be rejected, got: {result:?}"
+    );
     assert!(actions.is_empty(), "should produce no actions");
 }
 

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -2,13 +2,15 @@ use std::collections::BTreeSet;
 
 use fasm::actions::Action as FasmAction;
 use mosaic_cac_types::{
-    ChallengeIndices, DepositId, EvaluationIndices, HeapArray, Index,
-    state_machine::evaluator::{Action, EvaluatorState, StateMut, Step},
+    ChallengeIndices, ChallengeResponseMsgChunk, ChallengeResponseMsgHeader, CommitMsgChunk,
+    CommitMsgHeader, DepositId, EvaluationIndices, HeapArray, Index, Polynomial,
+    state_machine::evaluator::{Action, EvaluatorState, Input, StateMut, Step},
 };
 use mosaic_common::constants::N_EVAL_CIRCUITS;
 use mosaic_storage_inmemory::evaluator::StoredEvaluatorState;
+use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
-use super::stf::restore;
+use super::stf::{handle_event, restore};
 use crate::evaluator::stf::get_remaining_challenge_response_chunks;
 
 #[tokio::test]
@@ -169,4 +171,276 @@ async fn restore_waiting_for_challenge_response_replays_only_before_receipt() {
         actions.is_empty(),
         "challenge must not replay after response receipt begins"
     );
+}
+
+// ============================================================================
+// "Ack and ignore" tests
+//
+// Each test puts the STF in a step where the incoming message is no longer
+// relevant (the machine already advanced past it), and asserts that
+// handle_event returns Ok(()) with an empty action queue.
+// ============================================================================
+
+/// Helper: build a dummy `CommitMsgHeader` with arbitrary but valid-shaped data.
+fn dummy_commit_msg_header() -> CommitMsgHeader {
+    let mut rng = ChaCha20Rng::seed_from_u64(99);
+    let poly_commitment = Polynomial::rand(&mut rng).commit();
+    CommitMsgHeader {
+        garbling_table_commitments: HeapArray::new(|i| [i as u8; 32].into()),
+        output_polynomial_commitment: HeapArray::from_elem(poly_commitment.clone()),
+        all_aes128_keys: HeapArray::from_elem([0u8; 16]),
+        all_public_s: HeapArray::from_elem([0u8; 16]),
+        all_constant_zero_labels: HeapArray::from_elem([0u8; 16]),
+        all_constant_one_labels: HeapArray::from_elem([0u8; 16]),
+    }
+}
+
+/// Helper: build a dummy `CommitMsgChunk` for the given wire index.
+fn dummy_commit_msg_chunk(wire_index: u16) -> CommitMsgChunk {
+    let mut rng = ChaCha20Rng::seed_from_u64(100);
+    let poly_commitment = Polynomial::rand(&mut rng).commit();
+    CommitMsgChunk {
+        wire_index,
+        commitments: HeapArray::from_elem(poly_commitment),
+    }
+}
+
+/// Helper: build a dummy `ChallengeResponseMsgHeader`.
+fn dummy_challenge_response_header() -> ChallengeResponseMsgHeader {
+    let mut rng = ChaCha20Rng::seed_from_u64(101);
+    let dummy_share = Polynomial::rand(&mut rng).eval(Index::new(1).unwrap());
+    ChallengeResponseMsgHeader {
+        reserved_setup_input_shares: HeapArray::from_elem(dummy_share),
+        opened_output_shares: HeapArray::from_elem(dummy_share),
+        opened_garbling_seeds: HeapArray::from_elem([0u8; 32].into()),
+        unchallenged_output_label_cts: HeapArray::from_elem([0u8; 32].into()),
+    }
+}
+
+/// Helper: build a dummy `ChallengeResponseMsgChunk` for the given circuit index.
+fn dummy_challenge_response_chunk(circuit_index: u16) -> ChallengeResponseMsgChunk {
+    let mut rng = ChaCha20Rng::seed_from_u64(102);
+    let dummy_share = Polynomial::rand(&mut rng).eval(Index::new(1).unwrap());
+    ChallengeResponseMsgChunk {
+        circuit_index,
+        shares: HeapArray::from_elem(HeapArray::from_elem(dummy_share)),
+    }
+}
+
+#[tokio::test]
+async fn duplicate_commit_header_is_ack_and_ignore() {
+    let mut state = StoredEvaluatorState::default();
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::WaitingForCommit {
+                header: true,
+                chunks: HeapArray::from_elem(false),
+            },
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvCommitMsgHeader(dummy_commit_msg_header()),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn commit_header_after_waiting_for_challenge_response_is_ack_and_ignore() {
+    let mut state = StoredEvaluatorState::default();
+    let challenge_indices = ChallengeIndices::new(|i| Index::new(i + 1).unwrap());
+    let remaining = get_remaining_challenge_response_chunks(&challenge_indices);
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::WaitingForChallengeResponse {
+                header: false,
+                remaining_chunks: remaining,
+            },
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvCommitMsgHeader(dummy_commit_msg_header()),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn duplicate_commit_chunk_is_ack_and_ignore() {
+    let mut state = StoredEvaluatorState::default();
+    let mut chunks = HeapArray::from_elem(false);
+    chunks[0] = true; // chunk 0 already received
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::WaitingForCommit {
+                header: false,
+                chunks,
+            },
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvCommitMsgChunk(dummy_commit_msg_chunk(0)), // duplicate wire 0
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn commit_chunk_after_waiting_for_challenge_response_is_ack_and_ignore() {
+    let mut state = StoredEvaluatorState::default();
+    let challenge_indices = ChallengeIndices::new(|i| Index::new(i + 1).unwrap());
+    let remaining = get_remaining_challenge_response_chunks(&challenge_indices);
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::WaitingForChallengeResponse {
+                header: false,
+                remaining_chunks: remaining,
+            },
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvCommitMsgChunk(dummy_commit_msg_chunk(0)),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn duplicate_challenge_response_header_is_ack_and_ignore() {
+    let mut state = StoredEvaluatorState::default();
+    let challenge_indices = ChallengeIndices::new(|i| Index::new(i + 1).unwrap());
+    let remaining = get_remaining_challenge_response_chunks(&challenge_indices);
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::WaitingForChallengeResponse {
+                header: true, // already received
+                remaining_chunks: remaining,
+            },
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeResponseMsgHeader(dummy_challenge_response_header()),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn challenge_response_header_after_verifying_is_ack_and_ignore() {
+    let mut state = StoredEvaluatorState::default();
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::VerifyingOpenedInputShares,
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeResponseMsgHeader(dummy_challenge_response_header()),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn duplicate_challenge_response_chunk_is_ack_and_ignore() {
+    let mut state = StoredEvaluatorState::default();
+    let challenge_indices = ChallengeIndices::new(|i| Index::new(i + 1).unwrap());
+    let mut remaining = get_remaining_challenge_response_chunks(&challenge_indices);
+    // Mark first challenge index's chunk as already received.
+    let first_challenge_idx = challenge_indices[0].get() - 1;
+    remaining[first_challenge_idx] = false;
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::WaitingForChallengeResponse {
+                header: false,
+                remaining_chunks: remaining,
+            },
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    // Send same chunk again (circuit_index is 1-based).
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeResponseMsgChunk(dummy_challenge_response_chunk(
+            challenge_indices[0].get() as u16,
+        )),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn challenge_response_chunk_after_verifying_is_ack_and_ignore() {
+    let mut state = StoredEvaluatorState::default();
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::VerifyingOpenedInputShares,
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeResponseMsgChunk(dummy_challenge_response_chunk(1)),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
 }

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -88,62 +88,68 @@ pub(crate) async fn handle_event<S: StateMut>(
                 }
             }
         }
-        Input::RecvChallengeMsg(challenge_msg) => {
-            match root_state.step {
-                Step::SendingCommit { .. } | Step::WaitingForChallenge => {
-                    if is_valid_challenge(&challenge_msg) {
-                        info!("garbler received valid challenge, sending response");
+        Input::RecvChallengeMsg(challenge_msg) => match root_state.step {
+            Step::SendingCommit { .. } | Step::WaitingForChallenge => {
+                if is_valid_challenge(&challenge_msg) {
+                    info!("garbler received valid challenge, sending response");
 
-                        let reserved_setup_input_shares = state
-                            .get_reserved_setup_input_shares()
-                            .await
-                            .require("expected reserved setup input shares")?;
-                        let output_shares = state
-                            .get_output_shares()
-                            .await
-                            .require("expected output shares")?;
-                        let config = require_config(&root_state)?;
-                        let seeds = generate_garbling_table_seeds(config.seed);
+                    let reserved_setup_input_shares = state
+                        .get_reserved_setup_input_shares()
+                        .await
+                        .require("expected reserved setup input shares")?;
+                    let output_shares = state
+                        .get_output_shares()
+                        .await
+                        .require("expected output shares")?;
+                    let config = require_config(&root_state)?;
+                    let seeds = generate_garbling_table_seeds(config.seed);
 
-                        let all_output_label_cts = state
-                            .get_all_output_label_cts()
-                            .await
-                            .require("expected garbling table metadata")?;
+                    let all_output_label_cts = state
+                        .get_all_output_label_cts()
+                        .await
+                        .require("expected garbling table metadata")?;
 
-                        let challenge_indices = challenge_msg.challenge_indices;
+                    let challenge_indices = challenge_msg.challenge_indices;
 
-                        let header = create_challenge_response_msg_header(
-                            &challenge_indices,
-                            reserved_setup_input_shares,
-                            &output_shares,
-                            seeds,
-                            all_output_label_cts,
-                        );
-                        state
-                            .put_challenge_indices(&challenge_indices)
-                            .await
-                            .map_err(SMError::storage)?;
+                    let header = create_challenge_response_msg_header(
+                        &challenge_indices,
+                        reserved_setup_input_shares,
+                        &output_shares,
+                        seeds,
+                        all_output_label_cts,
+                    );
+                    state
+                        .put_challenge_indices(&challenge_indices)
+                        .await
+                        .map_err(SMError::storage)?;
 
-                        root_state.step = Step::SendingChallengeResponse {
-                            header_acked: false,
-                            chunk_acked: HeapArray::from_elem(false),
-                        };
+                    root_state.step = Step::SendingChallengeResponse {
+                        header_acked: false,
+                        chunk_acked: HeapArray::from_elem(false),
+                    };
 
-                        emit(actions, Action::SendChallengeResponseMsgHeader(header));
-                        for circuit_idx in challenge_indices {
-                            emit(actions, Action::SendChallengeResponseMsgChunk(circuit_idx));
-                        }
-                    } else {
-                        // TODO: should this abort, or just ignore and stay at same state ?
-                        warn!("garbler received invalid challenge, aborting");
-                        root_state.step = Step::Aborted {
-                            reason: "invalid challenge msg".into(),
-                        };
+                    emit(actions, Action::SendChallengeResponseMsgHeader(header));
+                    for circuit_idx in challenge_indices {
+                        emit(actions, Action::SendChallengeResponseMsgChunk(circuit_idx));
                     }
+                } else {
+                    warn!("garbler received invalid challenge, aborting");
+                    root_state.step = Step::Aborted {
+                        reason: "invalid challenge msg".into(),
+                    };
                 }
-                _ => return Err(SMError::unexpected_input()),
             }
-        }
+            // ack on all steps after WaitingForChallenge
+            Step::SendingChallengeResponse { .. }
+            | Step::TransferringGarblingTables { .. }
+            | Step::SetupComplete
+            | Step::CompletingAdaptors { .. }
+            | Step::SetupConsumed { .. }
+            | Step::Aborted { .. } => {
+                warn!("garbler received challenge after completion, ack and ignore");
+            }
+            _ => return Err(SMError::unexpected_input()),
+        },
         Input::RecvTableTransferRequest(request_msg) => match &root_state.step {
             Step::TransferringGarblingTables {
                 eval_seeds,
@@ -169,6 +175,12 @@ pub(crate) async fn handle_event<S: StateMut>(
                 // Only begin table transfer after getting request from evaluator.
                 debug!(commitment = %request_msg.garbling_table_commitment, "garbler received table transfer request");
                 emit(actions, Action::TransferGarblingTable(*seed));
+            }
+            Step::SetupComplete
+            | Step::CompletingAdaptors { .. }
+            | Step::SetupConsumed { .. }
+            | Step::Aborted { .. } => {
+                warn!("garbler received table transfer request after completion, ack and ignore");
             }
             _ => return Err(SMError::unexpected_input()),
         },
@@ -202,6 +214,12 @@ pub(crate) async fn handle_event<S: StateMut>(
                     info!("all garbling tables transferred, setup complete");
                     root_state.step = Step::SetupComplete;
                 }
+            }
+            Step::SetupComplete
+            | Step::CompletingAdaptors { .. }
+            | Step::SetupConsumed { .. }
+            | Step::Aborted { .. } => {
+                warn!("garbler received table transfer receipt after completion, ack and ignore");
             }
             _ => return Err(SMError::unexpected_input()),
         },
@@ -762,13 +780,19 @@ async fn handle_recv_deposit_adaptor_msg_chunk<S: StateMut>(
 
             let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
-            let all_chunks_received = if let DepositStep::WaitingForAdaptors { chunks } =
-                &mut deposit_state.step
-            {
+            let all_chunks_received = {
+                let DepositStep::WaitingForAdaptors { chunks } = &mut deposit_state.step else {
+                    // WaitingForAdaptors is first step of deposit state machine. All other steps
+                    // are after it.
+                    warn!("garbler received adaptor chunk after completion, ack and ignore");
+                    return Ok(());
+                };
+
                 let chunk_idx = adaptor_msg_chunk.chunk_index as usize;
 
                 if chunks[chunk_idx] {
-                    return Err(SMError::invalid_input_data());
+                    warn!("garbler received duplicate adaptor chunk, ack and ignore");
+                    return Ok(());
                 }
 
                 state
@@ -780,8 +804,6 @@ async fn handle_recv_deposit_adaptor_msg_chunk<S: StateMut>(
                 debug!(%deposit_id, chunk_idx, done = chunks.count_ones(), total = chunks.len(), "adaptor chunk received");
 
                 chunks.all()
-            } else {
-                false
             };
 
             if all_chunks_received {
@@ -796,9 +818,15 @@ async fn handle_recv_deposit_adaptor_msg_chunk<S: StateMut>(
                 .map_err(SMError::storage)?;
 
             if !all_chunks_received {
+                // stay on same step and wait for more
+                debug!("waiting for adaptor chunks");
                 return Ok(());
             }
         }
+        Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. } | Step::Aborted { .. } => {
+            warn!("garbler received adaptor chunk after completion, ack and ignore");
+        }
+
         _ => return Err(SMError::unexpected_input()),
     };
 

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -142,13 +142,9 @@ pub(crate) async fn handle_event<S: StateMut>(
                 }
             }
             // ack on all steps after WaitingForChallenge
-            Step::SendingChallengeResponse { .. }
-            | Step::TransferringGarblingTables { .. }
-            | Step::SetupComplete
-            | Step::CompletingAdaptors { .. }
-            | Step::SetupConsumed { .. }
-            | Step::Aborted { .. } => {
+            step if step.phase() > StepPhase::WaitingForChallenge => {
                 warn!("garbler received challenge after completion, ack and ignore");
+                return Ok(());
             }
             _ => return Err(SMError::unexpected_input()),
         },
@@ -178,11 +174,9 @@ pub(crate) async fn handle_event<S: StateMut>(
                 debug!(commitment = %request_msg.garbling_table_commitment, "garbler received table transfer request");
                 emit(actions, Action::TransferGarblingTable(*seed));
             }
-            Step::SetupComplete
-            | Step::CompletingAdaptors { .. }
-            | Step::SetupConsumed { .. }
-            | Step::Aborted { .. } => {
+            step if step.phase() > StepPhase::TransferringGarblingTables => {
                 warn!("garbler received table transfer request after completion, ack and ignore");
+                return Ok(());
             }
             _ => return Err(SMError::unexpected_input()),
         },
@@ -217,11 +211,9 @@ pub(crate) async fn handle_event<S: StateMut>(
                     root_state.step = Step::SetupComplete;
                 }
             }
-            Step::SetupComplete
-            | Step::CompletingAdaptors { .. }
-            | Step::SetupConsumed { .. }
-            | Step::Aborted { .. } => {
+            step if step.phase() > StepPhase::TransferringGarblingTables => {
                 warn!("garbler received table transfer receipt after completion, ack and ignore");
+                return Ok(());
             }
             _ => return Err(SMError::unexpected_input()),
         },
@@ -831,8 +823,9 @@ async fn handle_recv_deposit_adaptor_msg_chunk<S: StateMut>(
                 return Ok(());
             }
         }
-        Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. } | Step::Aborted { .. } => {
+        step if step.phase() > StepPhase::SetupComplete => {
             warn!("garbler received adaptor chunk after completion, ack and ignore");
+            return Ok(());
         }
 
         _ => return Err(SMError::unexpected_input()),

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -143,7 +143,7 @@ pub(crate) async fn handle_event<S: StateMut>(
             }
             // ack on all steps after WaitingForChallenge
             step if step.phase() > StepPhase::WaitingForChallenge => {
-                warn!("garbler received challenge after completion, ack and ignore");
+                debug!("garbler received challenge after completion, ack and ignore");
                 return Ok(());
             }
             _ => return Err(SMError::unexpected_input()),
@@ -175,7 +175,7 @@ pub(crate) async fn handle_event<S: StateMut>(
                 emit(actions, Action::TransferGarblingTable(*seed));
             }
             step if step.phase() > StepPhase::TransferringGarblingTables => {
-                warn!("garbler received table transfer request after completion, ack and ignore");
+                debug!("garbler received table transfer request after completion, ack and ignore");
                 return Ok(());
             }
             _ => return Err(SMError::unexpected_input()),
@@ -212,7 +212,7 @@ pub(crate) async fn handle_event<S: StateMut>(
                 }
             }
             step if step.phase() > StepPhase::TransferringGarblingTables => {
-                warn!("garbler received table transfer receipt after completion, ack and ignore");
+                debug!("garbler received table transfer receipt after completion, ack and ignore");
                 return Ok(());
             }
             _ => return Err(SMError::unexpected_input()),
@@ -400,7 +400,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     }
                 }
                 step if step.phase() > StepPhase::SendingCommit => {
-                    warn!("garbler received commit header ack after completion, ignore");
+                    debug!("garbler received commit header ack after completion, ignore");
                 }
                 _ => return Err(SMError::unexpected_input()),
             }
@@ -434,7 +434,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     }
                 }
                 step if step.phase() > StepPhase::SendingCommit => {
-                    warn!("garbler received commit chunk ack after completion, ignore");
+                    debug!("garbler received commit chunk ack after completion, ignore");
                 }
                 _ => return Err(SMError::unexpected_input()),
             }
@@ -525,7 +525,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     // Informational only. We mark a table as transferred once we get corresponding
                     // [`TableTransferReceiptMsg`](mosaic_cac_types::TableTransferReceiptMsg) from
                     // evaluator.
-                    info!(%commitment, "garbling table transferred")
+                    debug!(%commitment, "garbling table transferred")
                 }
                 _ => return Err(SMError::unexpected_input()),
             }
@@ -784,14 +784,14 @@ async fn handle_recv_deposit_adaptor_msg_chunk<S: StateMut>(
                 let DepositStep::WaitingForAdaptors { chunks } = &mut deposit_state.step else {
                     // WaitingForAdaptors is first step of deposit state machine. All other steps
                     // are after it.
-                    warn!("garbler received adaptor chunk after completion, ack and ignore");
+                    debug!("garbler received adaptor chunk after completion, ack and ignore");
                     return Ok(());
                 };
 
                 let chunk_idx = adaptor_msg_chunk.chunk_index as usize;
 
                 if chunks[chunk_idx] {
-                    warn!("garbler received duplicate adaptor chunk, ack and ignore");
+                    debug!("garbler received duplicate adaptor chunk, ack and ignore");
                     return Ok(());
                 }
 
@@ -824,7 +824,7 @@ async fn handle_recv_deposit_adaptor_msg_chunk<S: StateMut>(
             }
         }
         step if step.phase() > StepPhase::SetupComplete => {
-            warn!("garbler received adaptor chunk after completion, ack and ignore");
+            debug!("garbler received adaptor chunk after completion, ack and ignore");
             return Ok(());
         }
 

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -89,6 +89,8 @@ pub(crate) async fn handle_event<S: StateMut>(
             }
         }
         Input::RecvChallengeMsg(challenge_msg) => match root_state.step {
+            // Final commit chunk ack and challenge message is sent in same step by evaluator, so
+            // allow challenge to be received early if it is valid.
             Step::SendingCommit { .. } | Step::WaitingForChallenge => {
                 if is_valid_challenge(&challenge_msg) {
                     info!("garbler received valid challenge, sending response");
@@ -405,6 +407,9 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                         root_state.step = Step::WaitingForChallenge;
                     }
                 }
+                step if step.phase() > StepPhase::SendingCommit => {
+                    warn!("garbler received commit header ack after completion, ignore");
+                }
                 _ => return Err(SMError::unexpected_input()),
             }
         }
@@ -435,6 +440,9 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                         info!("all commit msg parts acked, waiting for challenge");
                         root_state.step = Step::WaitingForChallenge;
                     }
+                }
+                step if step.phase() > StepPhase::SendingCommit => {
+                    warn!("garbler received commit chunk ack after completion, ignore");
                 }
                 _ => return Err(SMError::unexpected_input()),
             }

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -14,7 +14,7 @@ use mosaic_common::constants::{
 };
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use tracing::{error, info};
+use tracing::{debug, error, info, warn};
 
 use super::emit;
 use crate::{
@@ -45,6 +45,8 @@ pub(crate) async fn handle_event<S: StateMut>(
         Input::Init(data) => {
             match root_state.step {
                 Step::Uninit => {
+                    info!("garbler init: generating polynomial commitments");
+
                     // state update
                     root_state.config = Some(Config {
                         seed: data.seed,
@@ -77,13 +79,21 @@ pub(crate) async fn handle_event<S: StateMut>(
                         );
                     }
                 }
-                _ => return Err(SMError::unexpected_input()),
+                _ => {
+                    warn!(
+                        step = root_state.step.step_name(),
+                        "garbler init in unexpected step"
+                    );
+                    return Err(SMError::unexpected_input());
+                }
             }
         }
         Input::RecvChallengeMsg(challenge_msg) => {
             match root_state.step {
                 Step::SendingCommit { .. } | Step::WaitingForChallenge => {
                     if is_valid_challenge(&challenge_msg) {
+                        info!("garbler received valid challenge, sending response");
+
                         let reserved_setup_input_shares = state
                             .get_reserved_setup_input_shares()
                             .await
@@ -125,6 +135,7 @@ pub(crate) async fn handle_event<S: StateMut>(
                         }
                     } else {
                         // TODO: should this abort, or just ignore and stay at same state ?
+                        warn!("garbler received invalid challenge, aborting");
                         root_state.step = Step::Aborted {
                             reason: "invalid challenge msg".into(),
                         };
@@ -156,6 +167,7 @@ pub(crate) async fn handle_event<S: StateMut>(
                 };
 
                 // Only begin table transfer after getting request from evaluator.
+                debug!(commitment = %request_msg.garbling_table_commitment, "garbler received table transfer request");
                 emit(actions, Action::TransferGarblingTable(*seed));
             }
             _ => return Err(SMError::unexpected_input()),
@@ -179,8 +191,15 @@ pub(crate) async fn handle_event<S: StateMut>(
                 };
 
                 transferred[pos] = true;
+                debug!(
+                    pos,
+                    done = transferred.count_ones(),
+                    total = transferred.len(),
+                    "garbler received table transfer receipt"
+                );
 
                 if transferred.all() {
+                    info!("all garbling tables transferred, setup complete");
                     root_state.step = Step::SetupComplete;
                 }
             }
@@ -201,10 +220,11 @@ pub(crate) async fn handle_event<S: StateMut>(
                     .map_err(SMError::storage)?
                     .is_some()
                 {
-                    // deposit already exists
+                    warn!(%deposit_id, "garbler deposit already exists");
                     return Err(SMError::deposit_already_exists(deposit_id));
                 }
 
+                info!(%deposit_id, "garbler initializing deposit");
                 let deposit_state = DepositState {
                     step: DepositStep::WaitingForAdaptors {
                         chunks: HeapArray::from_elem(false),
@@ -244,6 +264,7 @@ pub(crate) async fn handle_event<S: StateMut>(
 
                 match &mut deposit_state.step {
                     DepositStep::DepositReady => {
+                        info!(%deposit_id, "garbler deposit undisputed withdrawal");
                         deposit_state.step = DepositStep::WithdrawnUndisputed;
                     }
                     _ => return Err(SMError::unexpected_input()),
@@ -263,6 +284,7 @@ pub(crate) async fn handle_event<S: StateMut>(
 
                     match &mut deposit_state.step {
                         DepositStep::DepositReady => {
+                            info!(%deposit_id, "garbler disputed withdrawal, completing adaptors");
                             // next step
                             root_state.step = Step::CompletingAdaptors { deposit_id };
 
@@ -358,8 +380,10 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     }
 
                     *header = true;
+                    debug!("garbler commit msg header acked");
 
                     if chunk_acked.all() {
+                        info!("all commit msg parts acked, waiting for challenge");
                         root_state.step = Step::WaitingForChallenge;
                     }
                 }
@@ -382,8 +406,15 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     }
 
                     acked[idx] = true;
+                    debug!(
+                        wire_index,
+                        done = acked.count_ones(),
+                        total = acked.len(),
+                        "garbler commit msg chunk acked"
+                    );
 
                     if *header && acked.all() {
+                        info!("all commit msg parts acked, waiting for challenge");
                         root_state.step = Step::WaitingForChallenge;
                     }
                 }
@@ -403,6 +434,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     }
 
                     *header_acked = true;
+                    debug!("garbler challenge response header acked");
 
                     if chunk_acked.all() {
                         handle_post_sending_challenge_response(&mut root_state, state, actions)
@@ -436,6 +468,12 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     }
 
                     chunk_acked[challenge_index_pos] = true;
+                    debug!(
+                        circuit_index,
+                        done = chunk_acked.count_ones(),
+                        total = chunk_acked.len(),
+                        "garbler challenge response chunk acked"
+                    );
 
                     if *header_acked && chunk_acked.all() {
                         handle_post_sending_challenge_response(&mut root_state, state, actions)
@@ -482,8 +520,10 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                     match &mut deposit_state.step {
                         DepositStep::VerifyingAdaptors => {
                             if verification_success {
+                                info!(%deposit_id, "garbler adaptor verification succeeded, deposit ready");
                                 deposit_state.step = DepositStep::DepositReady;
                             } else {
+                                warn!(%deposit_id, "garbler adaptor verification failed, aborting deposit");
                                 deposit_state.step = DepositStep::Aborted {
                                     reason: "adaptor verification failed".into(),
                                 };
@@ -512,6 +552,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                         .await
                         .map_err(SMError::storage)?;
 
+                    info!(%deposit_id, "garbler adaptor signatures completed, setup consumed");
                     // next step
                     root_state.step = Step::SetupConsumed { deposit_id };
                 }
@@ -550,6 +591,12 @@ async fn handle_polynomial_commitments_generated<S: StateMut>(
                         return Err(SMError::duplicate_action());
                     }
                     inputs[wire as usize] = true;
+                    debug!(
+                        wire,
+                        done = inputs.count_ones(),
+                        total = inputs.len(),
+                        "polynomial commitment generated (input)"
+                    );
                     state
                         .put_input_polynomial_commitments_chunk(wire, &commitments)
                         .await
@@ -561,6 +608,7 @@ async fn handle_polynomial_commitments_generated<S: StateMut>(
                         return Err(SMError::duplicate_action());
                     }
                     *output = true;
+                    debug!("polynomial commitment generated (output)");
                     state
                         .put_output_polynomial_commitment(&output_commitment)
                         .await
@@ -584,6 +632,7 @@ async fn handle_polynomial_commitments_generated<S: StateMut>(
                 let index = Index::new(idx).expect("valid ckt index");
                 emit(actions, Action::GenerateShares(stage_seed, index));
             }
+            info!("all polynomial commitments generated, generating shares");
             root_state.step = Step::GeneratingShares {
                 generated: HeapArray::from_elem(false),
             };
@@ -610,6 +659,7 @@ async fn handle_shares_generated<S: StateMut>(
 
             // state update
             generated[index.get()] = true;
+            debug!(%index, done = generated.count_ones(), total = generated.len(), "shares generated");
             state
                 .put_shares_for_index(index, &input_shares, &output_share)
                 .await
@@ -631,6 +681,7 @@ async fn handle_shares_generated<S: StateMut>(
                 emit(actions, Action::GenerateTableCommitment(index, *seed));
             }
 
+            info!("all shares generated, generating table commitments");
             root_state.step = Step::GeneratingTableCommitments {
                 seeds,
                 generated: HeapArray::from_elem(false),
@@ -662,6 +713,7 @@ async fn handle_table_commitment_generated<S: StateMut>(
 
             // state update
             generated[idx] = true;
+            debug!(%index, done = generated.count_ones(), total = generated.len(), "table commitment generated");
             state
                 .put_garbling_table_commitment(index, &commitment)
                 .await
@@ -675,6 +727,7 @@ async fn handle_table_commitment_generated<S: StateMut>(
                 // wait for all commitments to be generated.
                 return Ok(());
             }
+            info!("all table commitments generated, sending commit msg");
             root_state.step = Step::SendingCommit {
                 header_acked: false,
                 chunk_acked: HeapArray::from_elem(false),
@@ -709,27 +762,30 @@ async fn handle_recv_deposit_adaptor_msg_chunk<S: StateMut>(
 
             let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
-            let all_chunks_received =
-                if let DepositStep::WaitingForAdaptors { chunks } = &mut deposit_state.step {
-                    let chunk_idx = adaptor_msg_chunk.chunk_index as usize;
+            let all_chunks_received = if let DepositStep::WaitingForAdaptors { chunks } =
+                &mut deposit_state.step
+            {
+                let chunk_idx = adaptor_msg_chunk.chunk_index as usize;
 
-                    if chunks[chunk_idx] {
-                        return Err(SMError::invalid_input_data());
-                    }
+                if chunks[chunk_idx] {
+                    return Err(SMError::invalid_input_data());
+                }
 
-                    state
-                        .put_adaptor_msg_chunk_for_deposit(&deposit_id, &adaptor_msg_chunk)
-                        .await
-                        .map_err(SMError::storage)?;
+                state
+                    .put_adaptor_msg_chunk_for_deposit(&deposit_id, &adaptor_msg_chunk)
+                    .await
+                    .map_err(SMError::storage)?;
 
-                    chunks[chunk_idx] = true;
+                chunks[chunk_idx] = true;
+                debug!(%deposit_id, chunk_idx, done = chunks.count_ones(), total = chunks.len(), "adaptor chunk received");
 
-                    chunks.all()
-                } else {
-                    false
-                };
+                chunks.all()
+            } else {
+                false
+            };
 
             if all_chunks_received {
+                info!(%deposit_id, "all adaptor chunks received, verifying");
                 deposit_state.step = DepositStep::VerifyingAdaptors;
                 emit(actions, Action::DepositVerifyAdaptors(deposit_id));
             }
@@ -762,6 +818,11 @@ pub(crate) async fn restore<S: StateRead>(
         .await
         .map_err(SMError::storage)?
         .unwrap_or_default();
+
+    info!(
+        step = root_state.step.step_name(),
+        "garbler restoring state"
+    );
 
     match &root_state.step {
         Step::Uninit => {}
@@ -932,6 +993,10 @@ async fn handle_post_sending_challenge_response<S: StateMut>(
     // NOTE: we dont automatically start transferring garbling tables, but wait for corresponding
     // [`TableTransferRequestMsg`](mosaic_cac_types::TableTransferRequestMsg) from evaluator to
     // begin transfer.
+    info!(
+        eval_count = eval_seeds.len(),
+        "challenge response complete, ready for table transfers"
+    );
     root_state.step = Step::TransferringGarblingTables {
         eval_seeds,
         eval_commitments,

--- a/crates/cac/protocol/src/garbler/tests.rs
+++ b/crates/cac/protocol/src/garbler/tests.rs
@@ -1,8 +1,9 @@
 use mosaic_cac_types::{
-    Adaptor, AdaptorMsgChunk, DepositId, HeapArray, Index, KeyPair, Polynomial, SecretKey,
-    WideLabelWireAdaptors, WithdrawalAdaptorsChunk,
+    Adaptor, AdaptorMsgChunk, ChallengeMsg, DepositId, HeapArray, Index, KeyPair, Polynomial,
+    SecretKey, TableTransferReceiptMsg, TableTransferRequestMsg, WideLabelWireAdaptors,
+    WithdrawalAdaptorsChunk,
     state_machine::garbler::{
-        Action, ActionId, ActionResult, Config, DepositStep, GarblerDepositInitData,
+        Action, ActionId, ActionResult, Config, DepositState, DepositStep, GarblerDepositInitData,
         GarblerInitData, GarblerState, GarblingMetadata, Input, StateMut, StateRead, Step,
     },
 };
@@ -287,4 +288,244 @@ async fn sending_commit_requires_header_and_chunks_acked_before_transition() {
         matches!(root_state.step, Step::WaitingForChallenge),
         "must transition once header and all chunks are acked"
     );
+}
+
+// ============================================================================
+// "Ack and ignore" tests
+//
+// Each test puts the STF in a step where the incoming message is no longer
+// relevant (the machine already advanced past it), and asserts that
+// handle_event returns Ok(()) with an empty action queue.
+// ============================================================================
+
+/// Helper: build a valid `ChallengeMsg` whose indices are all non-reserved.
+fn dummy_challenge_msg() -> ChallengeMsg {
+    ChallengeMsg {
+        challenge_indices: HeapArray::new(|i| Index::new(i + 1).unwrap()),
+    }
+}
+
+#[tokio::test]
+async fn challenge_after_sending_challenge_response_is_ack_and_ignore() {
+    let mut state = StoredGarblerState::default();
+    state
+        .put_root_state(&GarblerState {
+            config: None,
+            step: Step::SendingChallengeResponse {
+                header_acked: false,
+                chunk_acked: HeapArray::from_elem(false),
+            },
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeMsg(dummy_challenge_msg()),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn table_transfer_request_after_setup_complete_is_ack_and_ignore() {
+    let mut state = StoredGarblerState::default();
+    state
+        .put_root_state(&GarblerState {
+            config: None,
+            step: Step::SetupComplete,
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvTableTransferRequest(TableTransferRequestMsg {
+            garbling_table_commitment: [0xAA; 32].into(),
+        }),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn table_transfer_receipt_after_setup_complete_is_ack_and_ignore() {
+    let mut state = StoredGarblerState::default();
+    state
+        .put_root_state(&GarblerState {
+            config: None,
+            step: Step::SetupComplete,
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvTableTransferReceipt(TableTransferReceiptMsg {
+            garbling_table_commitment: [0xBB; 32].into(),
+        }),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn adaptor_chunk_after_deposit_past_waiting_is_ack_and_ignore() {
+    let mut state = StoredGarblerState::default();
+    let deposit_id = DepositId::from([0x01; 32]);
+    let pk = SecretKey::from_raw_bytes(&[5; 32]).to_pubkey();
+
+    state
+        .put_root_state(&GarblerState {
+            config: None,
+            step: Step::SetupComplete,
+        })
+        .await
+        .unwrap();
+
+    // Put deposit in VerifyingAdaptors (past WaitingForAdaptors).
+    state
+        .put_deposit(
+            deposit_id,
+            &DepositState {
+                step: DepositStep::VerifyingAdaptors,
+                pk,
+            },
+        )
+        .await
+        .unwrap();
+
+    let chunk = AdaptorMsgChunk {
+        deposit_id,
+        chunk_index: 0,
+        deposit_adaptor: sample_adaptor(),
+        withdrawal_adaptors: WithdrawalAdaptorsChunk::new(|_| {
+            WideLabelWireAdaptors::new(|_| sample_adaptor())
+        }),
+    };
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::DepositRecvAdaptorMsgChunk(deposit_id, chunk),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn duplicate_adaptor_chunk_is_ack_and_ignore() {
+    let mut state = StoredGarblerState::default();
+    let deposit_id = DepositId::from([0x02; 32]);
+    let pk = SecretKey::from_raw_bytes(&[5; 32]).to_pubkey();
+
+    state
+        .put_root_state(&GarblerState {
+            config: None,
+            step: Step::SetupComplete,
+        })
+        .await
+        .unwrap();
+
+    // Put deposit in WaitingForAdaptors with chunk 0 already received.
+    let mut chunks = HeapArray::from_elem(false);
+    chunks[0] = true;
+    state
+        .put_deposit(
+            deposit_id,
+            &DepositState {
+                step: DepositStep::WaitingForAdaptors { chunks },
+                pk,
+            },
+        )
+        .await
+        .unwrap();
+
+    let chunk = AdaptorMsgChunk {
+        deposit_id,
+        chunk_index: 0, // duplicate
+        deposit_adaptor: sample_adaptor(),
+        withdrawal_adaptors: WithdrawalAdaptorsChunk::new(|_| {
+            WideLabelWireAdaptors::new(|_| sample_adaptor())
+        }),
+    };
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::DepositRecvAdaptorMsgChunk(deposit_id, chunk),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
+}
+
+#[tokio::test]
+async fn adaptor_chunk_when_root_completing_adaptors_is_ack_and_ignore() {
+    let mut state = StoredGarblerState::default();
+    let deposit_id = DepositId::from([0x03; 32]);
+    let other_deposit_id = DepositId::from([0x04; 32]);
+    let pk = SecretKey::from_raw_bytes(&[5; 32]).to_pubkey();
+
+    // Root state has moved to CompletingAdaptors for a different deposit.
+    state
+        .put_root_state(&GarblerState {
+            config: None,
+            step: Step::CompletingAdaptors {
+                deposit_id: other_deposit_id,
+            },
+        })
+        .await
+        .unwrap();
+
+    // The target deposit still exists in storage.
+    state
+        .put_deposit(
+            deposit_id,
+            &DepositState {
+                step: DepositStep::WaitingForAdaptors {
+                    chunks: HeapArray::from_elem(false),
+                },
+                pk,
+            },
+        )
+        .await
+        .unwrap();
+
+    let chunk = AdaptorMsgChunk {
+        deposit_id,
+        chunk_index: 0,
+        deposit_adaptor: sample_adaptor(),
+        withdrawal_adaptors: WithdrawalAdaptorsChunk::new(|_| {
+            WideLabelWireAdaptors::new(|_| sample_adaptor())
+        }),
+    };
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::DepositRecvAdaptorMsgChunk(deposit_id, chunk),
+        &mut actions,
+    )
+    .await;
+
+    assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
+    assert!(actions.is_empty(), "should produce no actions");
 }

--- a/crates/cac/types/src/state_machine/evaluator/deposit.rs
+++ b/crates/cac/types/src/state_machine/evaluator/deposit.rs
@@ -14,31 +14,34 @@ pub struct DepositState {
     pub sk: SecretKey,
 }
 
-/// Steps in the evaluator's deposit state machine.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum DepositStep {
-    /// Generating adaptor signatures for deposit and withdrawal.
-    GeneratingAdaptors {
-        /// Whether the deposit adaptor has been generated.
-        deposit: bool,
-        /// Which withdrawal message chunks have been generated.
-        withdrawal_chunks: HeapArray<bool, N_ADAPTOR_MSG_CHUNKS>,
-    },
-    /// Sending adaptor message chunks to the garbler.
-    /// Transitions to `DepositReady` when all chunks are acked.
-    SendingAdaptors {
-        /// Track which adaptor message chunks have been acked.
-        acked: HeapArray<bool, N_ADAPTOR_MSG_CHUNKS>,
-    },
-    /// Deposit is ready and waiting for completion.
-    DepositReady,
-    /// Funds have been withdrawn without dispute.
-    WithdrawnUndisputed,
-    /// Deposit operation was aborted.
-    Aborted {
-        /// Reason for the abort.
-        reason: String,
-    },
+crate::state_machine::define_step_phase! {
+    DepositStepPhase;
+    /// Steps in the evaluator's deposit state machine.
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub enum DepositStep {
+        /// Generating adaptor signatures for deposit and withdrawal.
+        GeneratingAdaptors {
+            /// Whether the deposit adaptor has been generated.
+            deposit: bool,
+            /// Which withdrawal message chunks have been generated.
+            withdrawal_chunks: HeapArray<bool, N_ADAPTOR_MSG_CHUNKS>,
+        },
+        /// Sending adaptor message chunks to the garbler.
+        /// Transitions to `DepositReady` when all chunks are acked.
+        SendingAdaptors {
+            /// Track which adaptor message chunks have been acked.
+            acked: HeapArray<bool, N_ADAPTOR_MSG_CHUNKS>,
+        },
+        /// Deposit is ready and waiting for completion.
+        DepositReady,
+        /// Funds have been withdrawn without dispute.
+        WithdrawnUndisputed,
+        /// Deposit operation was aborted.
+        Aborted {
+            /// Reason for the abort.
+            reason: String,
+        },
+    }
 }
 
 impl Default for DepositStep {
@@ -46,19 +49,6 @@ impl Default for DepositStep {
         DepositStep::GeneratingAdaptors {
             deposit: false,
             withdrawal_chunks: HeapArray::from_elem(false),
-        }
-    }
-}
-
-impl DepositStep {
-    /// Name of step
-    pub fn step_name(&self) -> &'static str {
-        match &self {
-            DepositStep::GeneratingAdaptors { .. } => "GeneratingAdaptors",
-            DepositStep::SendingAdaptors { .. } => "SendingAdaptors",
-            DepositStep::DepositReady => "DepositReady",
-            DepositStep::WithdrawnUndisputed => "WithdrawnUndisputed",
-            DepositStep::Aborted { .. } => "Aborted",
         }
     }
 }

--- a/crates/cac/types/src/state_machine/evaluator/root_state.rs
+++ b/crates/cac/types/src/state_machine/evaluator/root_state.rs
@@ -24,90 +24,75 @@ pub struct Config {
     pub setup_inputs: SetupInputs,
 }
 
-/// Valid states.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Step {
-    #[default]
-    /// Not initialized; Default
-    Uninit,
-    /// Waiting for commit message from garbler.
-    WaitingForCommit {
-        /// Track if header is received
-        header: bool,
-        /// Track received commit message chunks
-        chunks: HeapArray<bool, N_COMMIT_MSG_CHUNKS>,
-    },
-    /// Challenge sent, waiting for challenge response from garbler.
-    WaitingForChallengeResponse {
-        /// Track if header is received
-        header: bool,
-        /// Track expected challenge response chunks
-        remaining_chunks: HeapArray<bool, N_CIRCUITS>,
-    },
-    /// Verifying opened input shares from challenge response.
-    VerifyingOpenedInputShares,
-    /// Verifying opened table commitments match opened seeds.
-    VerifyingTableCommitments {
-        /// Indices of circuits to verify
-        opened_indices: ChallengeIndices,
-        /// Seeds for opened circuits
-        opened_seeds: OpenedGarblingSeeds,
-        /// Commitments for opened circuits
-        opened_commitments: OpenedGarblingTableCommitments,
-        /// Track verified table commitments
-        verified: HeapArray<bool, N_OPEN_CIRCUITS>,
-    },
-    /// Receiving garbling tables for evaluation circuits.
-    ReceivingGarblingTables {
-        /// Indices of circuits to evaluate
-        eval_indices: EvaluationIndices,
-        /// Expected commitments of garbling tables
-        eval_commitments: EvalGarblingTableCommitments,
-        /// Track received garbling tables
-        received: HeapArray<bool, N_EVAL_CIRCUITS>,
-    },
-    /// Setup is completed, ready to be used for deposits.
-    /// Accepts deposit inputs
-    SetupComplete,
-    /// Evaluating garbling tables for a deposit.
-    EvaluatingTables {
-        /// Deposit being evaluated
-        deposit_id: DepositId,
-        /// Indices of circuits to evaluate
-        eval_indices: EvaluationIndices,
-        /// Expected commitments of garbling tables
-        eval_commitments: EvalGarblingTableCommitments,
-        /// Track evaluated tables
-        evaluated: HeapArray<bool, N_EVAL_CIRCUITS>,
-    },
-    /// Setup is consumed by a withdrawal dispute. Cannot be reused.
-    SetupConsumed {
-        /// Disputed withdrawal for deposit
-        deposit_id: DepositId,
-        /// If final secret was extracted and can be used to sign transaction (evaluator)
-        success: bool,
-    },
-    /// Setup was aborted due to a protocol violation.
-    Aborted {
-        /// Abort reason
-        reason: String,
-    },
-}
-
-impl Step {
-    /// Name of step
-    pub fn step_name(&self) -> &'static str {
-        match self {
-            Step::Uninit => "Uninit",
-            Step::WaitingForCommit { .. } => "WaitingForCommit",
-            Step::WaitingForChallengeResponse { .. } => "WaitingForChallengeResponse",
-            Step::VerifyingOpenedInputShares => "VerifyingOpenedInputShares",
-            Step::VerifyingTableCommitments { .. } => "VerifyingTableCommitments",
-            Step::ReceivingGarblingTables { .. } => "ReceivingGarblingTables",
-            Step::SetupComplete => "SetupComplete",
-            Step::EvaluatingTables { .. } => "EvaluatingTables",
-            Step::SetupConsumed { .. } => "SetupConsumed",
-            Step::Aborted { .. } => "Aborted",
-        }
+crate::state_machine::define_step_phase! {
+    StepPhase;
+    /// Valid states.
+    #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub enum Step {
+        #[default]
+        /// Not initialized; Default
+        Uninit,
+        /// Waiting for commit message from garbler.
+        WaitingForCommit {
+            /// Track if header is received
+            header: bool,
+            /// Track received commit message chunks
+            chunks: HeapArray<bool, N_COMMIT_MSG_CHUNKS>,
+        },
+        /// Challenge sent, waiting for challenge response from garbler.
+        WaitingForChallengeResponse {
+            /// Track if header is received
+            header: bool,
+            /// Track expected challenge response chunks
+            remaining_chunks: HeapArray<bool, N_CIRCUITS>,
+        },
+        /// Verifying opened input shares from challenge response.
+        VerifyingOpenedInputShares,
+        /// Verifying opened table commitments match opened seeds.
+        VerifyingTableCommitments {
+            /// Indices of circuits to verify
+            opened_indices: ChallengeIndices,
+            /// Seeds for opened circuits
+            opened_seeds: OpenedGarblingSeeds,
+            /// Commitments for opened circuits
+            opened_commitments: OpenedGarblingTableCommitments,
+            /// Track verified table commitments
+            verified: HeapArray<bool, N_OPEN_CIRCUITS>,
+        },
+        /// Receiving garbling tables for evaluation circuits.
+        ReceivingGarblingTables {
+            /// Indices of circuits to evaluate
+            eval_indices: EvaluationIndices,
+            /// Expected commitments of garbling tables
+            eval_commitments: EvalGarblingTableCommitments,
+            /// Track received garbling tables
+            received: HeapArray<bool, N_EVAL_CIRCUITS>,
+        },
+        /// Setup is completed, ready to be used for deposits.
+        /// Accepts deposit inputs
+        SetupComplete,
+        /// Evaluating garbling tables for a deposit.
+        EvaluatingTables {
+            /// Deposit being evaluated
+            deposit_id: DepositId,
+            /// Indices of circuits to evaluate
+            eval_indices: EvaluationIndices,
+            /// Expected commitments of garbling tables
+            eval_commitments: EvalGarblingTableCommitments,
+            /// Track evaluated tables
+            evaluated: HeapArray<bool, N_EVAL_CIRCUITS>,
+        },
+        /// Setup is consumed by a withdrawal dispute. Cannot be reused.
+        SetupConsumed {
+            /// Disputed withdrawal for deposit
+            deposit_id: DepositId,
+            /// If final secret was extracted and can be used to sign transaction (evaluator)
+            success: bool,
+        },
+        /// Setup was aborted due to a protocol violation.
+        Aborted {
+            /// Abort reason
+            reason: String,
+        },
     }
 }

--- a/crates/cac/types/src/state_machine/evaluator/root_state.rs
+++ b/crates/cac/types/src/state_machine/evaluator/root_state.rs
@@ -41,8 +41,8 @@ pub enum Step {
     WaitingForChallengeResponse {
         /// Track if header is received
         header: bool,
-        /// Track received challenge response chunks
-        chunks: HeapArray<bool, N_CIRCUITS>,
+        /// Track expected challenge response chunks
+        remaining_chunks: HeapArray<bool, N_CIRCUITS>,
     },
     /// Verifying opened input shares from challenge response.
     VerifyingOpenedInputShares,

--- a/crates/cac/types/src/state_machine/garbler/deposit.rs
+++ b/crates/cac/types/src/state_machine/garbler/deposit.rs
@@ -3,25 +3,28 @@ use serde::{Deserialize, Serialize};
 
 use crate::{HeapArray, PubKey};
 
-/// State machine steps for processing a deposit.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum DepositStep {
-    /// Waiting for adaptor signature message chunks.
-    WaitingForAdaptors {
-        /// Track which adaptor message chunks have been received.
-        chunks: HeapArray<bool, N_ADAPTOR_MSG_CHUNKS>,
-    },
-    /// Verifying received adaptor signatures.
-    VerifyingAdaptors,
-    /// Deposit is ready for withdrawal.
-    DepositReady,
-    /// Deposit was withdrawn without dispute.
-    WithdrawnUndisputed,
-    /// Deposit processing was aborted.
-    Aborted {
-        /// Reason for aborting the deposit.
-        reason: String,
-    },
+crate::state_machine::define_step_phase! {
+    DepositStepPhase;
+    /// State machine steps for processing a deposit.
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub enum DepositStep {
+        /// Waiting for adaptor signature message chunks.
+        WaitingForAdaptors {
+            /// Track which adaptor message chunks have been received.
+            chunks: HeapArray<bool, N_ADAPTOR_MSG_CHUNKS>,
+        },
+        /// Verifying received adaptor signatures.
+        VerifyingAdaptors,
+        /// Deposit is ready for withdrawal.
+        DepositReady,
+        /// Deposit was withdrawn without dispute.
+        WithdrawnUndisputed,
+        /// Deposit processing was aborted.
+        Aborted {
+            /// Reason for aborting the deposit.
+            reason: String,
+        },
+    }
 }
 
 impl Default for DepositStep {
@@ -39,17 +42,4 @@ pub struct DepositState {
     pub step: DepositStep,
     /// Pubkey for verifying adaptors for this deposit.
     pub pk: PubKey,
-}
-
-impl DepositStep {
-    /// Name of step
-    pub fn step_name(&self) -> &'static str {
-        match &self {
-            DepositStep::WaitingForAdaptors { .. } => "WaitingForAdaptors",
-            DepositStep::VerifyingAdaptors => "VerifyingAdaptors",
-            DepositStep::DepositReady => "DepositReady",
-            DepositStep::WithdrawnUndisputed => "WithdrawnUndisputed",
-            DepositStep::Aborted { .. } => "Aborted",
-        }
-    }
 }

--- a/crates/cac/types/src/state_machine/garbler/root_state.rs
+++ b/crates/cac/types/src/state_machine/garbler/root_state.rs
@@ -28,96 +28,79 @@ pub struct Config {
     pub setup_inputs: SetupInputs,
 }
 
-/// Valid states.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Step {
-    #[default]
-    /// Not initialized; Default
-    Uninit,
-    /// Polynomials generated.
-    GeneratingPolynomialCommitments {
-        /// Track generated input polynomial commitments.
-        inputs: HeapArray<bool, N_INPUT_WIRES>,
-        /// Track whether output polynomial commitment has been generated.
-        output: bool,
-    },
-    /// Generate shares for all tables.
-    GeneratingShares {
-        /// Track which shares have been generated.
-        generated: HeapArray<bool, { N_CIRCUITS + 1 }>,
-    },
-    /// Dispatch actions to generate commitments.
-    /// Wait for all table commitments to be provided.
-    GeneratingTableCommitments {
-        /// Seeds for all garbling operations.
-        seeds: AllGarblingSeeds,
-        /// Track which table commitments have been generated.
-        generated: HeapArray<bool, N_CIRCUITS>,
-    },
-    /// Got table commitments, sending commit msg chunks.
-    /// Transitions to WaitingForChallenge when all chunks are acked.
-    SendingCommit {
-        /// Track ack of commit msg header.
-        header_acked: bool,
-        /// Track which commit msg chunks have been acked.
-        chunk_acked: HeapArray<bool, N_COMMIT_MSG_CHUNKS>,
-    },
-    /// All commit chunks acked, waiting for challenge msg from evaluator.
-    WaitingForChallenge,
-    /// Sending challenge response chunks. Transitions to
-    /// TransferringGarblingTables when all chunks are acked.
-    SendingChallengeResponse {
-        /// Track ack of challenge response header.
-        header_acked: bool,
-        /// Track which challenge response chunks have been acked.
-        chunk_acked: HeapArray<bool, N_CHALLENGE_RESPONSE_CHUNKS>,
-    },
-    /// Challenge response msg ack received, send garbling tables
-    TransferringGarblingTables {
-        /// Seeds for garbling table generation
-        eval_seeds: EvalGarblingSeeds,
-        /// Expected commitments of garbling tables, for sanity
-        eval_commitments: EvalGarblingTableCommitments,
-        /// Track transferred garbling tables
-        transferred: HeapArray<bool, N_EVAL_CIRCUITS>,
-    },
-    /// Setup is completed, ready to be used for deposits.
-    /// Accepts deposit inputs
-    SetupComplete,
-    /// Disputed Withdrawal is triggered.
-    /// Compleing adaptor sigs.
-    CompletingAdaptors {
-        /// Disputed withdrawal for deposit
-        deposit_id: DepositId,
-    },
-    /// Setup is consumed by a withdrawal dispute. Cannot be reused.
-    SetupConsumed {
-        /// Disputed withdrawal for deposit
-        deposit_id: DepositId,
-    },
-    /// Setup was aborted due to a protocol violation.
-    Aborted {
-        /// Abort reason
-        reason: String,
-    },
-}
-
-impl Step {
-    /// Name of step
-    pub fn step_name(&self) -> &'static str {
-        match self {
-            Step::Uninit => "Uninit",
-            Step::GeneratingPolynomialCommitments { .. } => "GeneratingPolynomialCommitments",
-            Step::GeneratingShares { .. } => "GeneratingShares",
-            Step::GeneratingTableCommitments { .. } => "GeneratingTableCommitments",
-            Step::SendingCommit { .. } => "SendingCommit",
-            Step::WaitingForChallenge => "WaitingForChallenge",
-            Step::SendingChallengeResponse { .. } => "SendingChallengeResponse",
-            Step::TransferringGarblingTables { .. } => "TransferringGarblingTables",
-            Step::SetupComplete => "SetupComplete",
-            Step::CompletingAdaptors { .. } => "CompletingAdaptors",
-            Step::SetupConsumed { .. } => "SetupConsumed",
-            Step::Aborted { .. } => "Aborted",
-        }
+crate::state_machine::define_step_phase! {
+    StepPhase;
+    /// Valid states.
+    #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub enum Step {
+        #[default]
+        /// Not initialized; Default
+        Uninit,
+        /// Polynomials generated.
+        GeneratingPolynomialCommitments {
+            /// Track generated input polynomial commitments.
+            inputs: HeapArray<bool, N_INPUT_WIRES>,
+            /// Track whether output polynomial commitment has been generated.
+            output: bool,
+        },
+        /// Generate shares for all tables.
+        GeneratingShares {
+            /// Track which shares have been generated.
+            generated: HeapArray<bool, { N_CIRCUITS + 1 }>,
+        },
+        /// Dispatch actions to generate commitments.
+        /// Wait for all table commitments to be provided.
+        GeneratingTableCommitments {
+            /// Seeds for all garbling operations.
+            seeds: AllGarblingSeeds,
+            /// Track which table commitments have been generated.
+            generated: HeapArray<bool, N_CIRCUITS>,
+        },
+        /// Got table commitments, sending commit msg chunks.
+        /// Transitions to WaitingForChallenge when all chunks are acked.
+        SendingCommit {
+            /// Track ack of commit msg header.
+            header_acked: bool,
+            /// Track which commit msg chunks have been acked.
+            chunk_acked: HeapArray<bool, N_COMMIT_MSG_CHUNKS>,
+        },
+        /// All commit chunks acked, waiting for challenge msg from evaluator.
+        WaitingForChallenge,
+        /// Sending challenge response chunks. Transitions to
+        /// TransferringGarblingTables when all chunks are acked.
+        SendingChallengeResponse {
+            /// Track ack of challenge response header.
+            header_acked: bool,
+            /// Track which challenge response chunks have been acked.
+            chunk_acked: HeapArray<bool, N_CHALLENGE_RESPONSE_CHUNKS>,
+        },
+        /// Challenge response msg ack received, send garbling tables
+        TransferringGarblingTables {
+            /// Seeds for garbling table generation
+            eval_seeds: EvalGarblingSeeds,
+            /// Expected commitments of garbling tables, for sanity
+            eval_commitments: EvalGarblingTableCommitments,
+            /// Track transferred garbling tables
+            transferred: HeapArray<bool, N_EVAL_CIRCUITS>,
+        },
+        /// Setup is completed, ready to be used for deposits.
+        /// Accepts deposit inputs
+        SetupComplete,
+        /// Disputed Withdrawal is triggered.
+        /// Compleing adaptor sigs.
+        CompletingAdaptors {
+            /// Disputed withdrawal for deposit
+            deposit_id: DepositId,
+        },
+        /// Setup is consumed by a withdrawal dispute. Cannot be reused.
+        SetupConsumed {
+            /// Disputed withdrawal for deposit
+            deposit_id: DepositId,
+        },
+        /// Setup was aborted due to a protocol violation.
+        Aborted {
+            /// Abort reason
+            reason: String,
+        },
     }
 }

--- a/crates/cac/types/src/state_machine/mod.rs
+++ b/crates/cac/types/src/state_machine/mod.rs
@@ -124,3 +124,60 @@ impl Valid for StateMachineId {
         Ok(())
     }
 }
+
+/// Generates a fieldless "phase" enum from a step enum definition.
+///
+/// For each variant in the step enum, a corresponding fieldless variant is
+/// created in the phase enum. The phase enum derives `PartialOrd`/`Ord` from
+/// declaration order, so variants declared earlier are "less than" variants
+/// declared later.
+///
+/// Also generates:
+/// - `step_name() -> &'static str` on the step enum
+/// - `phase() -> $Phase` on the step enum
+macro_rules! define_step_phase {
+    (
+        $Phase:ident;
+        $(#[$enum_meta:meta])*
+        $vis:vis enum $Step:ident {
+            $(
+                $(#[$variant_meta:meta])*
+                $variant:ident $({ $($(#[$field_meta:meta])* $field:ident : $fty:ty),* $(,)? })?
+            ),*
+            $(,)?
+        }
+    ) => {
+        /// Fieldless mirror of the step enum for ordering comparisons.
+        #[allow(missing_docs, reason = "variants mirror the Step enum and share its documentation")]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        $vis enum $Phase {
+            $($variant,)*
+        }
+
+        $(#[$enum_meta])*
+        $vis enum $Step {
+            $(
+                $(#[$variant_meta])*
+                $variant $({ $($(#[$field_meta])* $field : $fty),* })?,
+            )*
+        }
+
+        impl $Step {
+            /// Name of step.
+            pub fn step_name(&self) -> &'static str {
+                match self {
+                    $(Self::$variant { .. } => stringify!($variant),)*
+                }
+            }
+
+            /// Returns the fieldless phase variant for ordering comparisons.
+            pub fn phase(&self) -> $Phase {
+                match self {
+                    $(Self::$variant { .. } => $Phase::$variant,)*
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use define_step_phase;

--- a/functional-tests/common/mosaic_e2e.py
+++ b/functional-tests/common/mosaic_e2e.py
@@ -69,12 +69,6 @@ def handle_deposit(
 
     sighashes = generate_sighashes(adaptor_pk)
 
-    evaluator.mosaic_initEvaluatorDeposit(
-        evaluator_tsid,
-        deposit_id,
-        {"deposit_inputs": deposit_inputs, "sighashes": sighashes},
-    )
-
     garbler.mosaic_initGarblerDeposit(
         garbler_tsid,
         deposit_id,
@@ -83,6 +77,12 @@ def handle_deposit(
             "sighashes": sighashes,
             "adaptor_pk": adaptor_pk,
         },
+    )
+
+    evaluator.mosaic_initEvaluatorDeposit(
+        evaluator_tsid,
+        deposit_id,
+        {"deposit_inputs": deposit_inputs, "sighashes": sighashes},
     )
 
     def check_both_deposit_ready():

--- a/functional-tests/env.bash
+++ b/functional-tests/env.bash
@@ -1,4 +1,3 @@
-export RUST_LOG=${RUST_LOG:-debug,sled=info,hyper=warn,soketto=warn,jsonrpsee-server=warn,mio=warn,bitcoind-async-client::client=warn,trie=warn}
 export NO_COLOR=${NO_COLOR:-1}
 export RUST_BACKTRACE=${RUST_BACKTRACE:-1}
 export LOG_LEVEL=${LOG_LEVEL:-info}

--- a/functional-tests/factories/mosaic/mosaic_config.py
+++ b/functional-tests/factories/mosaic/mosaic_config.py
@@ -4,7 +4,7 @@ from dataclasses import (
 )
 
 # Defaults matching mosaic config.rs constants
-DEFAULT_LOG_FILTER = "debug"
+DEFAULT_LOG_FILTER = "debug,h2=warn,hyper=warn,soketto=warn,jsonrpsee=warn"
 DEFAULT_KEEP_ALIVE_INTERVAL_SECS = 5
 DEFAULT_IDLE_TIMEOUT_SECS = 30
 DEFAULT_RECONNECT_BACKOFF_SECS = 1

--- a/functional-tests/tests/setup/fn_mosaic_setup_concurrent.py
+++ b/functional-tests/tests/setup/fn_mosaic_setup_concurrent.py
@@ -34,11 +34,14 @@ class MosaicSetupConcurrentTest(BaseTest):
         # Get peer IDs
         peer_ids = {i: rpcs[i].mosaic_getRpcPeerId() for i in range(NETWORK_SIZE)}
 
-        # Setup garbler + evaluator for every unordered pair.
+        # Setup garbler + evaluator for pair of mosaic nodes.
         # Garbler and evaluator share the same random setup_inputs.
         setups = []
         for garbler in range(NETWORK_SIZE):
-            for evaluator in range(garbler + 1, NETWORK_SIZE):
+            for evaluator in range(NETWORK_SIZE):
+                if garbler == evaluator:
+                    continue
+
                 setup_inputs = secrets.token_hex(32)
 
                 tsid_g = rpcs[garbler].mosaic_setupTableset(


### PR DESCRIPTION
## Description
When protocol messages transmitted between peers, already seen messages should be ignored, but an ACK sent back to ensure the sender does not get stuck.

- [x] (Garbler -> Evaluator) Send Commit Message Header
- [x] (Garbler -> Evaluator) Send Commit Message Chunk
- [x] (Evaluator -> Garbler) Send Challenge Message
- [x] (Garbler -> Evaluator) Send Challenge Response Header
- [x] (Garbler -> Evaluator) Send Challenge Response Chunk
- [x] (Evaluator -> Garbler) Send Table Request
- [x] (Evaluator -> Garbler) Send Table Receipt
- [x] (Evaluator -> Garbler) Send Adaptor Chunk

Additionally,
- [x] Add more logging in garbler and evaluator stf
- [x] remove trivial/unused validation functions

For #165 
Late commit message acks are ignored, and dont trigger unexpected input error.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
closes #155 , closes #165