### PR TITLE
chore: rename Docker test mode environment variable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,8 +36,8 @@ COPY crates crates
 RUN cargo build --release --bin mosaic \
     && cp target/release/mosaic target/release/mosaic-default \
     && cargo build --release --features=reduced-circuits --bin mosaic \
-    && mv target/release/mosaic target/release/mosaic-reduced \
-    && strip --strip-debug target/release/mosaic-default target/release/mosaic-reduced
+    && mv target/release/mosaic target/release/mosaic-unsafe-test \
+    && strip --strip-debug target/release/mosaic-default target/release/mosaic-unsafe-test
 
 # ------------------------------------------------------------------------------
 # Stage 2: Minimal runtime image
@@ -66,7 +66,7 @@ RUN FDB_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "amd64") \
 RUN mkdir -p /etc/mosaic && chown ubuntu:ubuntu /etc/mosaic
 
 COPY --from=builder /build/target/release/mosaic-default /usr/local/bin/mosaic
-COPY --from=builder /build/target/release/mosaic-reduced /usr/local/bin/mosaic-reduced
+COPY --from=builder /build/target/release/mosaic-unsafe-test /usr/local/bin/mosaic-unsafe-test
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,7 +8,8 @@
 # The config file's [circuit] section should reference:
 #   path = "/etc/mosaic/circuit.v5c"
 #
-# Set MOSAIC_REDUCED_CIRCUITS=1 to run the reduced-circuits build.
+# Set MOSAIC_UNSAFE_TEST=1 to run in test mode, which is faster.
+# **WARNING**: Test mode is UNSAFE, and MUST NOT be used in production.
 #
 # Any extra arguments are forwarded to the mosaic binary.
 
@@ -24,9 +25,9 @@ fi
 
 MOSAIC_BIN="/usr/local/bin/mosaic"
 
-case "${MOSAIC_REDUCED_CIRCUITS:-}" in
+case "${MOSAIC_UNSAFE_TEST:-}" in
     1|true|TRUE|yes|YES|on|ON)
-        MOSAIC_BIN="/usr/local/bin/mosaic-reduced"
+        MOSAIC_BIN="/usr/local/bin/mosaic-unsafe-test"
         ;;
 esac
 


### PR DESCRIPTION
## Description

It's possible to run Mosaic in an unsafe test mode, which uses lower cut-and-choose parameters to speed up testing. However, this mode is EXTREMELY UNSAFE to use in production. Recent work in #170 controls which mode is built and run in Docker via an environment variable `MOSAIC_REDUCED_CIRCUITS`.

This PR renames the compiled binary and environment variable to sound scary and help mitigate unintentional production misuse.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [x] Security fix

## Notes to Reviewers

This partially addresses #148, which suggests renaming the feature flag that is used under the hood. That renaming is deferred to later.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Partially addresses #148.