### PR TITLE
fix: s3 read related issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,7 @@ dependencies = [
  "object_store",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,6 +2659,7 @@ dependencies = [
 name = "mosaic-storage-s3"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "futures",
  "kanal",

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -12,6 +12,7 @@ use mosaic_net_client::NetClientConfig;
 use mosaic_net_svc::{NetServiceConfig, PeerConfig, PeerId};
 use mosaic_sm_executor_api::SmExecutorConfig;
 use mosaic_storage_fdb::FdbStorageConfig;
+use object_store::ClientOptions;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -149,6 +150,8 @@ impl MosaicConfig {
             endpoint,
             access_key_id,
             secret_access_key,
+            request_timeout_secs,
+            connect_timeout_secs,
             ..
         } = &self.table_store.backend
         {
@@ -166,6 +169,14 @@ impl MosaicConfig {
 
             if secret_access_key.is_empty() {
                 bail!("table_store.secret_access_key must not be empty");
+            }
+
+            if *request_timeout_secs == 0 {
+                bail!("table_store.request_timeout_secs must be greater than zero");
+            }
+
+            if *connect_timeout_secs == 0 {
+                bail!("table_store.connect_timeout_secs must be greater than zero");
             }
 
             if let Some(endpoint) = endpoint
@@ -276,11 +287,32 @@ pub(crate) enum TableStoreBackend {
         secret_access_key: String,
         endpoint: Option<String>,
         session_token: Option<String>,
+        #[serde(default = "default_s3_request_timeout_secs")]
+        request_timeout_secs: u64,
+        #[serde(default = "default_s3_connect_timeout_secs")]
+        connect_timeout_secs: u64,
         #[serde(default)]
         allow_http: bool,
         #[serde(default)]
         virtual_hosted_style_request: bool,
     },
+}
+
+impl TableStoreBackend {
+    pub(crate) fn build_s3_client_options(&self) -> Option<ClientOptions> {
+        match self {
+            Self::S3Compatible {
+                request_timeout_secs,
+                connect_timeout_secs,
+                ..
+            } => Some(
+                ClientOptions::new()
+                    .with_timeout(Duration::from_secs(*request_timeout_secs))
+                    .with_connect_timeout(Duration::from_secs(*connect_timeout_secs)),
+            ),
+            Self::LocalFilesystem { .. } => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -418,6 +450,8 @@ const DEFAULT_CHUNK_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_SUBMISSION_QUEUE_SIZE: usize = 256;
 const DEFAULT_COMPLETION_QUEUE_SIZE: usize = 256;
 const DEFAULT_COMMAND_QUEUE_SIZE: usize = 256;
+const DEFAULT_S3_REQUEST_TIMEOUT_SECS: u64 = 2 * 60 * 60;
+const DEFAULT_S3_CONNECT_TIMEOUT_SECS: u64 = 5;
 
 fn default_log_filter() -> String {
     DEFAULT_LOG_FILTER.to_string()
@@ -479,8 +513,18 @@ const fn default_command_queue_size() -> usize {
     DEFAULT_COMMAND_QUEUE_SIZE
 }
 
+const fn default_s3_request_timeout_secs() -> u64 {
+    DEFAULT_S3_REQUEST_TIMEOUT_SECS
+}
+
+const fn default_s3_connect_timeout_secs() -> u64 {
+    DEFAULT_S3_CONNECT_TIMEOUT_SECS
+}
+
 #[cfg(test)]
 mod tests {
+    use object_store::ClientConfigKey;
+
     use super::*;
 
     fn sample_config_toml(circuit_path: &Path) -> String {
@@ -507,6 +551,46 @@ cluster_file = "/etc/foundationdb/fdb.cluster"
 backend = "local_filesystem"
 root = "/var/lib/mosaic/tables"
 prefix = "tables"
+
+[job_scheduler]
+
+[sm_executor]
+
+[rpc]
+bind_addr = "127.0.0.1:8080"
+"#,
+            circuit_path.display()
+        )
+    }
+
+    fn sample_s3_config_toml(circuit_path: &Path, extra_table_store: &str) -> String {
+        format!(
+            r#"
+[logging]
+filter = "debug"
+
+[circuit]
+path = "{}"
+
+[network]
+signing_key_hex = "1111111111111111111111111111111111111111111111111111111111111111"
+bind_addr = "127.0.0.1:7000"
+
+[[network.peers]]
+peer_id_hex = "2222222222222222222222222222222222222222222222222222222222222222"
+addr = "127.0.0.1:7001"
+
+[storage]
+cluster_file = "/etc/foundationdb/fdb.cluster"
+
+[table_store]
+backend = "s3_compatible"
+bucket = "bucket"
+region = "us-east-1"
+prefix = "tables"
+access_key_id = "access"
+secret_access_key = "secret"
+{extra_table_store}
 
 [job_scheduler]
 
@@ -555,5 +639,60 @@ bind_addr = "127.0.0.1:8080"
             toml::from_str(&sample_config_toml(&path)).expect("config should parse");
 
         config.validate().expect("config should validate");
+    }
+
+    #[test]
+    fn s3_timeout_defaults_are_applied() {
+        let path = std::env::current_exe().expect("current executable path");
+        let config: MosaicConfig =
+            toml::from_str(&sample_s3_config_toml(&path, "")).expect("config should parse");
+
+        let options = config
+            .table_store
+            .backend
+            .build_s3_client_options()
+            .expect("s3 backend should build client options");
+
+        let expected = ClientOptions::new()
+            .with_timeout(Duration::from_secs(DEFAULT_S3_REQUEST_TIMEOUT_SECS))
+            .with_connect_timeout(Duration::from_secs(DEFAULT_S3_CONNECT_TIMEOUT_SECS));
+
+        assert_eq!(
+            options.get_config_value(&ClientConfigKey::Timeout),
+            expected.get_config_value(&ClientConfigKey::Timeout)
+        );
+        assert_eq!(
+            options.get_config_value(&ClientConfigKey::ConnectTimeout),
+            expected.get_config_value(&ClientConfigKey::ConnectTimeout)
+        );
+    }
+
+    #[test]
+    fn s3_timeout_overrides_are_applied() {
+        let path = std::env::current_exe().expect("current executable path");
+        let config: MosaicConfig = toml::from_str(&sample_s3_config_toml(
+            &path,
+            "request_timeout_secs = 900\nconnect_timeout_secs = 9",
+        ))
+        .expect("config should parse");
+
+        let options = config
+            .table_store
+            .backend
+            .build_s3_client_options()
+            .expect("s3 backend should build client options");
+
+        let expected = ClientOptions::new()
+            .with_timeout(Duration::from_secs(900))
+            .with_connect_timeout(Duration::from_secs(9));
+
+        assert_eq!(
+            options.get_config_value(&ClientConfigKey::Timeout),
+            expected.get_config_value(&ClientConfigKey::Timeout)
+        );
+        assert_eq!(
+            options.get_config_value(&ClientConfigKey::ConnectTimeout),
+            expected.get_config_value(&ClientConfigKey::ConnectTimeout)
+        );
     }
 }

--- a/bin/mosaic/src/main.rs
+++ b/bin/mosaic/src/main.rs
@@ -138,7 +138,12 @@ where
                 .with_access_key_id(access_key_id)
                 .with_secret_access_key(secret_access_key)
                 .with_allow_http(*allow_http)
-                .with_virtual_hosted_style_request(*virtual_hosted_style_request);
+                .with_virtual_hosted_style_request(*virtual_hosted_style_request)
+                // Disable the default 30-second request timeout. Ciphertext
+                // objects are tens of GB and streamed over long-lived HTTP
+                // connections. The S3TableReader handles connection drops
+                // internally via resume-from-offset.
+                .with_client_options(object_store::ClientOptions::new().with_timeout_disabled());
 
             if let Some(endpoint) = endpoint {
                 builder = builder.with_endpoint(endpoint);

--- a/bin/mosaic/src/main.rs
+++ b/bin/mosaic/src/main.rs
@@ -131,6 +131,7 @@ where
             session_token,
             allow_http,
             virtual_hosted_style_request,
+            ..
         } => {
             let mut builder = AmazonS3Builder::new()
                 .with_bucket_name(bucket)
@@ -139,11 +140,13 @@ where
                 .with_secret_access_key(secret_access_key)
                 .with_allow_http(*allow_http)
                 .with_virtual_hosted_style_request(*virtual_hosted_style_request)
-                // Disable the default 30-second request timeout. Ciphertext
-                // objects are tens of GB and streamed over long-lived HTTP
-                // connections. The S3TableReader handles connection drops
-                // internally via resume-from-offset.
-                .with_client_options(object_store::ClientOptions::new().with_timeout_disabled());
+                .with_client_options(
+                    config
+                        .table_store
+                        .backend
+                        .build_s3_client_options()
+                        .expect("s3 backend should build client options"),
+                );
 
             if let Some(endpoint) = endpoint {
                 builder = builder.with_endpoint(endpoint);

--- a/crates/storage/s3/Cargo.toml
+++ b/crates/storage/s3/Cargo.toml
@@ -19,7 +19,8 @@ futures = "0.3"
 kanal = "0.1.1"
 object_store = { version = "0.11", features = ["aws"] }
 thiserror.workspace = true
-tokio = { version = "1", features = ["rt", "sync", "macros"] }
+tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
+tracing.workspace = true
 
 [dev-dependencies]
 mosaic-net-svc-api.workspace = true

--- a/crates/storage/s3/Cargo.toml
+++ b/crates/storage/s3/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
 tracing.workspace = true
 
 [dev-dependencies]
+async-trait = "0.1"
 mosaic-net-svc-api.workspace = true
 mosaic-vs3.workspace = true
 

--- a/crates/storage/s3/src/lib.rs
+++ b/crates/storage/s3/src/lib.rs
@@ -188,13 +188,27 @@ impl TableStore for S3TableStore {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{
+        fmt,
+        ops::Range,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, Ordering},
+        },
+    };
 
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use futures::{StreamExt, stream::BoxStream};
     use mosaic_common::Byte32;
     use mosaic_net_svc_api::PeerId;
     use mosaic_storage_api::table_store::{TableMetadata, TableReader, TableStore, TableWriter};
     use mosaic_vs3::Index;
-    use object_store::memory::InMemory;
+    use object_store::{
+        Attributes, GetOptions, GetRange, GetResult, GetResultPayload, ListResult, MultipartUpload,
+        ObjectMeta, ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult,
+        Result as ObjectStoreResult, memory::InMemory, path::Path,
+    };
 
     use super::*;
 
@@ -224,6 +238,220 @@ mod tests {
             out.extend_from_slice(&buf[..n]);
         }
         out
+    }
+
+    #[derive(Debug, Default)]
+    struct TokioAssertingStore {
+        inner: InMemory,
+    }
+
+    impl fmt::Display for TokioAssertingStore {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "TokioAssertingStore")
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for TokioAssertingStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> ObjectStoreResult<PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOpts,
+        ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &Path,
+            options: GetOptions,
+        ) -> ObjectStoreResult<GetResult> {
+            assert!(
+                tokio::runtime::Handle::try_current().is_ok(),
+                "object_store get must run on a tokio runtime"
+            );
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn get_range(
+            &self,
+            location: &Path,
+            range: Range<usize>,
+        ) -> ObjectStoreResult<Bytes> {
+            self.inner.get_range(location, range).await
+        }
+
+        async fn get_ranges(
+            &self,
+            location: &Path,
+            ranges: &[Range<usize>],
+        ) -> ObjectStoreResult<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        async fn head(&self, location: &Path) -> ObjectStoreResult<ObjectMeta> {
+            self.inner.head(location).await
+        }
+
+        async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
+            self.inner.delete(location).await
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, ObjectStoreResult<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&Path>,
+        ) -> ObjectStoreResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+            self.inner.copy(from, to).await
+        }
+
+        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+            self.inner.copy_if_not_exists(from, to).await
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct ResumeStore {
+        inner: InMemory,
+        fail_first_ciphertext_stream: AtomicBool,
+        seen_offsets: Mutex<Vec<usize>>,
+    }
+
+    impl fmt::Display for ResumeStore {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "ResumeStore")
+        }
+    }
+
+    impl ResumeStore {
+        fn seen_offsets(&self) -> Vec<usize> {
+            self.seen_offsets.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for ResumeStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> ObjectStoreResult<PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOpts,
+        ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &Path,
+            options: GetOptions,
+        ) -> ObjectStoreResult<GetResult> {
+            if !location.to_string().ends_with("/ciphertexts") {
+                return self.inner.get_opts(location, options).await;
+            }
+
+            let offset = match options.range {
+                Some(GetRange::Offset(offset)) => offset,
+                None => 0,
+                Some(other) => panic!("unexpected get range in test: {other:?}"),
+            };
+            self.seen_offsets.lock().unwrap().push(offset);
+
+            let meta = self.inner.head(location).await?;
+            let bytes = self.inner.get(location).await?.bytes().await?;
+
+            let payload = if offset == 0
+                && self
+                    .fail_first_ciphertext_stream
+                    .swap(false, Ordering::SeqCst)
+            {
+                let first_len = 5.min(bytes.len());
+                let injected = object_store::Error::Generic {
+                    store: "test",
+                    source: Box::new(std::io::Error::other("injected stream failure")),
+                };
+                let stream =
+                    futures::stream::iter(vec![Ok(bytes.slice(0..first_len)), Err(injected)])
+                        .boxed();
+                GetResultPayload::Stream(stream)
+            } else {
+                let stream = futures::stream::iter(vec![Ok(bytes.slice(offset..))]).boxed();
+                GetResultPayload::Stream(stream)
+            };
+
+            Ok(GetResult {
+                payload,
+                meta,
+                range: offset..bytes.len(),
+                attributes: Attributes::default(),
+            })
+        }
+
+        async fn get_range(
+            &self,
+            location: &Path,
+            range: Range<usize>,
+        ) -> ObjectStoreResult<Bytes> {
+            self.inner.get_range(location, range).await
+        }
+
+        async fn get_ranges(
+            &self,
+            location: &Path,
+            ranges: &[Range<usize>],
+        ) -> ObjectStoreResult<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        async fn head(&self, location: &Path) -> ObjectStoreResult<ObjectMeta> {
+            self.inner.head(location).await
+        }
+
+        async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
+            self.inner.delete(location).await
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, ObjectStoreResult<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&Path>,
+        ) -> ObjectStoreResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+            self.inner.copy(from, to).await
+        }
+
+        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+            self.inner.copy_if_not_exists(from, to).await
+        }
     }
 
     #[tokio::test]
@@ -264,5 +492,42 @@ mod tests {
 
         store.delete(&id).await.unwrap();
         assert!(!store.exists(&id).await.unwrap());
+    }
+
+    #[test]
+    fn open_bridges_committed_version_fetch_onto_tokio_runtime() {
+        let store = S3TableStore::new(Arc::new(TokioAssertingStore::default()), "tables");
+        let id = table_id();
+
+        futures::executor::block_on(async {
+            let mut writer = store.create(&id).await.unwrap();
+            writer.write_ciphertext(b"ciphertexts").await.unwrap();
+            writer.finish(b"translation", metadata(7)).await.unwrap();
+        });
+
+        let mut reader = futures::executor::block_on(store.open(&id)).unwrap();
+        assert_eq!(
+            futures::executor::block_on(reader.read_translation()).unwrap(),
+            b"translation"
+        );
+    }
+
+    #[tokio::test]
+    async fn ciphertext_stream_resumes_from_last_delivered_offset() {
+        let backing = Arc::new(ResumeStore {
+            inner: InMemory::new(),
+            fail_first_ciphertext_stream: AtomicBool::new(true),
+            seen_offsets: Mutex::new(Vec::new()),
+        });
+        let store = S3TableStore::new(backing.clone() as Arc<dyn ObjectStore>, "tables");
+        let id = table_id();
+
+        let mut writer = store.create(&id).await.unwrap();
+        writer.write_ciphertext(b"abcdefghij").await.unwrap();
+        writer.finish(b"translation", metadata(9)).await.unwrap();
+
+        let mut reader = store.open(&id).await.unwrap();
+        assert_eq!(read_all_ciphertexts(&mut reader).await, b"abcdefghij");
+        assert_eq!(backing.seen_offsets(), vec![0, 5]);
     }
 }

--- a/crates/storage/s3/src/reader.rs
+++ b/crates/storage/s3/src/reader.rs
@@ -46,7 +46,20 @@ impl S3TableReader {
         rt_handle: tokio::runtime::Handle,
         root_paths: TableRootPaths,
     ) -> Result<Self, S3Error> {
-        let version = fetch_committed_version(&store, &root_paths.committed).await?;
+        // Fetch committed version via tokio runtime.
+        let (ver_tx, ver_rx) = kanal::bounded_async(1);
+        {
+            let store = Arc::clone(&store);
+            let committed_path = root_paths.committed.clone();
+            rt_handle.spawn(async move {
+                let result = fetch_committed_version(&store, &committed_path).await;
+                let _ = ver_tx.send(result).await;
+            });
+        }
+        let version = ver_rx
+            .recv()
+            .await
+            .map_err(|_| S3Error::Channel("committed version fetch task gone".into()))??;
         let paths = root_paths.version_paths(version);
 
         // Fetch metadata and translation eagerly via the tokio runtime.

--- a/crates/storage/s3/src/reader.rs
+++ b/crates/storage/s3/src/reader.rs
@@ -2,17 +2,23 @@
 //!
 //! Reads garbling table components from object storage. Metadata and
 //! translation material are fetched eagerly on construction (they're small).
-//! Ciphertext data is streamed lazily via a background tokio task that
-//! pre-fetches chunks through a bounded channel.
+//! Ciphertext data is streamed via a background tokio task that pre-fetches
+//! chunks through a bounded channel. If the HTTP connection drops mid-transfer,
+//! the background task automatically resumes from the last successfully
+//! delivered byte offset.
 
 use std::{future::Future, sync::Arc};
 
 use futures::StreamExt;
 use mosaic_common::Byte32;
 use mosaic_storage_api::table_store::{TableMetadata, TableReader};
-use object_store::ObjectStore;
+use object_store::{GetOptions, GetRange, ObjectStore};
+use tracing::{debug, error, warn};
 
 use crate::{error::S3Error, paths::TableRootPaths};
+
+/// Maximum retries when opening or resuming a ciphertext stream.
+const STREAM_MAX_RETRIES: u32 = 3;
 
 /// Reads a garbling table from object storage.
 ///
@@ -20,6 +26,9 @@ use crate::{error::S3Error, paths::TableRootPaths};
 /// Ciphertext data is streamed on demand via [`read_ciphertext`](Self::read_ciphertext),
 /// backed by a background tokio task that pre-fetches chunks from the object
 /// store through a bounded channel.
+///
+/// If the underlying HTTP connection drops, the background task automatically
+/// resumes from the last delivered byte offset.
 #[derive(Debug)]
 pub struct S3TableReader {
     /// Table metadata (loaded eagerly).
@@ -255,36 +264,105 @@ async fn fetch_translation(
 
 /// Background task that streams ciphertext data from object storage
 /// through a bounded channel.
+///
+/// Uses a streaming GET for throughput. If the connection drops mid-transfer,
+/// the stream is automatically resumed from the last successfully delivered
+/// byte offset (via `GetRange::Offset`). Gives up after [`STREAM_MAX_RETRIES`]
+/// consecutive failures.
 async fn stream_ciphertexts(
     store: Arc<dyn ObjectStore>,
     path: object_store::path::Path,
     tx: kanal::AsyncSender<Result<Vec<u8>, S3Error>>,
 ) {
-    let get_result = match store.get(&path).await {
-        Ok(r) => r,
-        Err(e) => {
-            let _ = tx.send(Err(S3Error::ObjectStore(e))).await;
-            return;
-        }
-    };
-
-    let mut stream = get_result.into_stream();
+    let mut bytes_delivered: usize = 0;
+    let mut retries: u32 = 0;
 
     loop {
-        let chunk_result = stream.next().await;
-        match chunk_result {
-            Some(Ok(bytes)) => {
-                if tx.send(Ok(bytes.to_vec())).await.is_err() {
+        // Open a (possibly resumed) streaming GET.
+        let opts = if bytes_delivered == 0 {
+            GetOptions::default()
+        } else {
+            GetOptions {
+                range: Some(GetRange::Offset(bytes_delivered)),
+                ..Default::default()
+            }
+        };
+
+        debug!(
+            path = %path,
+            bytes_delivered,
+            resumed = bytes_delivered > 0,
+            "ciphertext stream: opening GET"
+        );
+
+        let get_result = match store.get_opts(&path, opts).await {
+            Ok(r) => r,
+            Err(e) => {
+                retries += 1;
+                if retries > STREAM_MAX_RETRIES {
+                    error!(
+                        path = %path, bytes_delivered, retries,
+                        %e, "ciphertext stream: failed to open after retries"
+                    );
+                    let _ = tx.send(Err(S3Error::ObjectStore(e))).await;
                     return;
                 }
+                warn!(
+                    path = %path, bytes_delivered, retries,
+                    %e, "ciphertext stream: open failed, will retry"
+                );
+                let backoff = std::time::Duration::from_millis(100 * (1 << retries));
+                tokio::time::sleep(backoff).await;
+                continue;
             }
-            Some(Err(e)) => {
-                let _ = tx.send(Err(S3Error::ObjectStore(e))).await;
-                return;
+        };
+
+        let mut stream = get_result.into_stream();
+        let mut stream_failed = false;
+
+        while let Some(chunk_result) = stream.next().await {
+            match chunk_result {
+                Ok(bytes) => {
+                    let len = bytes.len();
+                    if tx.send(Ok(bytes.to_vec())).await.is_err() {
+                        debug!(
+                            path = %path, bytes_delivered,
+                            "ciphertext stream: consumer dropped, stopping"
+                        );
+                        return;
+                    }
+                    bytes_delivered += len;
+                    retries = 0; // Successful data resets the retry counter.
+                }
+                Err(e) => {
+                    retries += 1;
+                    if retries > STREAM_MAX_RETRIES {
+                        error!(
+                            path = %path, bytes_delivered, retries,
+                            %e, "ciphertext stream: failed after retries"
+                        );
+                        let _ = tx.send(Err(S3Error::ObjectStore(e))).await;
+                        return;
+                    }
+                    warn!(
+                        path = %path, bytes_delivered, retries,
+                        %e, "ciphertext stream: connection lost, will resume"
+                    );
+                    let backoff = std::time::Duration::from_millis(100 * (1 << retries));
+                    tokio::time::sleep(backoff).await;
+                    stream_failed = true;
+                    break; // Break inner loop to re-open from offset.
+                }
             }
-            None => break,
+        }
+
+        if !stream_failed {
+            // Stream completed normally (no more chunks).
+            debug!(
+                path = %path, bytes_delivered,
+                "ciphertext stream: completed"
+            );
+            return;
         }
     }
-
-    // Stream complete — dropping tx signals EOF to the receiver.
 }

--- a/crates/storage/s3/src/writer.rs
+++ b/crates/storage/s3/src/writer.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use mosaic_storage_api::table_store::{TableMetadata, TableWriter};
 use object_store::ObjectStore;
+use tracing::error;
 
 use crate::{
     PART_BUFFER_SIZE,
@@ -126,7 +127,16 @@ async fn background_writer(
     result_tx: kanal::AsyncSender<Result<(), S3Error>>,
 ) {
     let result = background_writer_inner(&store, &root_paths, &version_paths, &cmd_rx).await;
-    let _ = result_tx.send(result).await;
+    if let Err(e) = &result {
+        error!(
+            path = %version_paths.ciphertexts,
+            %e,
+            "background writer failed"
+        );
+    }
+    if result_tx.send(result).await.is_err() {
+        tracing::warn!("background writer: result channel closed, caller gone");
+    }
 }
 
 async fn background_writer_inner(


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
Fixes for s3 related issues during garbling evaluation
- [x] run `fetch_committed_version` inside tokio runtime
- [x] disable default 30s request timeout inside object_store
- [x] Allow read streams to resume with offset if interrupted

Also adds tracing in relevant code sections, mainly in failure paths.
  
### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
