### PR TITLE
Migrate to FASM 0.4 and split read-only state paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,6 +2620,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "foundationdb",
+ "mosaic-cac-types",
  "mosaic-net-svc-api",
  "mosaic-storage-api",
  "mosaic-storage-kvstore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1164,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "fasm"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeeb720348b3e0675242d3c09fdb75be4bc216ff01381348d22c4fffee571a2"
+checksum = "ec91f05d045b6a9aa3964796b78f046e056779af00c7d03041e8b2abbd4da89f"
 
 [[package]]
 name = "fastbloom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ bytes = "1.10"
 ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt" }
 ckt-gobble = { git = "https://github.com/alpenlabs/ckt" }
 criterion = "0.5"
-fasm = "0.3.0"
+fasm = "0.4.0"
 # TODO(alpenlabs): switch back to crates.io foundationdb >= 0.11 once released.
 
 foundationdb = { git = "https://github.com/foundationdb-rs/foundationdb-rs.git", rev = "ed274ba533e15ec02e4ab8dd4defca7d18eaf355", features = [

--- a/crates/cac/protocol/Cargo.toml
+++ b/crates/cac/protocol/Cargo.toml
@@ -25,9 +25,9 @@ tracing.workspace = true
 
 [dev-dependencies]
 mosaic-cac-types = { workspace = true, features = ["test-utils"] }
+mosaic-storage-api.workspace = true
 mosaic-storage-inmemory.workspace = true
 mosaic-job-executors.workspace = true
-mosaic-storage-api.workspace = true
 mosaic-job-api.workspace = true
 mosaic-net-svc-api.workspace = true
 mosaic-net-svc.workspace = true

--- a/crates/cac/protocol/src/error.rs
+++ b/crates/cac/protocol/src/error.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use mosaic_cac_types::DepositId;
+use mosaic_cac_types::{DepositId, RetryableStorageError};
 
 /// State machine error
 #[derive(Debug, thiserror::Error)]
@@ -27,8 +27,15 @@ pub enum SMError {
     #[error("CRITICAL: State is inconsistent with expectations: {0}")]
     StateInconsistency(String),
     /// Error while accessing storage.
-    #[error("Error while accessing storage: {0}")]
-    Storage(Box<dyn Error>),
+    #[error("Error while accessing storage: {source}")]
+    Storage {
+        /// Whether the underlying storage failure is safe to retry by
+        /// discarding the current STF attempt and rerunning it from the start.
+        retryable: bool,
+        /// Original storage error.
+        #[source]
+        source: Box<dyn Error + Send + Sync>,
+    },
 }
 
 impl SMError {
@@ -68,8 +75,20 @@ impl SMError {
     }
 
     /// Creates a storage error.
-    pub fn storage(err: impl Error + 'static) -> Self {
-        Self::Storage(Box::new(err))
+    pub fn storage(err: impl Error + RetryableStorageError + Send + Sync + 'static) -> Self {
+        Self::Storage {
+            retryable: err.is_retryable(),
+            source: Box::new(err),
+        }
+    }
+
+    /// Returns true when this error came from storage and the caller may
+    /// safely retry the whole STF unit from the start.
+    pub fn is_retryable_storage(&self) -> bool {
+        match self {
+            Self::Storage { retryable, .. } => *retryable,
+            _ => false,
+        }
     }
 }
 
@@ -84,13 +103,13 @@ pub trait ResultOptionExt<T, E> {
     /// into a single method call.
     fn require(self, message: &str) -> Result<T, SMError>
     where
-        E: std::error::Error + 'static;
+        E: std::error::Error + RetryableStorageError + Send + Sync + 'static;
 }
 
 impl<T, E> ResultOptionExt<T, E> for Result<Option<T>, E> {
     fn require(self, message: &str) -> Result<T, SMError>
     where
-        E: std::error::Error + 'static,
+        E: std::error::Error + RetryableStorageError + Send + Sync + 'static,
     {
         self.map_err(SMError::storage)?
             .ok_or_else(|| SMError::state_inconsistency(message))

--- a/crates/cac/protocol/src/evaluator/mod.rs
+++ b/crates/cac/protocol/src/evaluator/mod.rs
@@ -3,7 +3,8 @@ use std::marker::PhantomData;
 
 use fasm::{StateMachine, actions::Action as FasmAction};
 use mosaic_cac_types::state_machine::evaluator::{
-    Action, ActionContainer, EvaluatorTrackedActionTypes, Input, StateMut, UntrackedAction,
+    Action, ActionContainer, EvaluatorTrackedActionTypes, Input, StateMut, StateRead,
+    UntrackedAction,
 };
 
 mod stf;
@@ -13,8 +14,8 @@ mod tests;
 use crate::SMError;
 
 #[derive(Debug)]
-pub struct EvaluatorSM<S: StateMut> {
-    _s: PhantomData<S>,
+pub struct EvaluatorSM<S: StateMut, R: StateRead = S> {
+    _s: PhantomData<(S, R)>,
 }
 
 /// Push a single action into the FASM actions container with proper tracking ID.
@@ -23,9 +24,9 @@ pub(crate) fn emit(actions: &mut ActionContainer, action: Action) {
     actions.push(FasmAction::new_tracked(id, action));
 }
 
-impl<S: StateMut> StateMachine for EvaluatorSM<S> {
+impl<S: StateMut, R: StateRead> StateMachine for EvaluatorSM<S, R> {
     type State = S;
-    type RestoreState = S;
+    type RestoreState = R;
 
     type Input = Input;
 

--- a/crates/cac/protocol/src/evaluator/mod.rs
+++ b/crates/cac/protocol/src/evaluator/mod.rs
@@ -25,6 +25,7 @@ pub(crate) fn emit(actions: &mut ActionContainer, action: Action) {
 
 impl<S: StateMut> StateMachine for EvaluatorSM<S> {
     type State = S;
+    type RestoreState = S;
 
     type Input = Input;
 
@@ -57,7 +58,7 @@ impl<S: StateMut> StateMachine for EvaluatorSM<S> {
     }
 
     async fn restore(
-        state: &Self::State,
+        state: &Self::RestoreState,
         actions: &mut Self::Actions,
     ) -> Result<(), Self::RestoreError> {
         stf::restore(state, actions).await?;

--- a/crates/cac/protocol/src/garbler/mod.rs
+++ b/crates/cac/protocol/src/garbler/mod.rs
@@ -25,6 +25,7 @@ pub(crate) fn emit(actions: &mut ActionContainer, action: Action) {
 
 impl<S: StateMut> StateMachine for GarblerSM<S> {
     type State = S;
+    type RestoreState = S;
 
     type Input = Input;
 
@@ -57,7 +58,7 @@ impl<S: StateMut> StateMachine for GarblerSM<S> {
     }
 
     async fn restore(
-        state: &Self::State,
+        state: &Self::RestoreState,
         actions: &mut Self::Actions,
     ) -> Result<(), Self::RestoreError> {
         stf::restore(state, actions).await?;

--- a/crates/cac/protocol/src/garbler/mod.rs
+++ b/crates/cac/protocol/src/garbler/mod.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use fasm::{StateMachine, actions::Action as FasmAction};
 use mosaic_cac_types::state_machine::garbler::{
-    Action, ActionContainer, GarblerTrackedActionTypes, Input, StateMut, UntrackedAction,
+    Action, ActionContainer, GarblerTrackedActionTypes, Input, StateMut, StateRead, UntrackedAction,
 };
 
 mod stf;
@@ -13,8 +13,8 @@ mod tests;
 use crate::SMError;
 
 #[derive(Debug)]
-pub struct GarblerSM<S: StateMut> {
-    _s: PhantomData<S>,
+pub struct GarblerSM<S: StateMut, R: StateRead = S> {
+    _s: PhantomData<(S, R)>,
 }
 
 /// Push a single action into the FASM actions container with proper tracking ID.
@@ -23,9 +23,9 @@ pub(crate) fn emit(actions: &mut ActionContainer, action: Action) {
     actions.push(FasmAction::new_tracked(id, action));
 }
 
-impl<S: StateMut> StateMachine for GarblerSM<S> {
+impl<S: StateMut, R: StateRead> StateMachine for GarblerSM<S, R> {
     type State = S;
-    type RestoreState = S;
+    type RestoreState = R;
 
     type Input = Input;
 

--- a/crates/cac/protocol/src/tests.rs
+++ b/crates/cac/protocol/src/tests.rs
@@ -341,7 +341,7 @@ async fn handle_init_garbler<SP: StorageProvider + StorageProviderMut>(
         .garbler_state_mut(eval_peer_id)
         .await
         .unwrap();
-    garbler::GarblerSM::stf(
+    garbler::GarblerSM::<_>::stf(
         &mut garb_state,
         fasm::Input::Normal(GarbInput::Init(GarblerInitData {
             seed: garb_seed,
@@ -370,7 +370,7 @@ async fn handle_init_evaluator<SP: StorageProvider + StorageProviderMut>(
         .evaluator_state_mut(&garbler_peer_id)
         .await
         .unwrap();
-    evaluator::EvaluatorSM::stf(
+    evaluator::EvaluatorSM::<_>::stf(
         &mut eval_state,
         fasm::Input::Normal(EvalInput::Init(EvaluatorInitData {
             seed: eval_seed,
@@ -409,7 +409,7 @@ async fn handle_garbler_prepares_commit_msg<SP: StorageProvider + StorageProvide
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
@@ -424,7 +424,7 @@ async fn handle_garbler_prepares_commit_msg<SP: StorageProvider + StorageProvide
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
@@ -441,7 +441,7 @@ async fn handle_garbler_prepares_commit_msg<SP: StorageProvider + StorageProvide
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
@@ -498,7 +498,7 @@ async fn handle_garbler_waits_for_challenge<SP: StorageProvider + StorageProvide
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
@@ -522,7 +522,7 @@ async fn handle_evaluator_prepares_challenge<SP: StorageProvider + StorageProvid
         .await
         .unwrap();
     while let Some(ei) = eval_inputs.pop() {
-        evaluator::EvaluatorSM::stf(&mut eval_state, fasm::Input::Normal(ei), eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, fasm::Input::Normal(ei), eval_actions)
             .await
             .unwrap();
     }
@@ -575,7 +575,7 @@ async fn handle_evaluator_waits_for_challenge_response<SP: StorageProvider + Sto
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
@@ -598,7 +598,7 @@ async fn handle_garbler_prepares_challenge_response<SP: StorageProvider + Storag
         .garbler_state_mut(&eval_peer_id)
         .await
         .unwrap();
-    garbler::GarblerSM::stf(
+    garbler::GarblerSM::<_>::stf(
         &mut garb_state,
         fasm::Input::Normal(garb_inputs),
         garb_actions,
@@ -653,7 +653,7 @@ async fn handle_garbler_prepares_for_table_transfer<SP: StorageProviderMut + Sto
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
@@ -683,7 +683,7 @@ async fn handle_garbler_processes_table_requests<SP: StorageProvider + StoragePr
         .await
         .unwrap();
     while let Some(input) = garb_inputs.pop() {
-        garbler::GarblerSM::stf(&mut garb_state, fasm::Input::Normal(input), garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, fasm::Input::Normal(input), garb_actions)
             .await
             .unwrap();
     }
@@ -708,7 +708,7 @@ async fn handle_evaluator_processes_challenge_response<SP: StorageProvider + Sto
         .await
         .unwrap();
     while let Some(ei) = eval_inputs.pop() {
-        evaluator::EvaluatorSM::stf(&mut eval_state, fasm::Input::Normal(ei), eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, fasm::Input::Normal(ei), eval_actions)
             .await
             .unwrap();
     }
@@ -725,7 +725,7 @@ async fn handle_evaluator_processes_challenge_response<SP: StorageProvider + Sto
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
@@ -741,7 +741,7 @@ async fn handle_evaluator_processes_challenge_response<SP: StorageProvider + Sto
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
@@ -773,7 +773,7 @@ async fn handle_evaluator_processes_table<SP: StorageProvider + StorageProviderM
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
@@ -807,7 +807,7 @@ async fn handle_garbler_waits_for_receipt<SP: StorageProvider + StorageProviderM
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
@@ -865,7 +865,7 @@ async fn handle_evaluator_consumes_receipt_ack<SP: StorageProvider + StorageProv
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
@@ -893,7 +893,7 @@ async fn handle_garbler_consumes_receipt_ack<SP: StorageProvider + StorageProvid
         .await
         .unwrap();
     while let Some(input) = garb_inputs.pop() {
-        garbler::GarblerSM::stf(&mut garb_state, fasm::Input::Normal(input), garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, fasm::Input::Normal(input), garb_actions)
             .await
             .unwrap();
     }
@@ -928,7 +928,7 @@ async fn handle_garbler_inits_deposit<SP: StorageProvider + StorageProviderMut>(
         sighashes: HeapArray::from_vec(sighashes.to_vec()),
         deposit_inputs,
     };
-    garbler::GarblerSM::stf(
+    garbler::GarblerSM::<_>::stf(
         &mut garb_state,
         fasm::Input::Normal(GarbInput::DepositInit(deposit_id, deposit_input)),
         garb_actions,
@@ -963,7 +963,7 @@ async fn handle_evaluator_inits_deposit<SP: StorageProvider + StorageProviderMut
         .await
         .unwrap();
 
-    evaluator::EvaluatorSM::stf(
+    evaluator::EvaluatorSM::<_>::stf(
         &mut eval_state,
         fasm::Input::Normal(EvalInput::DepositInit(deposit_id, deposit_input)),
         eval_actions,
@@ -980,7 +980,7 @@ async fn handle_evaluator_inits_deposit<SP: StorageProvider + StorageProviderMut
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
@@ -1040,7 +1040,7 @@ async fn handle_evaluator_is_deposit_ready<SP: StorageProvider + StorageProvider
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }
@@ -1083,7 +1083,7 @@ async fn handle_garbler_verifies_adaptors<SP: StorageProvider + StorageProviderM
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
@@ -1122,7 +1122,7 @@ async fn handle_garbler_starts_adaptor_verification_job<
         .await
         .unwrap();
     while let Some(ei) = garb_inputs.pop() {
-        garbler::GarblerSM::stf(&mut garb_state, fasm::Input::Normal(ei), garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, fasm::Input::Normal(ei), garb_actions)
             .await
             .unwrap();
     }
@@ -1146,7 +1146,7 @@ async fn handle_garbler_completes_signatures<SP: StorageProvider + StorageProvid
         .garbler_state_mut(&eval_peer_id)
         .await
         .unwrap();
-    garbler::GarblerSM::stf(
+    garbler::GarblerSM::<_>::stf(
         &mut garb_state,
         fasm::Input::Normal(GarbInput::DisputedWithdrawal(deposit_id, withdrawal_input)),
         garb_actions,
@@ -1165,7 +1165,7 @@ async fn handle_garbler_completes_signatures<SP: StorageProvider + StorageProvid
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        garbler::GarblerSM::stf(&mut garb_state, tracked_input, garb_actions)
+        garbler::GarblerSM::<_>::stf(&mut garb_state, tracked_input, garb_actions)
             .await
             .unwrap();
     }
@@ -1202,7 +1202,7 @@ async fn handle_evaluator_finds_fault_secret<SP: StorageProvider + StorageProvid
     let eval_disputed_withdrawal = EvaluatorDisputedWithdrawalData {
         signatures: on_chain_sigs.clone(),
     };
-    evaluator::EvaluatorSM::stf(
+    evaluator::EvaluatorSM::<_>::stf(
         &mut eval_state,
         fasm::Input::Normal(EvalInput::DisputedWithdrawal(
             deposit_id,
@@ -1224,7 +1224,7 @@ async fn handle_evaluator_finds_fault_secret<SP: StorageProvider + StorageProvid
                 id: action_id.clone(),
                 result: action_result.clone(),
             };
-        evaluator::EvaluatorSM::stf(&mut eval_state, tracked_input, eval_actions)
+        evaluator::EvaluatorSM::<_>::stf(&mut eval_state, tracked_input, eval_actions)
             .await
             .unwrap();
     }

--- a/crates/cac/types/src/lib.rs
+++ b/crates/cac/types/src/lib.rs
@@ -25,6 +25,14 @@ pub use protocol::*;
 pub use seed::Seed;
 use serde::{Deserialize, Serialize};
 
+/// Error contract for storage operations that may be retried safely by
+/// discarding the current logical attempt and rerunning it from the start.
+pub trait RetryableStorageError {
+    /// Returns true when the caller may safely retry the whole logical
+    /// operation from the beginning.
+    fn is_retryable(&self) -> bool;
+}
+
 /// Commitment to a Garbling Table
 pub type GarblingTableCommitment = Byte32;
 

--- a/crates/cac/types/src/state_machine/evaluator/input.rs
+++ b/crates/cac/types/src/state_machine/evaluator/input.rs
@@ -24,7 +24,7 @@ use crate::{
 /// (e.g. challenge message is acked, verification finishes), the result is
 /// delivered via [`fasm::Input::TrackedActionCompleted`] with an
 /// [`ActionId`](super::ActionId) and [`ActionResult`](super::ActionResult).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Input {
     /// Initialize the evaluator state machine with seed and setup inputs.
     Init(EvaluatorInitData),
@@ -61,7 +61,7 @@ pub enum Input {
 }
 
 /// Data required during evaluator state machine initialization.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EvaluatorInitData {
     /// Seed for deterministic RNG.
     pub seed: Seed,
@@ -70,7 +70,7 @@ pub struct EvaluatorInitData {
 }
 
 /// Data required to initialize a deposit on the evaluator side.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EvaluatorDepositInitData {
     /// Secret key used to generate adaptors.
     pub sk: SecretKey,
@@ -81,7 +81,7 @@ pub struct EvaluatorDepositInitData {
 }
 
 /// Data required to initiate a disputed withdrawal process.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EvaluatorDisputedWithdrawalData {
     /// Completed adaptor signatures extracted from on-chain transaction.
     pub signatures: CompletedSignatures,

--- a/crates/cac/types/src/state_machine/evaluator/state.rs
+++ b/crates/cac/types/src/state_machine/evaluator/state.rs
@@ -8,15 +8,16 @@ use super::{DepositState, EvaluatorState};
 use crate::{
     AllGarblingTableCommitments, ChallengeIndices, CircuitInputShares, CompletedSignatures,
     DepositAdaptors, DepositId, DepositInputs, EvaluationIndices, OpenedGarblingSeeds,
-    OpenedOutputShares, OutputPolynomialCommitment, ReservedSetupInputShares, Sighashes,
-    WideLabelWirePolynomialCommitments, WideLabelZerothPolynomialCoefficients, WithdrawalAdaptors,
-    WithdrawalAdaptorsChunk, WithdrawalInputs,
+    OpenedOutputShares, OutputPolynomialCommitment, ReservedSetupInputShares,
+    RetryableStorageError, Sighashes, WideLabelWirePolynomialCommitments,
+    WideLabelZerothPolynomialCoefficients, WithdrawalAdaptors, WithdrawalAdaptorsChunk,
+    WithdrawalInputs,
 };
 
 /// Read-only access to evaluator state storage.
 pub trait StateRead {
     /// Error type used by state operations.
-    type Error: Error + Debug + Send + 'static;
+    type Error: Error + RetryableStorageError + Debug + Send + Sync + 'static;
 
     /// Retrieves the root evaluator state.
     fn get_root_state(

--- a/crates/cac/types/src/state_machine/garbler/input.rs
+++ b/crates/cac/types/src/state_machine/garbler/input.rs
@@ -23,7 +23,7 @@ use crate::{
 /// (e.g. polynomial generation finishes, a message is acked), the result is
 /// delivered via [`fasm::Input::TrackedActionCompleted`] with an
 /// [`ActionId`](super::ActionId) and [`ActionResult`](super::ActionResult).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Input {
     /// Initialize the garbler state machine with seed and setup inputs.
     Init(GarblerInitData),
@@ -59,7 +59,7 @@ pub enum Input {
 }
 
 /// Data required during garbler state machine initialization.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GarblerInitData {
     /// Seed for deterministic RNG.
     pub seed: Seed,
@@ -68,7 +68,7 @@ pub struct GarblerInitData {
 }
 
 /// Data required to initialize a deposit on the garbler side.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GarblerDepositInitData {
     /// Public key used to verify adaptors created under evaluator's secret key.
     pub pk: PubKey,

--- a/crates/cac/types/src/state_machine/garbler/state.rs
+++ b/crates/cac/types/src/state_machine/garbler/state.rs
@@ -8,14 +8,15 @@ use crate::{
     AllGarblingTableCommitments, AllOutputLabelCts, AllPublicSValues, ChallengeIndices,
     CircuitInputShares, CircuitOutputShare, CompletedSignatures, DepositAdaptors, DepositId,
     DepositInputs, GarblingTableCommitment, Index, OutputPolynomialCommitment, OutputShares,
-    ReservedInputShares, ReservedSetupInputShares, Sighashes, WideLabelWirePolynomialCommitments,
-    WithdrawalAdaptors, WithdrawalInputs, state_machine::garbler::GarblingMetadata,
+    ReservedInputShares, ReservedSetupInputShares, RetryableStorageError, Sighashes,
+    WideLabelWirePolynomialCommitments, WithdrawalAdaptors, WithdrawalInputs,
+    state_machine::garbler::GarblingMetadata,
 };
 
 /// Read-only access to garbler state storage.
 pub trait StateRead {
     /// Error type used by state operations.
-    type Error: Error + Debug + Send + 'static;
+    type Error: Error + RetryableStorageError + Debug + Send + Sync + 'static;
 
     /// Retrieves the root garbler state.
     fn get_root_state(

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -24,6 +24,7 @@ use mosaic_storage_api::{
     table_store::{TableId, TableReader as _, TableStore, TableWriter as _},
 };
 use mosaic_vs3::{Index, Share, batch_verify_shares, interpolate};
+
 use super::MosaicExecutor;
 use crate::{
     circuit_sessions::{CiphertextReaderAdapter, EvaluationSession},
@@ -151,7 +152,9 @@ pub(crate) async fn handle_verify_opened_input_shares<SP: StorageProvider, TS: T
     let Some(challenge_indices) = eval_state.get_challenge_indices().await.ok().flatten() else {
         return HandlerOutcome::Retry;
     };
-    let Ok(opened_input_shares) = load_opened_input_shares(&ctx.storage, peer_id, &challenge_indices).await else {
+    let Ok(opened_input_shares) =
+        load_opened_input_shares(&ctx.storage, peer_id, &challenge_indices).await
+    else {
         return HandlerOutcome::Retry;
     };
 

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -24,8 +24,6 @@ use mosaic_storage_api::{
     table_store::{TableId, TableReader as _, TableStore, TableWriter as _},
 };
 use mosaic_vs3::{Index, Share, batch_verify_shares, interpolate};
-use tracing::{error, warn};
-
 use super::MosaicExecutor;
 use crate::{
     circuit_sessions::{CiphertextReaderAdapter, EvaluationSession},
@@ -37,86 +35,49 @@ fn completed(id: ActionId, result: ActionResult) -> HandlerOutcome {
     HandlerOutcome::Done(ActionCompletion::Evaluator { id, result })
 }
 
-/// Load opened input shares for challenged circuits, retrying with a fresh
-/// transaction on FDB transaction expiry.
-pub(crate) async fn load_opened_input_shares_with_retry<SP: StorageProvider>(
+/// Load opened input shares for challenged circuits.
+pub(crate) async fn load_opened_input_shares<SP: StorageProvider>(
     storage: &SP,
     peer_id: &PeerId,
     challenge_indices: &ChallengeIndices,
 ) -> Result<Vec<CircuitInputShares>, CircuitError> {
     let mut items = Vec::with_capacity(N_OPEN_CIRCUITS);
-    let mut store = storage
+    let store = storage
         .evaluator_state(peer_id)
         .await
         .map_err(|_| CircuitError::StorageUnavailable)?;
 
     for challenge_idx in challenge_indices {
         let circuit_idx = challenge_idx.get() as u16;
-        match store.get_opened_input_shares_for_circuit(circuit_idx).await {
-            Ok(Some(ckt_shares)) => items.push(ckt_shares),
-            Ok(None) => return Err(CircuitError::StorageUnavailable),
-            Err(err) => {
-                warn!(?err, "failed to load input shares");
-                // Assume the error is due to transaction expiry (fdb).
-                // Retry once with new txn.
-                store = storage
-                    .evaluator_state(peer_id)
-                    .await
-                    .map_err(|_| CircuitError::StorageUnavailable)?;
-                let ckt_shares = store
-                    .get_opened_input_shares_for_circuit(circuit_idx)
-                    .await
-                    .map_err(|err| {
-                        error!(?err, "failed to load input shares after retry");
-                        CircuitError::StorageUnavailable
-                    })?
-                    .ok_or(CircuitError::StorageUnavailable)?;
-                items.push(ckt_shares);
-            }
-        }
+        let ckt_shares = store
+            .get_opened_input_shares_for_circuit(circuit_idx)
+            .await
+            .map_err(|_| CircuitError::StorageUnavailable)?
+            .ok_or(CircuitError::StorageUnavailable)?;
+        items.push(ckt_shares);
     }
 
     Ok(items)
 }
 
-/// Load input polynomial commitments for all wires, retrying with a fresh
-/// transaction on FDB transaction expiry.
-pub(crate) async fn load_polynomial_commitments_with_retry<SP: StorageProvider>(
+/// Load input polynomial commitments for all wires.
+pub(crate) async fn load_polynomial_commitments<SP: StorageProvider>(
     storage: &SP,
     peer_id: &PeerId,
 ) -> Result<Vec<WideLabelWirePolynomialCommitments>, CircuitError> {
     let mut items = Vec::with_capacity(N_INPUT_WIRES);
-    let mut store = storage
+    let store = storage
         .evaluator_state(peer_id)
         .await
         .map_err(|_| CircuitError::StorageUnavailable)?;
 
     for wire_idx in 0..N_INPUT_WIRES as u16 {
-        match store
+        let commitment = store
             .get_input_polynomial_commitments_for_wire(wire_idx)
             .await
-        {
-            Ok(Some(commitment)) => items.push(commitment),
-            Ok(None) => return Err(CircuitError::StorageUnavailable),
-            Err(err) => {
-                warn!(?err, "failed to load input polynomial commitments");
-                // Assume the error is due to transaction expiry (fdb).
-                // Retry once with new txn.
-                store = storage
-                    .evaluator_state(peer_id)
-                    .await
-                    .map_err(|_| CircuitError::StorageUnavailable)?;
-                let commitment = store
-                    .get_input_polynomial_commitments_for_wire(wire_idx)
-                    .await
-                    .map_err(|err| {
-                        error!(?err, "failed to load polynomial commitments after retry");
-                        CircuitError::StorageUnavailable
-                    })?
-                    .ok_or(CircuitError::StorageUnavailable)?;
-                items.push(commitment);
-            }
-        }
+            .map_err(|_| CircuitError::StorageUnavailable)?
+            .ok_or(CircuitError::StorageUnavailable)?;
+        items.push(commitment);
     }
 
     Ok(items)
@@ -190,14 +151,11 @@ pub(crate) async fn handle_verify_opened_input_shares<SP: StorageProvider, TS: T
     let Some(challenge_indices) = eval_state.get_challenge_indices().await.ok().flatten() else {
         return HandlerOutcome::Retry;
     };
-    let Ok(opened_input_shares) =
-        load_opened_input_shares_with_retry(&ctx.storage, peer_id, &challenge_indices).await
-    else {
+    let Ok(opened_input_shares) = load_opened_input_shares(&ctx.storage, peer_id, &challenge_indices).await else {
         return HandlerOutcome::Retry;
     };
 
-    let Ok(commitments) = load_polynomial_commitments_with_retry(&ctx.storage, peer_id).await
-    else {
+    let Ok(commitments) = load_polynomial_commitments(&ctx.storage, peer_id).await else {
         return HandlerOutcome::Retry;
     };
 
@@ -669,7 +627,7 @@ pub(crate) async fn setup_evaluation_session<SP: StorageProvider, TS: TableStore
         .flatten()
         .ok_or(CircuitError::StorageUnavailable)?;
     let opened_input_shares =
-        load_opened_input_shares_with_retry(&ctx.storage, peer_id, &challenge_indices).await?;
+        load_opened_input_shares(&ctx.storage, peer_id, &challenge_indices).await?;
     // ── Build selected input values (which value index per wire) ────────
     let mut selected_input: [u8; N_INPUT_WIRES] = [0; N_INPUT_WIRES];
     selected_input[..N_SETUP_INPUT_WIRES].copy_from_slice(&setup_input);

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -24,6 +24,7 @@ use mosaic_storage_api::{
     table_store::{TableId, TableReader as _, TableStore, TableWriter as _},
 };
 use mosaic_vs3::{Index, Share, batch_verify_shares, interpolate};
+use tracing::{error, warn};
 
 use super::MosaicExecutor;
 use crate::{

--- a/crates/job/executors/src/lib.rs
+++ b/crates/job/executors/src/lib.rs
@@ -299,7 +299,7 @@ impl<SP: StorageProvider, TS: TableStore> ExecuteEvaluatorJob for MosaicExecutor
                 .ok()
                 .flatten()
                 .ok_or(CircuitError::StorageUnavailable)?;
-            let opened_input_shares = evaluator::load_opened_input_shares_with_retry(
+            let opened_input_shares = evaluator::load_opened_input_shares(
                 &self.storage,
                 &peer_id,
                 &challenge_indices,

--- a/crates/job/executors/src/lib.rs
+++ b/crates/job/executors/src/lib.rs
@@ -299,12 +299,9 @@ impl<SP: StorageProvider, TS: TableStore> ExecuteEvaluatorJob for MosaicExecutor
                 .ok()
                 .flatten()
                 .ok_or(CircuitError::StorageUnavailable)?;
-            let opened_input_shares = evaluator::load_opened_input_shares(
-                &self.storage,
-                &peer_id,
-                &challenge_indices,
-            )
-            .await?;
+            let opened_input_shares =
+                evaluator::load_opened_input_shares(&self.storage, &peer_id, &challenge_indices)
+                    .await?;
             let pos = challenge_indices.iter().position(|ci| *ci == index).ok_or(
                 CircuitError::SetupFailed("index not in challenge indices".into()),
             )?;

--- a/crates/sm-executor/src/lib.rs
+++ b/crates/sm-executor/src/lib.rs
@@ -6,7 +6,7 @@ use fasm::{Input as FasmInput, StateMachine};
 use futures::FutureExt;
 use mosaic_cac_protocol::{SMError, evaluator::EvaluatorSM, garbler::GarblerSM};
 use mosaic_cac_types::{
-    Msg,
+    Msg, RetryableStorageError,
     state_machine::{evaluator, garbler},
 };
 use mosaic_job_api::{ActionCompletion, JobActions, JobBatch, JobCompletion, JobSchedulerHandle};
@@ -130,6 +130,8 @@ pub enum SmExecutorError {
         peer_id: PeerId,
         /// Role whose state failed to commit.
         role: SmRole,
+        /// Whether retrying the whole STF unit is safe.
+        retryable: bool,
         /// Commit failure detail.
         reason: String,
     },
@@ -810,32 +812,56 @@ where
             input_kind = garbler_input_kind(&input)
         );
         async move {
-            tracing::trace!("running STF for event");
-            let mut state = self
-                .storage
-                .garbler_state_mut(&peer_id)
-                .await
-                .map_err(|source| SmExecutorError::Storage {
-                    peer_id,
-                    role: SmRole::Garbler,
-                    source,
-                })?;
-            let mut actions = garbler::ActionContainer::default();
+            let mut attempts = 0u32;
+            loop {
+                tracing::trace!(attempts, "running STF for event");
+                let mut state = match self.storage.garbler_state_mut(&peer_id).await {
+                    Ok(state) => state,
+                    Err(source) => {
+                        let err = SmExecutorError::Storage {
+                            peer_id,
+                            role: SmRole::Garbler,
+                            source,
+                        };
+                        if Self::is_retryable_processing_error(&err) {
+                            attempts = attempts.saturating_add(1);
+                            tracing::warn!(peer = ?peer_id, role = ?SmRole::Garbler, attempts, error = ?err, "retryable storage acquisition failure; retrying STF unit");
+                            continue;
+                        }
+                        return Err(err);
+                    }
+                };
+                let mut actions = garbler::ActionContainer::default();
 
-            Self::stf_guard(peer_id, SmRole::Garbler, "event", async {
-                GarblerSM::<<S as StorageProviderMut>::GarblerState>::stf(
-                    &mut state,
-                    FasmInput::Normal(input),
-                    &mut actions,
-                )
+                if let Err(err) = Self::stf_guard(peer_id, SmRole::Garbler, "event", async {
+                    GarblerSM::<<S as StorageProviderMut>::GarblerState>::stf(
+                        &mut state,
+                        FasmInput::Normal(input.clone()),
+                        &mut actions,
+                    )
+                    .await
+                })
                 .await
-            })
-            .await?;
-            tracing::debug!(actions = actions.len(), "garbler event STF completed");
+                {
+                    if Self::is_retryable_processing_error(&err) {
+                        attempts = attempts.saturating_add(1);
+                        tracing::warn!(peer = ?peer_id, role = ?SmRole::Garbler, attempts, error = ?err, "retryable STF failure; retrying STF unit");
+                        continue;
+                    }
+                    return Err(err);
+                }
+                tracing::debug!(actions = actions.len(), "garbler event STF completed");
 
-            Self::commit_state(state, peer_id, SmRole::Garbler).await?;
-            self.submit_actions(peer_id, JobActions::Garbler(actions))
-                .await
+                if let Err(err) = Self::commit_state(state, peer_id, SmRole::Garbler).await {
+                    if Self::is_retryable_processing_error(&err) {
+                        attempts = attempts.saturating_add(1);
+                        tracing::warn!(peer = ?peer_id, role = ?SmRole::Garbler, attempts, error = ?err, "retryable commit failure; retrying STF unit");
+                        continue;
+                    }
+                    return Err(err);
+                }
+                return self.submit_actions(peer_id, JobActions::Garbler(actions)).await;
+            }
         }
         .instrument(span)
         .await
@@ -853,32 +879,58 @@ where
             input_kind = evaluator_input_kind(&input)
         );
         async move {
-            tracing::trace!("running STF for event");
-            let mut state = self
-                .storage
-                .evaluator_state_mut(&peer_id)
-                .await
-                .map_err(|source| SmExecutorError::Storage {
-                    peer_id,
-                    role: SmRole::Evaluator,
-                    source,
-                })?;
-            let mut actions = evaluator::ActionContainer::default();
+            let mut attempts = 0u32;
+            loop {
+                tracing::trace!(attempts, "running STF for event");
+                let mut state = match self.storage.evaluator_state_mut(&peer_id).await {
+                    Ok(state) => state,
+                    Err(source) => {
+                        let err = SmExecutorError::Storage {
+                            peer_id,
+                            role: SmRole::Evaluator,
+                            source,
+                        };
+                        if Self::is_retryable_processing_error(&err) {
+                            attempts = attempts.saturating_add(1);
+                            tracing::warn!(peer = ?peer_id, role = ?SmRole::Evaluator, attempts, error = ?err, "retryable storage acquisition failure; retrying STF unit");
+                            continue;
+                        }
+                        return Err(err);
+                    }
+                };
+                let mut actions = evaluator::ActionContainer::default();
 
-            Self::stf_guard(peer_id, SmRole::Evaluator, "event", async {
-                EvaluatorSM::<<S as StorageProviderMut>::EvaluatorState>::stf(
-                    &mut state,
-                    FasmInput::Normal(input),
-                    &mut actions,
-                )
+                if let Err(err) = Self::stf_guard(peer_id, SmRole::Evaluator, "event", async {
+                    EvaluatorSM::<<S as StorageProviderMut>::EvaluatorState>::stf(
+                        &mut state,
+                        FasmInput::Normal(input.clone()),
+                        &mut actions,
+                    )
+                    .await
+                })
                 .await
-            })
-            .await?;
-            tracing::debug!(actions = actions.len(), "evaluator event STF completed");
+                {
+                    if Self::is_retryable_processing_error(&err) {
+                        attempts = attempts.saturating_add(1);
+                        tracing::warn!(peer = ?peer_id, role = ?SmRole::Evaluator, attempts, error = ?err, "retryable STF failure; retrying STF unit");
+                        continue;
+                    }
+                    return Err(err);
+                }
+                tracing::debug!(actions = actions.len(), "evaluator event STF completed");
 
-            Self::commit_state(state, peer_id, SmRole::Evaluator).await?;
-            self.submit_actions(peer_id, JobActions::Evaluator(actions))
-                .await
+                if let Err(err) = Self::commit_state(state, peer_id, SmRole::Evaluator).await {
+                    if Self::is_retryable_processing_error(&err) {
+                        attempts = attempts.saturating_add(1);
+                        tracing::warn!(peer = ?peer_id, role = ?SmRole::Evaluator, attempts, error = ?err, "retryable commit failure; retrying STF unit");
+                        continue;
+                    }
+                    return Err(err);
+                }
+                return self
+                    .submit_actions(peer_id, JobActions::Evaluator(actions))
+                    .await;
+            }
         }
         .instrument(span)
         .await
@@ -897,32 +949,60 @@ where
             action_id = ?id
         );
         async move {
-            tracing::trace!("running STF for tracked completion");
-            let mut state = self
-                .storage
-                .garbler_state_mut(&peer_id)
-                .await
-                .map_err(|source| SmExecutorError::Storage {
-                    peer_id,
-                    role: SmRole::Garbler,
-                    source,
-                })?;
-            let mut actions = garbler::ActionContainer::default();
+            let mut attempts = 0u32;
+            loop {
+                tracing::trace!(attempts, "running STF for tracked completion");
+                let mut state = match self.storage.garbler_state_mut(&peer_id).await {
+                    Ok(state) => state,
+                    Err(source) => {
+                        let err = SmExecutorError::Storage {
+                            peer_id,
+                            role: SmRole::Garbler,
+                            source,
+                        };
+                        if Self::is_retryable_processing_error(&err) {
+                            attempts = attempts.saturating_add(1);
+                            tracing::warn!(peer = ?peer_id, role = ?SmRole::Garbler, attempts, error = ?err, "retryable storage acquisition failure; retrying STF unit");
+                            continue;
+                        }
+                        return Err(err);
+                    }
+                };
+                let mut actions = garbler::ActionContainer::default();
 
-            Self::stf_guard(peer_id, SmRole::Garbler, "completion", async {
-                GarblerSM::<<S as StorageProviderMut>::GarblerState>::stf(
-                    &mut state,
-                    FasmInput::TrackedActionCompleted { id, result },
-                    &mut actions,
-                )
-                .await
-            })
-            .await?;
-            tracing::debug!(actions = actions.len(), "garbler completion STF completed");
+                if let Err(err) =
+                    Self::stf_guard(peer_id, SmRole::Garbler, "completion", async {
+                        GarblerSM::<<S as StorageProviderMut>::GarblerState>::stf(
+                            &mut state,
+                            FasmInput::TrackedActionCompleted {
+                                id: id.clone(),
+                                result: result.clone(),
+                            },
+                            &mut actions,
+                        )
+                        .await
+                    })
+                    .await
+                {
+                    if Self::is_retryable_processing_error(&err) {
+                        attempts = attempts.saturating_add(1);
+                        tracing::warn!(peer = ?peer_id, role = ?SmRole::Garbler, attempts, error = ?err, "retryable STF failure; retrying STF unit");
+                        continue;
+                    }
+                    return Err(err);
+                }
+                tracing::debug!(actions = actions.len(), "garbler completion STF completed");
 
-            Self::commit_state(state, peer_id, SmRole::Garbler).await?;
-            self.submit_actions(peer_id, JobActions::Garbler(actions))
-                .await
+                if let Err(err) = Self::commit_state(state, peer_id, SmRole::Garbler).await {
+                    if Self::is_retryable_processing_error(&err) {
+                        attempts = attempts.saturating_add(1);
+                        tracing::warn!(peer = ?peer_id, role = ?SmRole::Garbler, attempts, error = ?err, "retryable commit failure; retrying STF unit");
+                        continue;
+                    }
+                    return Err(err);
+                }
+                return self.submit_actions(peer_id, JobActions::Garbler(actions)).await;
+            }
         }
         .instrument(span)
         .await
@@ -941,35 +1021,65 @@ where
             action_id = ?id
         );
         async move {
-            tracing::trace!("running STF for tracked completion");
-            let mut state = self
-                .storage
-                .evaluator_state_mut(&peer_id)
-                .await
-                .map_err(|source| SmExecutorError::Storage {
-                    peer_id,
-                    role: SmRole::Evaluator,
-                    source,
-                })?;
-            let mut actions = evaluator::ActionContainer::default();
+            let mut attempts = 0u32;
+            loop {
+                tracing::trace!(attempts, "running STF for tracked completion");
+                let mut state = match self.storage.evaluator_state_mut(&peer_id).await {
+                    Ok(state) => state,
+                    Err(source) => {
+                        let err = SmExecutorError::Storage {
+                            peer_id,
+                            role: SmRole::Evaluator,
+                            source,
+                        };
+                        if Self::is_retryable_processing_error(&err) {
+                            attempts = attempts.saturating_add(1);
+                            tracing::warn!(peer = ?peer_id, role = ?SmRole::Evaluator, attempts, error = ?err, "retryable storage acquisition failure; retrying STF unit");
+                            continue;
+                        }
+                        return Err(err);
+                    }
+                };
+                let mut actions = evaluator::ActionContainer::default();
 
-            Self::stf_guard(peer_id, SmRole::Evaluator, "completion", async {
-                EvaluatorSM::<<S as StorageProviderMut>::EvaluatorState>::stf(
-                    &mut state,
-                    FasmInput::TrackedActionCompleted { id, result },
-                    &mut actions,
-                )
-                .await
-            })
-            .await?;
-            tracing::debug!(
-                actions = actions.len(),
-                "evaluator completion STF completed"
-            );
+                if let Err(err) =
+                    Self::stf_guard(peer_id, SmRole::Evaluator, "completion", async {
+                        EvaluatorSM::<<S as StorageProviderMut>::EvaluatorState>::stf(
+                            &mut state,
+                            FasmInput::TrackedActionCompleted {
+                                id: id.clone(),
+                                result: result.clone(),
+                            },
+                            &mut actions,
+                        )
+                        .await
+                    })
+                    .await
+                {
+                    if Self::is_retryable_processing_error(&err) {
+                        attempts = attempts.saturating_add(1);
+                        tracing::warn!(peer = ?peer_id, role = ?SmRole::Evaluator, attempts, error = ?err, "retryable STF failure; retrying STF unit");
+                        continue;
+                    }
+                    return Err(err);
+                }
+                tracing::debug!(
+                    actions = actions.len(),
+                    "evaluator completion STF completed"
+                );
 
-            Self::commit_state(state, peer_id, SmRole::Evaluator).await?;
-            self.submit_actions(peer_id, JobActions::Evaluator(actions))
-                .await
+                if let Err(err) = Self::commit_state(state, peer_id, SmRole::Evaluator).await {
+                    if Self::is_retryable_processing_error(&err) {
+                        attempts = attempts.saturating_add(1);
+                        tracing::warn!(peer = ?peer_id, role = ?SmRole::Evaluator, attempts, error = ?err, "retryable commit failure; retrying STF unit");
+                        continue;
+                    }
+                    return Err(err);
+                }
+                return self
+                    .submit_actions(peer_id, JobActions::Evaluator(actions))
+                    .await;
+            }
         }
         .instrument(span)
         .await
@@ -1017,6 +1127,7 @@ where
             .map_err(|err| SmExecutorError::Commit {
                 peer_id,
                 role,
+                retryable: err.is_retryable(),
                 reason: format!("{err:?}"),
             })?;
         tracing::debug!(peer = ?peer_id, role = ?role, "state committed");
@@ -1056,6 +1167,20 @@ where
         matches!(err, SmExecutorError::JobSubmission { .. })
     }
 
+    fn is_retryable_processing_error(err: &SmExecutorError) -> bool {
+        match err {
+            SmExecutorError::Storage { source, .. } => source.is_retryable(),
+            SmExecutorError::Commit { retryable, .. } => *retryable,
+            SmExecutorError::Stf { source, .. } => source.is_retryable_storage(),
+            SmExecutorError::SourceClosed(_)
+            | SmExecutorError::NetRecv(_)
+            | SmExecutorError::Ack { .. }
+            | SmExecutorError::JobSubmission { .. }
+            | SmExecutorError::RoleMismatch(_)
+            | SmExecutorError::StfPanic { .. } => false,
+        }
+    }
+
     fn handle_failed_completion(
         pending_completions: &mut VecDeque<PendingJobCompletion>,
         mut completion: PendingJobCompletion,
@@ -1093,17 +1218,20 @@ where
     }
 
     fn completion_error_action(err: &SmExecutorError) -> CompletionErrorAction {
+        if Self::is_retryable_processing_error(err) {
+            return CompletionErrorAction::Requeue;
+        }
+
         match err {
-            SmExecutorError::Storage { .. } | SmExecutorError::Commit { .. } => {
-                CompletionErrorAction::Requeue
-            }
             SmExecutorError::Stf { .. } => CompletionErrorAction::Drop,
             SmExecutorError::JobSubmission { .. }
             | SmExecutorError::RoleMismatch(_)
             | SmExecutorError::StfPanic { .. }
             | SmExecutorError::SourceClosed(_)
             | SmExecutorError::NetRecv(_)
-            | SmExecutorError::Ack { .. } => CompletionErrorAction::Fatal,
+            | SmExecutorError::Ack { .. }
+            | SmExecutorError::Storage { .. }
+            | SmExecutorError::Commit { .. } => CompletionErrorAction::Fatal,
         }
     }
 }
@@ -1181,6 +1309,7 @@ mod tests {
     use futures::task::noop_waker_ref;
     use mosaic_cac_types::{
         AllGarblingTableCommitments, ChallengeIndices, ChallengeMsg, HeapArray, Index, Msg,
+        RetryableStorageError,
         state_machine::{
             evaluator::{
                 self, EvaluatorInitData, StateMut as EvaluatorStateMut,
@@ -1208,6 +1337,16 @@ mod tests {
 
     #[derive(Debug, Default, Clone, Copy)]
     struct TestStorage;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("{0}")]
+    struct TestRetryableStorageError(&'static str);
+
+    impl RetryableStorageError for TestRetryableStorageError {
+        fn is_retryable(&self) -> bool {
+            true
+        }
+    }
 
     impl StorageProvider for TestStorage {
         type GarblerState = StoredGarblerState;
@@ -1303,9 +1442,9 @@ mod tests {
             let fail_next = Arc::clone(&self.fail_next_evaluator_state_mut);
             async move {
                 if fail_next.swap(false, Ordering::AcqRel) {
-                    return Err(StorageProviderError::Other(
-                        "transient evaluator state acquisition failure".into(),
-                    ));
+                    return Err(StorageProviderError::source(TestRetryableStorageError(
+                        "transient evaluator state acquisition failure",
+                    )));
                 }
                 inner.evaluator_state_mut(&peer_id).await
             }
@@ -1495,14 +1634,14 @@ mod tests {
     }
 
     #[test]
-    fn completion_error_policy_requeues_transient_failures_and_drops_stf_errors() {
+    fn completion_error_policy_requeues_only_retryable_failures() {
         let peer_id = PeerId::from([6; 32]);
 
         let storage_err =
             SmExecutor::<TestStorage>::completion_error_action(&SmExecutorError::Storage {
                 peer_id,
                 role: SmRole::Evaluator,
-                source: StorageProviderError::Other("temporary".into()),
+                source: StorageProviderError::source(TestRetryableStorageError("temporary")),
             });
         assert_eq!(storage_err, CompletionErrorAction::Requeue);
 
@@ -1510,9 +1649,27 @@ mod tests {
             SmExecutor::<TestStorage>::completion_error_action(&SmExecutorError::Commit {
                 peer_id,
                 role: SmRole::Garbler,
+                retryable: true,
                 reason: "temporary".into(),
             });
         assert_eq!(commit_err, CompletionErrorAction::Requeue);
+
+        let non_retryable_storage =
+            SmExecutor::<TestStorage>::completion_error_action(&SmExecutorError::Storage {
+                peer_id,
+                role: SmRole::Evaluator,
+                source: StorageProviderError::Other("permanent".into()),
+            });
+        assert_eq!(non_retryable_storage, CompletionErrorAction::Fatal);
+
+        let non_retryable_commit =
+            SmExecutor::<TestStorage>::completion_error_action(&SmExecutorError::Commit {
+                peer_id,
+                role: SmRole::Garbler,
+                retryable: false,
+                reason: "permanent".into(),
+            });
+        assert_eq!(non_retryable_commit, CompletionErrorAction::Fatal);
 
         let stf_err = SmExecutor::<TestStorage>::completion_error_action(&SmExecutorError::Stf {
             peer_id,
@@ -1547,6 +1704,7 @@ mod tests {
             SmExecutorError::Commit {
                 peer_id,
                 role: SmRole::Evaluator,
+                retryable: true,
                 reason: "temporary".into(),
             },
         )

--- a/crates/sm-executor/src/lib.rs
+++ b/crates/sm-executor/src/lib.rs
@@ -16,7 +16,7 @@ use mosaic_sm_executor_api::{
     DepositInitData, DisputedWithdrawalData, InitData, SmCommand, SmCommandKind, SmExecutorConfig,
     SmExecutorHandle, SmRole,
 };
-use mosaic_storage_api::{Commit, StorageProviderError, StorageProviderMut};
+use mosaic_storage_api::{Commit, StorageProvider, StorageProviderError, StorageProviderMut};
 use tracing::Instrument;
 
 /// Initial backoff before retrying a completion that failed to apply.
@@ -188,9 +188,11 @@ async fn recv_shutdown(
 #[derive(Debug)]
 pub struct SmExecutor<S>
 where
-    S: StorageProviderMut + 'static,
-    S::GarblerState: garbler::StateMut + Commit,
-    S::EvaluatorState: evaluator::StateMut + Commit,
+    S: StorageProvider + StorageProviderMut + 'static,
+    <S as StorageProviderMut>::GarblerState: garbler::StateMut + Commit,
+    <S as StorageProviderMut>::EvaluatorState: evaluator::StateMut + Commit,
+    <S as StorageProvider>::GarblerState: garbler::StateRead,
+    <S as StorageProvider>::EvaluatorState: evaluator::StateRead,
 {
     config: SmExecutorConfig,
     storage: S,
@@ -201,9 +203,11 @@ where
 
 impl<S> SmExecutor<S>
 where
-    S: StorageProviderMut + 'static,
-    S::GarblerState: garbler::StateMut + Commit,
-    S::EvaluatorState: evaluator::StateMut + Commit,
+    S: StorageProvider + StorageProviderMut + 'static,
+    <S as StorageProviderMut>::GarblerState: garbler::StateMut + Commit,
+    <S as StorageProviderMut>::EvaluatorState: evaluator::StateMut + Commit,
+    <S as StorageProvider>::GarblerState: garbler::StateRead,
+    <S as StorageProvider>::EvaluatorState: evaluator::StateRead,
 {
     /// Create a new executor and handle.
     pub fn new(
@@ -467,11 +471,15 @@ where
         async {
             let garbler_ok = {
                 tracing::debug!(role = ?SmRole::Garbler, "restoring garbler state machine");
-                match self.storage.garbler_state_mut(&peer_id).await {
+                match self.storage.garbler_state(&peer_id).await {
                     Ok(state) => {
                         let mut actions = garbler::ActionContainer::default();
                         match Self::stf_guard(peer_id, SmRole::Garbler, "restore", async {
-                            GarblerSM::<S::GarblerState>::restore(&state, &mut actions).await
+                            GarblerSM::<
+                                <S as StorageProviderMut>::GarblerState,
+                                <S as StorageProvider>::GarblerState,
+                            >::restore(&state, &mut actions)
+                            .await
                         })
                         .await
                         {
@@ -481,31 +489,19 @@ where
                                     actions = actions.len(),
                                     "garbler restore STF completed"
                                 );
-                                match Self::commit_state(state, peer_id, SmRole::Garbler).await {
-                                    Ok(()) => {
-                                        match self
-                                            .submit_actions(peer_id, JobActions::Garbler(actions))
-                                            .await
-                                        {
-                                            Ok(()) => true,
-                                            Err(err) => {
-                                                if Self::is_fatal_processing_error(&err) {
-                                                    return Err(err);
-                                                }
-                                                tracing::error!(
-                                                    role = ?SmRole::Garbler,
-                                                    error = ?err,
-                                                    "garbler restore action submission failed"
-                                                );
-                                                false
-                                            }
-                                        }
-                                    }
+                                match self
+                                    .submit_actions(peer_id, JobActions::Garbler(actions))
+                                    .await
+                                {
+                                    Ok(()) => true,
                                     Err(err) => {
+                                        if Self::is_fatal_processing_error(&err) {
+                                            return Err(err);
+                                        }
                                         tracing::error!(
                                             role = ?SmRole::Garbler,
                                             error = ?err,
-                                            "garbler restore commit failed"
+                                            "garbler restore action submission failed"
                                         );
                                         false
                                     }
@@ -534,11 +530,15 @@ where
 
             let evaluator_ok = {
                 tracing::debug!(role = ?SmRole::Evaluator, "restoring evaluator state machine");
-                match self.storage.evaluator_state_mut(&peer_id).await {
+                match self.storage.evaluator_state(&peer_id).await {
                     Ok(state) => {
                         let mut actions = evaluator::ActionContainer::default();
                         match Self::stf_guard(peer_id, SmRole::Evaluator, "restore", async {
-                            EvaluatorSM::<S::EvaluatorState>::restore(&state, &mut actions).await
+                            EvaluatorSM::<
+                                <S as StorageProviderMut>::EvaluatorState,
+                                <S as StorageProvider>::EvaluatorState,
+                            >::restore(&state, &mut actions)
+                            .await
                         })
                         .await
                         {
@@ -548,31 +548,19 @@ where
                                     actions = actions.len(),
                                     "evaluator restore STF completed"
                                 );
-                                match Self::commit_state(state, peer_id, SmRole::Evaluator).await {
-                                    Ok(()) => {
-                                        match self
-                                            .submit_actions(peer_id, JobActions::Evaluator(actions))
-                                            .await
-                                        {
-                                            Ok(()) => true,
-                                            Err(err) => {
-                                                if Self::is_fatal_processing_error(&err) {
-                                                    return Err(err);
-                                                }
-                                                tracing::error!(
-                                                    role = ?SmRole::Evaluator,
-                                                    error = ?err,
-                                                    "evaluator restore action submission failed"
-                                                );
-                                                false
-                                            }
-                                        }
-                                    }
+                                match self
+                                    .submit_actions(peer_id, JobActions::Evaluator(actions))
+                                    .await
+                                {
+                                    Ok(()) => true,
                                     Err(err) => {
+                                        if Self::is_fatal_processing_error(&err) {
+                                            return Err(err);
+                                        }
                                         tracing::error!(
                                             role = ?SmRole::Evaluator,
                                             error = ?err,
-                                            "evaluator restore commit failed"
+                                            "evaluator restore action submission failed"
                                         );
                                         false
                                     }
@@ -835,7 +823,7 @@ where
             let mut actions = garbler::ActionContainer::default();
 
             Self::stf_guard(peer_id, SmRole::Garbler, "event", async {
-                GarblerSM::<S::GarblerState>::stf(
+                GarblerSM::<<S as StorageProviderMut>::GarblerState>::stf(
                     &mut state,
                     FasmInput::Normal(input),
                     &mut actions,
@@ -878,7 +866,7 @@ where
             let mut actions = evaluator::ActionContainer::default();
 
             Self::stf_guard(peer_id, SmRole::Evaluator, "event", async {
-                EvaluatorSM::<S::EvaluatorState>::stf(
+                EvaluatorSM::<<S as StorageProviderMut>::EvaluatorState>::stf(
                     &mut state,
                     FasmInput::Normal(input),
                     &mut actions,
@@ -922,7 +910,7 @@ where
             let mut actions = garbler::ActionContainer::default();
 
             Self::stf_guard(peer_id, SmRole::Garbler, "completion", async {
-                GarblerSM::<S::GarblerState>::stf(
+                GarblerSM::<<S as StorageProviderMut>::GarblerState>::stf(
                     &mut state,
                     FasmInput::TrackedActionCompleted { id, result },
                     &mut actions,
@@ -966,7 +954,7 @@ where
             let mut actions = evaluator::ActionContainer::default();
 
             Self::stf_guard(peer_id, SmRole::Evaluator, "completion", async {
-                EvaluatorSM::<S::EvaluatorState>::stf(
+                EvaluatorSM::<<S as StorageProviderMut>::EvaluatorState>::stf(
                     &mut state,
                     FasmInput::TrackedActionCompleted { id, result },
                     &mut actions,
@@ -1220,6 +1208,25 @@ mod tests {
 
     #[derive(Debug, Default, Clone, Copy)]
     struct TestStorage;
+
+    impl StorageProvider for TestStorage {
+        type GarblerState = StoredGarblerState;
+        type EvaluatorState = StoredEvaluatorState;
+
+        fn garbler_state(
+            &self,
+            _peer_id: &PeerId,
+        ) -> impl Future<Output = StorageProviderResult<Self::GarblerState>> + Send {
+            std::future::ready(Ok(StoredGarblerState::default()))
+        }
+
+        fn evaluator_state(
+            &self,
+            _peer_id: &PeerId,
+        ) -> impl Future<Output = StorageProviderResult<Self::EvaluatorState>> + Send {
+            std::future::ready(Ok(StoredEvaluatorState::default()))
+        }
+    }
 
     impl StorageProviderMut for TestStorage {
         type GarblerState = StoredGarblerState;

--- a/crates/storage/api/src/lib.rs
+++ b/crates/storage/api/src/lib.rs
@@ -36,8 +36,12 @@ pub mod __private {
 }
 
 use core::future::Future;
+use std::error::Error;
 
-use mosaic_cac_types::state_machine::{evaluator, garbler};
+use mosaic_cac_types::{
+    RetryableStorageError,
+    state_machine::{evaluator, garbler},
+};
 use mosaic_net_svc_api::PeerId;
 pub use table_store::{TableId, TableMetadata, TableReader, TableStore, TableWriter};
 use thiserror::Error;
@@ -51,10 +55,38 @@ pub enum StorageProviderError {
     /// Other type of error not covered above.
     #[error("storage: {0}")]
     Other(String),
+    /// Source error preserved for retryability inspection.
+    #[error("storage: {source}")]
+    Source {
+        /// Whether the underlying failure is safe to retry.
+        retryable: bool,
+        /// Original source error.
+        #[source]
+        source: Box<dyn Error + Send + Sync>,
+    },
 }
 
 /// Storage Provider Result
 pub type StorageProviderResult<T> = Result<T, StorageProviderError>;
+
+impl StorageProviderError {
+    /// Wrap a typed source error, preserving retryability.
+    pub fn source(err: impl Error + RetryableStorageError + Send + Sync + 'static) -> Self {
+        Self::Source {
+            retryable: err.is_retryable(),
+            source: Box::new(err),
+        }
+    }
+}
+
+impl RetryableStorageError for StorageProviderError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::Serialization(_) | Self::Other(_) => false,
+            Self::Source { retryable, .. } => *retryable,
+        }
+    }
+}
 
 /// Commit hook for mutable storage sessions/handles.
 ///
@@ -63,7 +95,7 @@ pub type StorageProviderResult<T> = Result<T, StorageProviderError>;
 /// call. In-memory backends may implement this as a no-op.
 pub trait Commit {
     /// Error type produced by commit.
-    type Error: std::fmt::Debug;
+    type Error: std::fmt::Debug + RetryableStorageError;
 
     /// Finalize writes performed through this mutable handle.
     fn commit(self) -> impl Future<Output = Result<(), Self::Error>>;

--- a/crates/storage/fdb/Cargo.toml
+++ b/crates/storage/fdb/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
+mosaic-cac-types.workspace = true
 mosaic-net-svc-api.workspace = true
 mosaic-storage-api.workspace = true
 mosaic-storage-kvstore.workspace = true

--- a/crates/storage/fdb/src/lib.rs
+++ b/crates/storage/fdb/src/lib.rs
@@ -12,7 +12,8 @@ use std::{
 };
 
 use foundationdb::{
-    Database, FdbError, KeySelector, RangeOption, Transaction, TransactionCommitError,
+    Database, FdbError, KeySelector, RangeOption, TransactOption, Transaction,
+    TransactionCommitError,
     directory::{Directory, DirectoryError, DirectoryLayer, DirectoryOutput},
     options,
 };
@@ -54,6 +55,20 @@ pub enum FdbStorageError {
     /// Returned key escaped the scoped directory prefix.
     #[error("scoped range returned a key outside the expected directory prefix")]
     PrefixViolation,
+    /// A mutation was attempted through a read-only handle.
+    #[error("mutation attempted through read-only foundationdb state handle")]
+    ReadOnlyMutation,
+}
+
+impl TryFrom<FdbStorageError> for FdbError {
+    type Error = FdbStorageError;
+
+    fn try_from(value: FdbStorageError) -> Result<Self, Self::Error> {
+        match value {
+            FdbStorageError::Fdb(err) => Ok(err),
+            other => Err(other),
+        }
+    }
 }
 
 /// FoundationDB-backed provider for garbler and evaluator state.
@@ -129,6 +144,32 @@ impl FdbStorageProvider {
         Ok(KvStoreEvaluator::new(FdbTransaction::new(tx, prefix)))
     }
 
+    async fn garbler_state_read_handle(
+        &self,
+        peer_id: PeerId,
+    ) -> Result<KvStoreGarbler<FdbReadOnlyStore>, FdbStorageError> {
+        let prefix = self
+            .ensure_role_keyspace(peer_id, RoleKeyspace::Garbler)
+            .await?;
+        Ok(KvStoreGarbler::new(FdbReadOnlyStore::new(
+            self.db.clone(),
+            prefix,
+        )))
+    }
+
+    async fn evaluator_state_read_handle(
+        &self,
+        peer_id: PeerId,
+    ) -> Result<KvStoreEvaluator<FdbReadOnlyStore>, FdbStorageError> {
+        let prefix = self
+            .ensure_role_keyspace(peer_id, RoleKeyspace::Evaluator)
+            .await?;
+        Ok(KvStoreEvaluator::new(FdbReadOnlyStore::new(
+            self.db.clone(),
+            prefix,
+        )))
+    }
+
     async fn ensure_role_keyspace(
         &self,
         peer_id: PeerId,
@@ -173,8 +214,8 @@ impl FdbStorageProvider {
 }
 
 impl StorageProvider for FdbStorageProvider {
-    type GarblerState = KvStoreGarbler<FdbTransaction>;
-    type EvaluatorState = KvStoreEvaluator<FdbTransaction>;
+    type GarblerState = KvStoreGarbler<FdbReadOnlyStore>;
+    type EvaluatorState = KvStoreEvaluator<FdbReadOnlyStore>;
 
     fn garbler_state(
         &self,
@@ -186,7 +227,7 @@ impl StorageProvider for FdbStorageProvider {
         let provider = self.clone();
         async move {
             provider
-                .garbler_state_handle(peer_id)
+                .garbler_state_read_handle(peer_id)
                 .await
                 .map_err(|err| StorageProviderError::Other(err.to_string()))
         }
@@ -202,7 +243,7 @@ impl StorageProvider for FdbStorageProvider {
         let provider = self.clone();
         async move {
             provider
-                .evaluator_state_handle(peer_id)
+                .evaluator_state_read_handle(peer_id)
                 .await
                 .map_err(|err| StorageProviderError::Other(err.to_string()))
         }
@@ -274,6 +315,19 @@ pub struct FdbTransaction {
     prefix: Vec<u8>,
 }
 
+#[derive(Clone)]
+/// Read-only KV view that opens a fresh FoundationDB transaction per method call.
+pub struct FdbReadOnlyStore {
+    db: Arc<Database>,
+    prefix: Vec<u8>,
+}
+
+impl fmt::Debug for FdbReadOnlyStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FdbReadOnlyStore").finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug)]
 struct RangeCursor {
     opt: Option<RangeOption<'static>>,
@@ -286,70 +340,16 @@ impl FdbTransaction {
         Self { tx, prefix }
     }
 
-    fn prefix_key(&self, key: &[u8]) -> Vec<u8> {
-        let mut prefixed = Vec::with_capacity(self.prefix.len() + key.len());
-        prefixed.extend_from_slice(&self.prefix);
-        prefixed.extend_from_slice(key);
-        prefixed
-    }
-
-    fn owned_bound(bound: Bound<&[u8]>) -> Bound<Vec<u8>> {
-        match bound {
-            Bound::Included(key) => Bound::Included(key.to_vec()),
-            Bound::Excluded(key) => Bound::Excluded(key.to_vec()),
-            Bound::Unbounded => Bound::Unbounded,
-        }
-    }
-
-    fn start_selector(&self, bound: Bound<Vec<u8>>) -> KeySelector<'static> {
-        match bound {
-            Bound::Included(key) => KeySelector::first_greater_or_equal(self.prefix_key(&key)),
-            Bound::Excluded(key) => KeySelector::first_greater_than(self.prefix_key(&key)),
-            Bound::Unbounded => KeySelector::first_greater_or_equal(self.prefix.clone()),
-        }
-    }
-
-    fn end_selector(&self, bound: Bound<Vec<u8>>) -> KeySelector<'static> {
-        match bound {
-            Bound::Included(key) => KeySelector::first_greater_than(self.prefix_key(&key)),
-            Bound::Excluded(key) => KeySelector::first_greater_or_equal(self.prefix_key(&key)),
-            Bound::Unbounded => {
-                let next = next_prefix(&self.prefix).unwrap_or_else(|| vec![0xFF]);
-                KeySelector::first_greater_or_equal(next)
-            }
-        }
-    }
-
-    fn first_greater_than_key(key: &[u8]) -> Vec<u8> {
-        let mut out = Vec::with_capacity(key.len() + 1);
-        out.extend_from_slice(key);
-        out.push(0x00);
-        out
-    }
-
-    fn clear_range_start_key(&self, bound: Bound<Vec<u8>>) -> Vec<u8> {
-        match bound {
-            Bound::Included(key) => self.prefix_key(&key),
-            Bound::Excluded(key) => Self::first_greater_than_key(&self.prefix_key(&key)),
-            Bound::Unbounded => self.prefix.clone(),
-        }
-    }
-
-    fn clear_range_end_key(&self, bound: Bound<Vec<u8>>) -> Vec<u8> {
-        match bound {
-            Bound::Included(key) => Self::first_greater_than_key(&self.prefix_key(&key)),
-            Bound::Excluded(key) => self.prefix_key(&key),
-            Bound::Unbounded => next_prefix(&self.prefix).unwrap_or_else(|| vec![0xFF]),
-        }
-    }
-
     fn make_cursor(
         &self,
         start: Bound<Vec<u8>>,
         end: Bound<Vec<u8>>,
         reverse: bool,
     ) -> RangeCursor {
-        let mut opt = RangeOption::from((self.start_selector(start), self.end_selector(end)));
+        let mut opt = RangeOption::from((
+            start_selector(&self.prefix, start),
+            end_selector(&self.prefix, end),
+        ));
         opt.reverse = reverse;
         opt.mode = options::StreamingMode::Iterator;
 
@@ -390,23 +390,171 @@ impl FdbTransaction {
     }
 }
 
+impl FdbReadOnlyStore {
+    fn new(db: Arc<Database>, prefix: Vec<u8>) -> Self {
+        Self { db, prefix }
+    }
+
+    async fn collect_range(
+        &self,
+        start: Bound<Vec<u8>>,
+        end: Bound<Vec<u8>>,
+        reverse: bool,
+    ) -> Result<Vec<KvPair>, FdbStorageError> {
+        self.db
+            .transact_boxed(
+                RangeRequest {
+                    prefix: self.prefix.clone(),
+                    start,
+                    end,
+                    reverse,
+                },
+                |tx, request| {
+                    Box::pin(async move {
+                        let mut cursor = make_cursor(
+                            &request.prefix,
+                            request.start.clone(),
+                            request.end.clone(),
+                            request.reverse,
+                        );
+                        let mut out = Vec::new();
+
+                        loop {
+                            let Some(opt) = cursor.opt.take() else {
+                                return Ok(out);
+                            };
+                            let values = tx.get_range(&opt, cursor.iteration, false).await?;
+                            cursor.iteration += 1;
+                            cursor.opt = opt.next_range(&values);
+
+                            for kv in values {
+                                let key = kv
+                                    .key()
+                                    .strip_prefix(request.prefix.as_slice())
+                                    .ok_or(FdbStorageError::PrefixViolation)?
+                                    .to_vec();
+                                out.push(KvPair {
+                                    key,
+                                    value: kv.value().to_vec(),
+                                });
+                            }
+                        }
+                    })
+                },
+                TransactOption::idempotent(),
+            )
+            .await
+    }
+
+    fn stream_from_pairs<'a>(mut pairs: VecDeque<KvPair>) -> KvStream<'a, FdbStorageError> {
+        KvStream::new(async move {
+            match pairs.pop_front() {
+                Some(pair) => Ok(Some((pair, Self::stream_from_pairs(pairs)))),
+                None => Ok(None),
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RangeRequest {
+    prefix: Vec<u8>,
+    start: Bound<Vec<u8>>,
+    end: Bound<Vec<u8>>,
+    reverse: bool,
+}
+
+fn prefix_key(prefix: &[u8], key: &[u8]) -> Vec<u8> {
+    let mut prefixed = Vec::with_capacity(prefix.len() + key.len());
+    prefixed.extend_from_slice(prefix);
+    prefixed.extend_from_slice(key);
+    prefixed
+}
+
+fn owned_bound(bound: Bound<&[u8]>) -> Bound<Vec<u8>> {
+    match bound {
+        Bound::Included(key) => Bound::Included(key.to_vec()),
+        Bound::Excluded(key) => Bound::Excluded(key.to_vec()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+fn start_selector(prefix: &[u8], bound: Bound<Vec<u8>>) -> KeySelector<'static> {
+    match bound {
+        Bound::Included(key) => KeySelector::first_greater_or_equal(prefix_key(prefix, &key)),
+        Bound::Excluded(key) => KeySelector::first_greater_than(prefix_key(prefix, &key)),
+        Bound::Unbounded => KeySelector::first_greater_or_equal(prefix.to_vec()),
+    }
+}
+
+fn end_selector(prefix: &[u8], bound: Bound<Vec<u8>>) -> KeySelector<'static> {
+    match bound {
+        Bound::Included(key) => KeySelector::first_greater_than(prefix_key(prefix, &key)),
+        Bound::Excluded(key) => KeySelector::first_greater_or_equal(prefix_key(prefix, &key)),
+        Bound::Unbounded => {
+            let next = next_prefix(prefix).unwrap_or_else(|| vec![0xFF]);
+            KeySelector::first_greater_or_equal(next)
+        }
+    }
+}
+
+fn first_greater_than_key(key: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(key.len() + 1);
+    out.extend_from_slice(key);
+    out.push(0x00);
+    out
+}
+
+fn clear_range_start_key(prefix: &[u8], bound: Bound<Vec<u8>>) -> Vec<u8> {
+    match bound {
+        Bound::Included(key) => prefix_key(prefix, &key),
+        Bound::Excluded(key) => first_greater_than_key(&prefix_key(prefix, &key)),
+        Bound::Unbounded => prefix.to_vec(),
+    }
+}
+
+fn clear_range_end_key(prefix: &[u8], bound: Bound<Vec<u8>>) -> Vec<u8> {
+    match bound {
+        Bound::Included(key) => first_greater_than_key(&prefix_key(prefix, &key)),
+        Bound::Excluded(key) => prefix_key(prefix, &key),
+        Bound::Unbounded => next_prefix(prefix).unwrap_or_else(|| vec![0xFF]),
+    }
+}
+
+fn make_cursor(
+    prefix: &[u8],
+    start: Bound<Vec<u8>>,
+    end: Bound<Vec<u8>>,
+    reverse: bool,
+) -> RangeCursor {
+    let mut opt = RangeOption::from((start_selector(prefix, start), end_selector(prefix, end)));
+    opt.reverse = reverse;
+    opt.mode = options::StreamingMode::Iterator;
+
+    RangeCursor {
+        opt: Some(opt),
+        iteration: 1,
+        buffered: VecDeque::new(),
+    }
+}
+
 #[async_trait::async_trait]
 impl KvStore for FdbTransaction {
     type Error = FdbStorageError;
 
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-        let key = self.prefix_key(key);
+        let key = prefix_key(&self.prefix, key);
         Ok(self.tx.get(&key, false).await?.map(|value| value.to_vec()))
     }
 
     async fn set(&mut self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
-        let key = self.prefix_key(key);
+        let key = prefix_key(&self.prefix, key);
         self.tx.set(&key, value);
         Ok(())
     }
 
     async fn delete(&mut self, key: &[u8]) -> Result<(), Self::Error> {
-        let key = self.prefix_key(key);
+        let key = prefix_key(&self.prefix, key);
         self.tx.clear(&key);
         Ok(())
     }
@@ -417,8 +565,8 @@ impl KvStore for FdbTransaction {
         end: Bound<&[u8]>,
         reverse: bool,
     ) -> KvStream<'a, Self::Error> {
-        let start = Self::owned_bound(start);
-        let end = Self::owned_bound(end);
+        let start = owned_bound(start);
+        let end = owned_bound(end);
         self.stream_from_cursor(self.make_cursor(start, end, reverse))
     }
 
@@ -427,12 +575,66 @@ impl KvStore for FdbTransaction {
         start: Bound<&[u8]>,
         end: Bound<&[u8]>,
     ) -> Result<(), Self::Error> {
-        let start = Self::owned_bound(start);
-        let end = Self::owned_bound(end);
-        let begin = self.clear_range_start_key(start);
-        let end = self.clear_range_end_key(end);
+        let start = owned_bound(start);
+        let end = owned_bound(end);
+        let begin = clear_range_start_key(&self.prefix, start);
+        let end = clear_range_end_key(&self.prefix, end);
         self.tx.clear_range(&begin, &end);
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl KvStore for FdbReadOnlyStore {
+    type Error = FdbStorageError;
+
+    async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.db
+            .transact_boxed(
+                (self.prefix.clone(), key.to_vec()),
+                |tx, data| {
+                    Box::pin(async move {
+                        let key = prefix_key(&data.0, &data.1);
+                        Ok(tx.get(&key, false).await?.map(|value| value.to_vec()))
+                    })
+                },
+                TransactOption::idempotent(),
+            )
+            .await
+    }
+
+    async fn set(&mut self, _key: &[u8], _value: &[u8]) -> Result<(), Self::Error> {
+        Err(FdbStorageError::ReadOnlyMutation)
+    }
+
+    async fn delete(&mut self, _key: &[u8]) -> Result<(), Self::Error> {
+        Err(FdbStorageError::ReadOnlyMutation)
+    }
+
+    fn range<'a>(
+        &'a self,
+        start: Bound<&[u8]>,
+        end: Bound<&[u8]>,
+        reverse: bool,
+    ) -> KvStream<'a, Self::Error> {
+        let store = self.clone();
+        let start = owned_bound(start);
+        let end = owned_bound(end);
+        KvStream::new(async move {
+            let mut pairs = VecDeque::from(store.collect_range(start, end, reverse).await?);
+            match pairs.pop_front() {
+                Some(pair) => Ok(Some((pair, FdbReadOnlyStore::stream_from_pairs(pairs)))),
+                None => Ok(None),
+            }
+        })
+    }
+
+    async fn clear_range(
+        &mut self,
+        _start: Bound<&[u8]>,
+        _end: Bound<&[u8]>,
+    ) -> Result<(), Self::Error> {
+        Err(FdbStorageError::ReadOnlyMutation)
     }
 }
 

--- a/crates/storage/fdb/src/lib.rs
+++ b/crates/storage/fdb/src/lib.rs
@@ -17,6 +17,7 @@ use foundationdb::{
     directory::{Directory, DirectoryError, DirectoryLayer, DirectoryOutput},
     options,
 };
+use mosaic_cac_types::RetryableStorageError;
 use mosaic_net_svc_api::PeerId;
 use mosaic_storage_api::{Commit, StorageProvider, StorageProviderError, StorageProviderMut};
 use mosaic_storage_kvstore::{
@@ -67,6 +68,16 @@ impl TryFrom<FdbStorageError> for FdbError {
         match value {
             FdbStorageError::Fdb(err) => Ok(err),
             other => Err(other),
+        }
+    }
+}
+
+impl RetryableStorageError for FdbStorageError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::Fdb(err) => err.is_retryable(),
+            Self::Commit(err) => err.is_retryable_not_committed(),
+            Self::Directory(_) | Self::PrefixViolation | Self::ReadOnlyMutation => false,
         }
     }
 }
@@ -229,7 +240,7 @@ impl StorageProvider for FdbStorageProvider {
             provider
                 .garbler_state_read_handle(peer_id)
                 .await
-                .map_err(|err| StorageProviderError::Other(err.to_string()))
+                .map_err(StorageProviderError::source)
         }
     }
 
@@ -245,7 +256,7 @@ impl StorageProvider for FdbStorageProvider {
             provider
                 .evaluator_state_read_handle(peer_id)
                 .await
-                .map_err(|err| StorageProviderError::Other(err.to_string()))
+                .map_err(StorageProviderError::source)
         }
     }
 }
@@ -265,7 +276,7 @@ impl StorageProviderMut for FdbStorageProvider {
             provider
                 .garbler_state_handle(peer_id)
                 .await
-                .map_err(|err| StorageProviderError::Other(err.to_string()))
+                .map_err(StorageProviderError::source)
         }
     }
 
@@ -281,7 +292,7 @@ impl StorageProviderMut for FdbStorageProvider {
             provider
                 .evaluator_state_handle(peer_id)
                 .await
-                .map_err(|err| StorageProviderError::Other(err.to_string()))
+                .map_err(StorageProviderError::source)
         }
     }
 }

--- a/crates/storage/inmemory/src/error.rs
+++ b/crates/storage/inmemory/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types for in-memory storage operations.
 
-use mosaic_cac_types::DepositId;
+use mosaic_cac_types::{DepositId, RetryableStorageError};
 use thiserror::Error;
 
 /// Errors that can occur during database operations.
@@ -37,5 +37,11 @@ impl DbError {
     /// Creates an invalid argument error.
     pub fn invalid_argument(s: impl Into<String>) -> Self {
         Self::InvalidArgument(s.into())
+    }
+}
+
+impl RetryableStorageError for DbError {
+    fn is_retryable(&self) -> bool {
+        false
     }
 }

--- a/crates/storage/kvstore/src/btreemap.rs
+++ b/crates/storage/kvstore/src/btreemap.rs
@@ -15,6 +15,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use mosaic_cac_types::RetryableStorageError;
 use mosaic_net_svc_api::PeerId;
 use mosaic_storage_api::{Commit, StorageProvider, StorageProviderMut, StorageProviderResult};
 
@@ -31,6 +32,12 @@ pub enum BTreeMapKvStoreError {
     /// The underlying lock was poisoned by a panic while held.
     #[error("btreemap store lock was poisoned")]
     PoisonedLock,
+}
+
+impl RetryableStorageError for BTreeMapKvStoreError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
 }
 
 /// In-memory key-value store using a `BTreeMap<Vec<u8>, Vec<u8>>`.

--- a/crates/storage/kvstore/src/kvstore.rs
+++ b/crates/storage/kvstore/src/kvstore.rs
@@ -2,6 +2,8 @@
 
 use std::{error::Error, fmt, fmt::Debug, ops::Bound, pin::Pin};
 
+use mosaic_cac_types::RetryableStorageError;
+
 /// A key-value pair returned from range scans.
 #[derive(Debug, Clone)]
 pub struct KvPair {
@@ -126,7 +128,7 @@ impl<'a, E> KvStream<'a, E> {
 #[async_trait::async_trait]
 pub trait KvStore: Send {
     /// The error type for this store.
-    type Error: Error + Debug + Send + Sync + 'static;
+    type Error: Error + RetryableStorageError + Debug + Send + Sync + 'static;
 
     /// Get a value by key.
     ///

--- a/crates/storage/kvstore/src/storage_error.rs
+++ b/crates/storage/kvstore/src/storage_error.rs
@@ -1,7 +1,7 @@
 //! Shared errors for KV-backed storage adapters.
 use std::error::Error;
 
-use mosaic_cac_types::DepositId;
+use mosaic_cac_types::{DepositId, RetryableStorageError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -20,8 +20,14 @@ pub enum StorageError {
     #[error("valuedeserialize: {0}")]
     ValueDeserialize(Box<dyn Error + Send + Sync>),
     /// Underlying KV backend error.
-    #[error("kvstore: {0}")]
-    KvStore(Box<dyn Error + Send + Sync>),
+    #[error("kvstore: {source}")]
+    KvStore {
+        /// Whether retrying the whole logical operation is safe.
+        retryable: bool,
+        /// Original backend error.
+        #[source]
+        source: Box<dyn Error + Send + Sync>,
+    },
     /// Received unexpected reserved index 0.
     #[error("Received unexpected Index(0)")]
     UnexpectedZeroIndex,
@@ -53,8 +59,11 @@ impl StorageError {
         Self::ValueDeserialize(Box::new(err))
     }
 
-    pub(crate) fn kvstore(err: impl Error + Send + Sync + 'static) -> Self {
-        Self::KvStore(Box::new(err))
+    pub(crate) fn kvstore(err: impl Error + RetryableStorageError + Send + Sync + 'static) -> Self {
+        Self::KvStore {
+            retryable: err.is_retryable(),
+            source: Box::new(err),
+        }
     }
 
     pub(crate) fn unknown_deposit(id: DepositId) -> Self {
@@ -67,5 +76,21 @@ impl StorageError {
 
     pub(crate) fn invalid_argument(s: impl Into<String>) -> Self {
         Self::InvalidArgument(s.into())
+    }
+}
+
+impl RetryableStorageError for StorageError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::KvStore { retryable, .. } => *retryable,
+            Self::KeyPack(_)
+            | Self::KeyUnpack(_)
+            | Self::ValueSerialize(_)
+            | Self::ValueDeserialize(_)
+            | Self::UnexpectedZeroIndex
+            | Self::UnknownDeposit(_)
+            | Self::StateInconsistency(_)
+            | Self::InvalidArgument(_) => false,
+        }
     }
 }


### PR DESCRIPTION
## Summary
- migrate Mosaic to `fasm` 0.4 and declare separate `RestoreState` types for the protocol state machines
- add read-only FDB state handles that open a fresh transaction per read call and use them for job execution and SM restore
- make `sm-executor` retry whole STF units on retryable storage failures instead of using ad hoc stale-transaction retry wrappers

Closes #176
Closes #177
Closes #178

## Commit stack
1. `build: migrate to fasm 0.4`
2. `storage/fdb: add read-only state handles`
3. `job/executors: remove stale transaction retries`
4. `sm-executor: restore from read-only state`
5. `sm-executor: retry stf units on retryable storage errors`

## Design
- jobs and restore now use read-only state access with fresh FDB transactions per method call
- STF apply remains on mutable state handles, but retries the whole logical STF unit when storage marks the failure as retryable
- `Commit` is preserved with the stronger contract that success means durable commit and error means no partial visible state

## Validation
- `cargo check -p mosaic-sm-executor -p mosaic-cac-protocol -p mosaic-cac-types -p mosaic-storage-api -p mosaic-storage-inmemory -p mosaic-storage-fdb -p mosaic-storage-kvstore`
- `cargo test -p mosaic-sm-executor --lib`
- `cargo test -p mosaic-storage-fdb`
- `cargo clippy -p mosaic-sm-executor -p mosaic-storage-fdb -p mosaic-storage-kvstore --tests --all-targets -- -D warnings`
- `cargo clippy -p mosaic-cac-protocol -p mosaic-cac-types -p mosaic-storage-api -p mosaic-storage-inmemory --tests --all-targets -- -D warnings`
- `cargo +nightly fmt --all --check`

Note: `cargo test -p mosaic-cac-protocol` reported all 24 unit tests green, but the process lingered on teardown in this environment after success output.
