### PR TITLE
mosaic: fail closed on critical thread exit

### DIFF
--- a/bin/mosaic/src/main.rs
+++ b/bin/mosaic/src/main.rs
@@ -6,7 +6,11 @@ mod rpc;
 use std::{
     env,
     path::PathBuf,
-    sync::{Arc, mpsc},
+    sync::{
+        Arc,
+        mpsc::{self, RecvTimeoutError},
+    },
+    time::Duration,
 };
 
 use anyhow::{Context, Result, bail};
@@ -43,8 +47,27 @@ fn main() -> Result<()> {
         .context("failed to build mosaic monoio runtime")?;
     let running = runtime.block_on(startup(config))?;
 
-    wait_for_shutdown_signal()?;
-    shutdown(running)
+    let reason = wait_for_shutdown_or_component_exit(&running)?;
+    match &reason {
+        ShutdownReason::Signal => tracing::info!("shutdown signal received"),
+        ShutdownReason::ComponentExited { component } => {
+            tracing::error!(
+                component = *component,
+                "critical component exited unexpectedly; shutting down mosaic"
+            );
+        }
+    }
+
+    let shutdown_result = shutdown(running);
+    match reason {
+        ShutdownReason::Signal => shutdown_result,
+        ShutdownReason::ComponentExited { component } => {
+            if let Err(error) = shutdown_result {
+                tracing::error!(component, error = ?error, "failed to fully shut down after critical component exit");
+            }
+            bail!("critical component exited unexpectedly: {component}")
+        }
+    }
 }
 
 struct RunningMosaic {
@@ -53,6 +76,11 @@ struct RunningMosaic {
     sm_executor_controller: SmExecutorController,
     _sm_executor_handle: SmExecutorHandle,
     rpc_controller: rpc::RpcController,
+}
+
+enum ShutdownReason {
+    Signal,
+    ComponentExited { component: &'static str },
 }
 
 async fn startup(config: MosaicConfig) -> Result<RunningMosaic> {
@@ -234,27 +262,86 @@ where
 }
 
 fn shutdown(running: RunningMosaic) -> Result<()> {
-    running
-        .rpc_controller
-        .shutdown()
-        .context("failed to shut down RPC server")?;
-    shutdown_net(running.net_controller)?;
-    shutdown_sm_executor(running.sm_executor_controller)?;
-    shutdown_job_scheduler(running.job_scheduler_controller)?;
+    let RunningMosaic {
+        net_controller,
+        job_scheduler_controller,
+        sm_executor_controller,
+        _sm_executor_handle: _,
+        rpc_controller,
+    } = running;
+
+    let mut first_error: Option<anyhow::Error> = None;
+
+    if let Err(error) = rpc_controller.shutdown() {
+        tracing::error!(error = ?error, "failed to shut down RPC server");
+        if first_error.is_none() {
+            first_error = Some(error.context("failed to shut down RPC server"));
+        }
+    }
+    if let Err(error) = shutdown_net(net_controller) {
+        tracing::error!(error = ?error, "failed to shut down net service");
+        if first_error.is_none() {
+            first_error = Some(error.context("failed to shut down net service"));
+        }
+    }
+    if let Err(error) = shutdown_sm_executor(sm_executor_controller) {
+        tracing::error!(error = ?error, "failed to shut down sm executor");
+        if first_error.is_none() {
+            first_error = Some(error.context("failed to shut down sm executor"));
+        }
+    }
+    if let Err(error) = shutdown_job_scheduler(job_scheduler_controller) {
+        tracing::error!(error = ?error, "failed to shut down job scheduler");
+        if first_error.is_none() {
+            first_error = Some(error.context("failed to shut down job scheduler"));
+        }
+    }
+
+    if let Some(error) = first_error {
+        return Err(error);
+    }
+
     tracing::info!("mosaic shutdown complete");
     Ok(())
 }
 
-fn wait_for_shutdown_signal() -> Result<()> {
+fn wait_for_shutdown_or_component_exit(running: &RunningMosaic) -> Result<ShutdownReason> {
     let (tx, rx) = mpsc::sync_channel(1);
     ctrlc::set_handler(move || {
         let _ = tx.send(());
     })
     .context("failed to install shutdown signal handler")?;
-    rx.recv()
-        .context("failed while waiting for shutdown signal")?;
-    tracing::info!("shutdown signal received");
-    Ok(())
+
+    loop {
+        match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(()) => return Ok(ShutdownReason::Signal),
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => {
+                bail!("failed while waiting for shutdown signal")
+            }
+        }
+
+        if !running.rpc_controller.is_running() {
+            return Ok(ShutdownReason::ComponentExited {
+                component: "rpc_server",
+            });
+        }
+        if !running.net_controller.is_running() {
+            return Ok(ShutdownReason::ComponentExited {
+                component: "net_service",
+            });
+        }
+        if !running.sm_executor_controller.is_running() {
+            return Ok(ShutdownReason::ComponentExited {
+                component: "sm_executor",
+            });
+        }
+        if !running.job_scheduler_controller.is_running() {
+            return Ok(ShutdownReason::ComponentExited {
+                component: "job_scheduler",
+            });
+        }
+    }
 }
 
 fn shutdown_net(controller: mosaic_net_svc::NetServiceController) -> Result<()> {

--- a/bin/mosaic/src/rpc.rs
+++ b/bin/mosaic/src/rpc.rs
@@ -32,6 +32,14 @@ impl RpcController {
         tracing::info!("RPC server shut down");
         Ok(())
     }
+
+    /// Check whether the RPC server thread is still running.
+    pub(crate) fn is_running(&self) -> bool {
+        self.thread_handle
+            .as_ref()
+            .map(|h| !h.is_finished())
+            .unwrap_or(false)
+    }
 }
 
 /// Start the RPC server on a dedicated tokio thread.

--- a/crates/job/scheduler/src/garbling/mod.rs
+++ b/crates/job/scheduler/src/garbling/mod.rs
@@ -48,7 +48,13 @@
 //! [`CircuitAction`]: mosaic_job_api::CircuitAction
 //! [`Arc<OwnedChunk>`]: mosaic_job_api::OwnedChunk
 
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    panic::{AssertUnwindSafe, catch_unwind},
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
+};
 
 use ckt_fmtv5_types::v5::c::{Block, ReaderV5c, get_block_num_gates};
 use mosaic_job_api::{
@@ -59,6 +65,16 @@ use mosaic_net_svc_api::PeerId;
 use tracing::Instrument;
 
 use crate::SchedulerFault;
+
+fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
+    match payload.downcast::<String>() {
+        Ok(message) => *message,
+        Err(payload) => match payload.downcast::<&'static str>() {
+            Ok(message) => (*message).to_string(),
+            Err(_) => "thread panicked".to_string(),
+        },
+    }
+}
 
 /// Size of each v5c gate record in bytes (3 × u32).
 const GATE_SIZE: usize = 12;
@@ -169,20 +185,37 @@ struct WorkerHandle {
 
 impl WorkerHandle {
     /// Spawn a new worker thread with its own monoio runtime.
-    fn spawn(id: usize, chunk_timeout: Duration) -> Self {
+    fn spawn(
+        id: usize,
+        chunk_timeout: Duration,
+        fault_tx: kanal::AsyncSender<SchedulerFault>,
+    ) -> Self {
         // Bounded channels: main sends at most 1 command before waiting for
         // a report, so capacity 2 provides adequate headroom.
         let (command_tx, command_rx) = kanal::bounded_async(2);
         let (report_tx, report_rx) = kanal::bounded_async(2);
 
+        let thread_name = format!("garbling-worker-{id}");
         let thread = std::thread::Builder::new()
-            .name(format!("garbling-worker-{id}"))
+            .name(thread_name.clone())
             .spawn(move || {
-                monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
-                    .enable_timer()
-                    .build()
-                    .expect("failed to build monoio runtime for garbling worker")
-                    .block_on(worker_loop(id, chunk_timeout, command_rx, report_tx));
+                let run_result = catch_unwind(AssertUnwindSafe(|| {
+                    monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
+                        .enable_timer()
+                        .build()
+                        .expect("failed to build monoio runtime for garbling worker")
+                        .block_on(worker_loop(id, chunk_timeout, command_rx, report_tx));
+                }));
+
+                if let Err(payload) = run_result {
+                    let reason = panic_payload_to_string(payload);
+                    tracing::error!(worker = id, %reason, "garbling worker thread exited due to panic");
+                    let _ = fault_tx.to_sync().send(SchedulerFault::ThreadExited {
+                        source: "garbling_worker",
+                        thread: thread_name,
+                        reason,
+                    });
+                }
             })
             .expect("failed to spawn garbling worker thread");
 
@@ -269,20 +302,33 @@ impl GarblingCoordinator {
     ) -> Self {
         let (submit_tx, submit_rx) = kanal::bounded_async(config.max_concurrent * 2);
 
+        let coordinator_thread_name = "garbling-coordinator".to_string();
         let thread = std::thread::Builder::new()
-            .name("garbling-coordinator".into())
+            .name(coordinator_thread_name.clone())
             .spawn(move || {
-                monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
-                    .enable_timer()
-                    .build()
-                    .expect("failed to build monoio runtime for garbling coordinator")
-                    .block_on(coordinator_loop(
-                        config,
-                        factory,
-                        submit_rx,
-                        completion_tx,
-                        fault_tx,
-                    ));
+                let run_result = catch_unwind(AssertUnwindSafe(|| {
+                    monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
+                        .enable_timer()
+                        .build()
+                        .expect("failed to build monoio runtime for garbling coordinator")
+                        .block_on(coordinator_loop(
+                            config,
+                            factory,
+                            submit_rx,
+                            completion_tx,
+                            fault_tx.clone(),
+                        ));
+                }));
+
+                if let Err(payload) = run_result {
+                    let reason = panic_payload_to_string(payload);
+                    tracing::error!(%reason, "garbling coordinator thread exited due to panic");
+                    let _ = fault_tx.to_sync().send(SchedulerFault::ThreadExited {
+                        source: "garbling_coordinator",
+                        thread: coordinator_thread_name,
+                        reason,
+                    });
+                }
             })
             .expect("failed to spawn garbling coordinator thread");
 
@@ -340,7 +386,7 @@ async fn coordinator_loop(
         // Spawn persistent worker threads.
         let n_workers = config.worker_threads.max(1);
         let mut workers: Vec<WorkerHandle> = (0..n_workers)
-            .map(|id| WorkerHandle::spawn(id, config.chunk_timeout))
+            .map(|id| WorkerHandle::spawn(id, config.chunk_timeout, fault_tx.clone()))
             .collect();
 
         tracing::info!(

--- a/crates/job/scheduler/src/lib.rs
+++ b/crates/job/scheduler/src/lib.rs
@@ -22,11 +22,16 @@ pub(crate) mod priority;
 
 use mosaic_net_svc_api::PeerId;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) enum SchedulerFault {
     CompletionChannelClosed {
         source: &'static str,
         peer_id: PeerId,
+    },
+    ThreadExited {
+        source: &'static str,
+        thread: String,
+        reason: String,
     },
 }
 

--- a/crates/job/scheduler/src/pool/worker.rs
+++ b/crates/job/scheduler/src/pool/worker.rs
@@ -10,7 +10,11 @@
 //! ensures one unresponsive peer cannot monopolise worker slots — other peers'
 //! jobs get a chance to run between retries.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::Arc,
+    time::Duration,
+};
 
 use mosaic_cac_types::state_machine::{
     evaluator::Action as EvaluatorAction, garbler::Action as GarblerAction,
@@ -105,21 +109,35 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> Worker<D> {
         fault_tx: kanal::AsyncSender<SchedulerFault>,
         concurrency: usize,
     ) -> Self {
+        let thread_name = format!("worker-{id}");
         let handle = std::thread::Builder::new()
-            .name(format!("worker-{id}"))
+            .name(thread_name.clone())
             .spawn(move || {
-                monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
-                    .enable_timer()
-                    .build()
-                    .expect("failed to build monoio runtime")
-                    .block_on(worker_loop(
-                        id,
-                        dispatcher,
-                        queue,
-                        completion_tx,
-                        fault_tx,
-                        concurrency,
-                    ));
+                let run_result = catch_unwind(AssertUnwindSafe(|| {
+                    monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
+                        .enable_timer()
+                        .build()
+                        .expect("failed to build monoio runtime")
+                        .block_on(worker_loop(
+                            id,
+                            dispatcher,
+                            Arc::clone(&queue),
+                            completion_tx,
+                            fault_tx.clone(),
+                            concurrency,
+                        ));
+                }));
+
+                if let Err(payload) = run_result {
+                    let reason = panic_payload_to_string(payload);
+                    tracing::error!(worker = id, %reason, "worker thread exited due to panic");
+                    queue.close();
+                    let _ = fault_tx.to_sync().send(SchedulerFault::ThreadExited {
+                        source: "pool_worker",
+                        thread: thread_name,
+                        reason,
+                    });
+                }
             })
             .expect("failed to spawn worker thread");
 
@@ -139,6 +157,16 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> Worker<D> {
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
         }
+    }
+}
+
+fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
+    match payload.downcast::<String>() {
+        Ok(message) => *message,
+        Err(payload) => match payload.downcast::<&'static str>() {
+            Ok(message) => (*message).to_string(),
+            Err(_) => "worker thread panicked".to_string(),
+        },
     }
 }
 

--- a/crates/job/scheduler/src/scheduler.rs
+++ b/crates/job/scheduler/src/scheduler.rs
@@ -99,6 +99,14 @@ impl JobSchedulerController {
 
         Ok(())
     }
+
+    /// Check whether the scheduler thread is still running.
+    pub fn is_running(&self) -> bool {
+        self.thread_handle
+            .as_ref()
+            .map(|h| !h.is_finished())
+            .unwrap_or(false)
+    }
 }
 
 impl Drop for JobSchedulerController {
@@ -226,6 +234,15 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                                 source,
                                 peer = ?peer_id,
                                 "job scheduler completion delivery failed; shutting down fail-closed"
+                            );
+                            break;
+                        }
+                        Ok(SchedulerFault::ThreadExited { source, thread, reason }) => {
+                            tracing::error!(
+                                source,
+                                %thread,
+                                %reason,
+                                "job scheduler thread dependency exited unexpectedly; shutting down fail-closed"
                             );
                             break;
                         }

--- a/crates/sm-executor/src/lib.rs
+++ b/crates/sm-executor/src/lib.rs
@@ -169,6 +169,14 @@ impl SmExecutorController {
 
         Ok(())
     }
+
+    /// Check whether the executor thread is still running.
+    pub fn is_running(&self) -> bool {
+        self.thread_handle
+            .as_ref()
+            .map(|h| !h.is_finished())
+            .unwrap_or(false)
+    }
 }
 
 impl Drop for SmExecutorController {


### PR DESCRIPTION
## Summary

Fail closed when a critical Mosaic thread exits unexpectedly instead of leaving the process running in a degraded state.

Closes #181.

## What changed

- propagate scheduler pool worker panics as fatal scheduler faults
- propagate garbling worker and garbling coordinator panics as fatal scheduler faults
- expose controller liveness checks for `rpc`, `sm-executor`, and `job-scheduler`
- make `bin/mosaic` wait on either shutdown signal or unexpected critical component exit
- on unexpected exit, perform best-effort shutdown of the remaining components and return an error

## Behavior

After this change:

- internal scheduler worker/coordinator thread death bubbles up to the scheduler
- unexpected exit of `rpc`, `net-svc`, `sm-executor`, or `job-scheduler` causes Mosaic to shut down and exit nonzero
- one dead component no longer prevents best-effort shutdown of the others

## Validation

- `cargo check -p mosaic -p mosaic-job-scheduler -p mosaic-sm-executor -p mosaic-net-svc`
- `cargo +nightly fmt --all --check`
- `cargo clippy -p mosaic -p mosaic-job-scheduler -p mosaic-sm-executor -p mosaic-net-svc --all-targets -- -D warnings`
