### PR TITLE
net/client: bound worker-side send stalls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ fuzz-*.log
 # Docker volume data
 docker/vol/fdb/data/
 docker/vol/mosaic-*/tables/
+
+# local scratch docs
+tmp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2447,9 @@ version = "0.1.0"
 dependencies = [
  "ark-serialize",
  "ed25519-dalek",
+ "futures-timer",
+ "futures-util",
+ "monoio",
  "mosaic-cac-types",
  "mosaic-net-svc",
  "mosaic-net-svc-api",

--- a/crates/job/scheduler/src/pool/worker.rs
+++ b/crates/job/scheduler/src/pool/worker.rs
@@ -50,6 +50,29 @@ fn retry_backoff(attempts: u32) -> Duration {
     backoff.min(RETRY_BACKOFF_MAX)
 }
 
+/// Releases a worker permit back to the pool when the spawned task exits.
+///
+/// This makes permit release robust against early returns and task panics.
+struct PermitGuard {
+    permit_tx: Option<kanal::Sender<()>>,
+}
+
+impl PermitGuard {
+    fn new(permit_tx: kanal::Sender<()>) -> Self {
+        Self {
+            permit_tx: Some(permit_tx),
+        }
+    }
+}
+
+impl Drop for PermitGuard {
+    fn drop(&mut self) {
+        if let Some(permit_tx) = self.permit_tx.take() {
+            let _ = permit_tx.try_send(());
+        }
+    }
+}
+
 /// A job descriptor that lives in the shared queue.
 ///
 /// Contains the action to execute and the peer it belongs to. The worker
@@ -227,6 +250,7 @@ async fn worker_loop<D: ExecuteGarblerJob + ExecuteEvaluatorJob>(
             //    whether it succeeded or was requeued for retry.
             monoio::spawn(
                 async move {
+                    let _permit = PermitGuard::new(permit_tx);
                     tracing::trace!("executing worker job");
                     let result = execute_job(dispatcher.as_ref(), &pool_job).await;
                     match result {
@@ -260,8 +284,6 @@ async fn worker_loop<D: ExecuteGarblerJob + ExecuteEvaluatorJob>(
                             queue.requeue(job);
                         }
                     }
-                    // Release permit back to the pool.
-                    let _ = permit_tx.send(());
                 }
                 .instrument(tracing::debug_span!(
                     "job_scheduler.worker_job",

--- a/crates/net/client/Cargo.toml
+++ b/crates/net/client/Cargo.toml
@@ -18,6 +18,10 @@ ark-serialize = { workspace = true }
 # Error handling
 thiserror = { workspace = true }
 
+# Runtime-agnostic timeout support
+futures-util = "0.3"
+futures-timer = "3"
+
 # Async runtime for timeouts
 tokio = { version = "1", features = ["time"] }
 
@@ -32,6 +36,7 @@ tokio = { version = "1", features = [
   "macros",
   "time",
 ] }
+monoio = { version = "0.2", features = ["sync"] }
 
 # Cryptography for test key generation
 ed25519-dalek = "2.2"

--- a/crates/net/client/src/lib.rs
+++ b/crates/net/client/src/lib.rs
@@ -64,6 +64,11 @@ use std::{
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
 pub use bulk::{BulkExpectation, BulkReceiver, BulkSender};
 pub use error::{AckError, BulkExpectError, BulkOpenError, BulkReceiveError, RecvError, SendError};
+use futures_util::{
+    FutureExt,
+    future::{Either, select},
+    pin_mut,
+};
 use mosaic_cac_types::Msg;
 use mosaic_net_svc::{FrameLimits, NetServiceHandle};
 pub use protocol::{Ack, InboundRequest, PeerId, StreamPriority};
@@ -184,7 +189,7 @@ impl NetClient {
         let msg: Msg = msg.into();
 
         // Open protocol stream with normal priority
-        let mut stream = match timeout_if_tokio_runtime(
+        let mut stream = match timeout_in_any_runtime(
             self.config.open_timeout,
             self.handle
                 .open_protocol_stream(peer, StreamPriority::Normal.as_i32()),
@@ -221,7 +226,7 @@ impl NetClient {
         let written_at = started.elapsed();
 
         // Wait for ack (empty response)
-        let _ack = match timeout_if_tokio_runtime(self.config.ack_timeout, stream.read()).await {
+        let _ack = match timeout_in_any_runtime(self.config.ack_timeout, stream.read()).await {
             Ok(Ok(ack)) => ack,
             Ok(Err(err)) => return Err(SendError::NoAck(err)),
             Err(TimeoutElapsed) => {
@@ -308,20 +313,20 @@ fn deserialize(bytes: &[u8]) -> Result<Msg, ark_serialize::SerializationError> {
 /// Marker error used when a tokio timeout elapses.
 struct TimeoutElapsed;
 
-/// Apply a timeout when running inside a tokio runtime.
+/// Apply a runtime-agnostic timeout.
 ///
-/// When no tokio runtime is present (for example, monoio worker threads),
-/// this awaits the future directly without enforcing a timeout.
-async fn timeout_if_tokio_runtime<T>(
+/// This keeps `NetClient::send()` futures `Send`, unlike embedding a
+/// monoio-specific timer future directly in the public future type.
+async fn timeout_in_any_runtime<T>(
     duration: Duration,
     fut: impl Future<Output = T>,
 ) -> Result<T, TimeoutElapsed> {
-    if tokio::runtime::Handle::try_current().is_ok() {
-        tokio::time::timeout(duration, fut)
-            .await
-            .map_err(|_| TimeoutElapsed)
-    } else {
-        Ok(fut.await)
+    let fut = fut.map(Ok::<T, TimeoutElapsed>);
+    let timeout = futures_timer::Delay::new(duration).map(|_| Err(TimeoutElapsed));
+    pin_mut!(fut);
+    pin_mut!(timeout);
+    match select(fut, timeout).await {
+        Either::Left((result, _)) | Either::Right((result, _)) => result,
     }
 }
 

--- a/crates/net/client/tests/integration.rs
+++ b/crates/net/client/tests/integration.rs
@@ -19,6 +19,8 @@ mod port_allocator;
 
 use ark_serialize as _;
 use ed25519_dalek as _;
+use futures_timer as _;
+use futures_util as _;
 use mosaic_net_svc_api as _;
 use mosaic_vs3 as _;
 use rand as _;
@@ -222,6 +224,18 @@ where
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .worker_threads(2)
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+fn run_monoio<F, T>(f: F) -> T
+where
+    F: std::future::Future<Output = T> + 'static,
+    T: Send + 'static,
+{
+    monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
+        .enable_timer()
         .build()
         .unwrap()
         .block_on(f)
@@ -700,6 +714,54 @@ fn test_send_times_out_without_ack() {
             .await
             .expect("send task join timed out")
             .expect("send task panicked");
+
+        match result {
+            Err(SendError::NoAck(_)) => {}
+            Ok(_) => panic!("expected NoAck error, got Ok"),
+            Err(other) => panic!("expected NoAck error, got {:?}", other),
+        }
+    });
+}
+
+#[test]
+fn test_send_times_out_without_ack_on_monoio() {
+    let ack_timeout = Duration::from_millis(200);
+    let config = NetClientConfig {
+        open_timeout: Duration::from_secs(2),
+        ack_timeout,
+    };
+    let (peer_a, peer_b) = create_client_pair_with_config(config);
+
+    run_async(async {
+        stabilize_stream_path(&peer_a, &peer_b).await;
+
+        let msg = make_challenge_msg(42);
+        let peer_b_id = peer_b.peer_id();
+        let client_a = peer_a.client.clone();
+        let handle_b = peer_b.client.handle().clone();
+        let (result_tx, result_rx) = mpsc::sync_channel(1);
+
+        std::thread::spawn(move || {
+            let result = run_monoio(async move { client_a.send(peer_b_id, msg).await });
+            let _ = result_tx.send(result);
+        });
+
+        // Receive raw stream but do not ack it.
+        let mut stream =
+            match tokio::time::timeout(Duration::from_secs(10), handle_b.protocol_streams().recv())
+                .await
+            {
+                Ok(Ok(stream)) => stream,
+                Ok(Err(e)) => panic!("recv failed before stream arrived: {:?}", e),
+                Err(_) => panic!("timed out waiting for raw stream"),
+            };
+        let _bytes = stream.read().await.expect("read failed");
+
+        tokio::time::sleep(ack_timeout.saturating_mul(2)).await;
+
+        let result = result_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("send thread did not return before timeout");
 
         match result {
             Err(SendError::NoAck(_)) => {}


### PR DESCRIPTION
## Summary
- make `NetClient::send()` enforce open and ack deadlines on monoio workers as well as Tokio callers
- add a permit guard so worker permits are released on panic and early exit
- add a monoio regression test proving sender-side ack timeouts now fire on worker runtimes

## Issues
Closes #183.
Refs #190.

## Validation
- `cargo test -p mosaic-net-client -p mosaic-job-scheduler`
- `cargo check -p mosaic -p mosaic-net-client -p mosaic-job-scheduler`
- `cargo clippy -p mosaic-net-client -p mosaic-job-scheduler -p mosaic --tests --all-targets -- -D warnings`
- `cargo +nightly fmt --all --check`

## Notes
- This PR intentionally does not add a generic worker execution timeout.
- `ReceiveGarblingTable` stall handling remains in the separate bulk-transfer hardening work.
