### PR TITLE
job/executors: harden garbling table receive path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,5 @@ docker/vol/fdb/data/
 docker/vol/mosaic-*/tables/
 
 # local scratch docs
+# Local analysis notes
 tmp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,6 +2437,7 @@ dependencies = [
  "ckt-gobble",
  "futures",
  "futures-timer",
+ "kanal",
  "mosaic-cac-types",
  "mosaic-common",
  "mosaic-heap-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,8 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/cac/protocol/src/tests.rs
+++ b/crates/cac/protocol/src/tests.rs
@@ -1512,11 +1512,17 @@ async fn test_e2e() {
                 .map(|commitment| {
                     let c = *commitment;
                     async move {
-                        let outcome = exec_ref.receive_garbling_table(&peer, c).await;
-                        match outcome {
-                            HandlerOutcome::Done(completion) => completion,
-                            other => panic!("expected Done, got {:?}", other),
+                        // Retry transient failures
+                        for _ in 0..100 {
+                            match exec_ref.receive_garbling_table(&peer, c).await {
+                                HandlerOutcome::Done(completion) => return completion,
+                                HandlerOutcome::Retry => {
+                                    tokio::time::sleep(Duration::from_millis(50)).await;
+                                    continue;
+                                }
+                            }
                         }
+                        panic!("receive_garbling_table still retrying after 100 attempts");
                     }
                 })
                 .collect();

--- a/crates/job/executors/Cargo.toml
+++ b/crates/job/executors/Cargo.toml
@@ -33,5 +33,9 @@ rand.workspace = true
 rand_chacha.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+thiserror.workspace = true
+tokio = { version = "1.50.0", features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/crates/job/executors/Cargo.toml
+++ b/crates/job/executors/Cargo.toml
@@ -27,6 +27,7 @@ ckt-fmtv5-types.workspace = true
 ckt-gobble.workspace = true
 futures = "0.3"
 futures-timer = "3"
+kanal.workspace = true
 parking_lot = "0.12"
 rand.workspace = true
 rand_chacha.workspace = true

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -1,5 +1,7 @@
 //! Executors for evaluator state machine actions.
 
+use std::time::{Duration, Instant};
+
 use bitvec::vec::BitVec;
 use ckt_fmtv5_types::v5::c::ReaderV5c;
 use ckt_gobble::{
@@ -18,6 +20,7 @@ use mosaic_common::constants::{
 };
 use mosaic_heap_array::HeapArray;
 use mosaic_job_api::{ActionCompletion, CircuitError, HandlerOutcome};
+use mosaic_net_client::{BulkReadError, BulkReceiveError};
 use mosaic_net_svc_api::PeerId;
 use mosaic_storage_api::{
     StorageProvider,
@@ -31,6 +34,11 @@ use crate::{
     circuit_sessions::{CiphertextReaderAdapter, EvaluationSession},
     garbling::{compute_commitment, hash_garbling_params},
 };
+
+const BULK_OPEN_WARN_AFTER: Duration = Duration::from_secs(5);
+const BULK_OPEN_TIMEOUT: Duration = Duration::from_secs(30);
+const BULK_READ_WARN_AFTER: Duration = Duration::from_secs(5);
+const BULK_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Build a successful evaluator completion from an action ID and result.
 fn completed(id: ActionId, result: ActionResult) -> HandlerOutcome {
@@ -243,6 +251,13 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
         return HandlerOutcome::Retry;
     };
     let index = eval_indices[pos];
+    let expected_ciphertext_bytes = match ctx.expected_table_ciphertext_bytes().await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            warn!(%peer_id, ?index, ?e, "failed to compute expected ciphertext length for receive_garbling_table");
+            return HandlerOutcome::Retry;
+        }
+    };
 
     // Register to receive the bulk transfer using the commitment as identifier.
     let identifier: [u8; 32] = expected_commitment
@@ -268,9 +283,33 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
     }
 
     // Wait for the garbler to open the stream.
-    let Ok(mut stream) = expectation.recv().await else {
-        warn!(%peer_id, "bulk stream receive failed for receive_garbling_table");
-        return HandlerOutcome::Retry;
+    let open_started = Instant::now();
+    let mut stream = match expectation.recv_with_timeout(BULK_OPEN_TIMEOUT).await {
+        Ok(stream) => {
+            let elapsed = open_started.elapsed();
+            if elapsed >= BULK_OPEN_WARN_AFTER {
+                warn!(
+                    %peer_id,
+                    ?index,
+                    ?elapsed,
+                    "bulk stream open was slower than expected for receive_garbling_table"
+                );
+            }
+            stream
+        }
+        Err(BulkReceiveError::TimedOut) => {
+            warn!(
+                %peer_id,
+                ?index,
+                timeout = ?BULK_OPEN_TIMEOUT,
+                "timed out waiting for bulk stream in receive_garbling_table"
+            );
+            return HandlerOutcome::Retry;
+        }
+        Err(BulkReceiveError::Closed) => {
+            warn!(%peer_id, ?index, "bulk stream receive failed for receive_garbling_table");
+            return HandlerOutcome::Retry;
+        }
     };
 
     // The garbler sends: translation bytes first, then ciphertext data.
@@ -293,11 +332,35 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
     let mut ct_hasher = blake3::Hasher::new();
     let mut translation_buf = Vec::with_capacity(translation_size);
     let mut translation_remaining = translation_size;
+    let mut ciphertext_bytes_received = 0usize;
 
     loop {
-        let chunk = match stream.read().await {
-            Ok(data) => data,
-            Err(_closed) => break,
+        let read_started = Instant::now();
+        let chunk = match stream.read_with_timeout(BULK_READ_TIMEOUT).await {
+            Ok(data) => {
+                let elapsed = read_started.elapsed();
+                if elapsed >= BULK_READ_WARN_AFTER {
+                    warn!(
+                        %peer_id,
+                        ?index,
+                        ?elapsed,
+                        "bulk stream read was slower than expected for receive_garbling_table"
+                    );
+                }
+                data
+            }
+            Err(BulkReadError::TimedOut) => {
+                warn!(
+                    %peer_id,
+                    ?index,
+                    timeout = ?BULK_READ_TIMEOUT,
+                    "timed out waiting for bulk payload in receive_garbling_table"
+                );
+                stream.reset(0).await;
+                let _ = ctx.table_store.delete(&table_id).await;
+                return HandlerOutcome::Retry;
+            }
+            Err(BulkReadError::Closed(_closed)) => break,
         };
 
         if chunk.is_empty() {
@@ -315,6 +378,20 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
 
             // Any overflow goes to ciphertext.
             if !ct_part.is_empty() {
+                let next_ciphertext_bytes = ciphertext_bytes_received + ct_part.len();
+                if next_ciphertext_bytes > expected_ciphertext_bytes {
+                    error!(
+                        %peer_id,
+                        ?index,
+                        received = next_ciphertext_bytes,
+                        expected = expected_ciphertext_bytes,
+                        "received oversized ciphertext stream for receive_garbling_table"
+                    );
+                    stream.reset(0).await;
+                    let _ = ctx.table_store.delete(&table_id).await;
+                    return HandlerOutcome::Retry;
+                }
+                ciphertext_bytes_received = next_ciphertext_bytes;
                 ct_hasher.update(ct_part);
                 if writer.write_ciphertext(ct_part).await.is_err() {
                     error!(%peer_id, "ciphertext write failed (translation overflow) for receive_garbling_table");
@@ -324,6 +401,20 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
             }
         } else {
             // All translation received — remaining data is ciphertext.
+            let next_ciphertext_bytes = ciphertext_bytes_received + chunk.len();
+            if next_ciphertext_bytes > expected_ciphertext_bytes {
+                error!(
+                    %peer_id,
+                    ?index,
+                    received = next_ciphertext_bytes,
+                    expected = expected_ciphertext_bytes,
+                    "received oversized ciphertext stream for receive_garbling_table"
+                );
+                stream.reset(0).await;
+                let _ = ctx.table_store.delete(&table_id).await;
+                return HandlerOutcome::Retry;
+            }
+            ciphertext_bytes_received = next_ciphertext_bytes;
             ct_hasher.update(&chunk);
             if writer.write_ciphertext(&chunk).await.is_err() {
                 error!(%peer_id, "ciphertext write failed for receive_garbling_table");
@@ -336,6 +427,17 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
     // Verify we received enough translation data.
     if translation_remaining > 0 {
         error!(%peer_id, translation_remaining, "incomplete translation data for receive_garbling_table");
+        let _ = ctx.table_store.delete(&table_id).await;
+        return HandlerOutcome::Retry;
+    }
+    if ciphertext_bytes_received != expected_ciphertext_bytes {
+        error!(
+            %peer_id,
+            ?index,
+            received = ciphertext_bytes_received,
+            expected = expected_ciphertext_bytes,
+            "ciphertext length mismatch for receive_garbling_table"
+        );
         let _ = ctx.table_store.delete(&table_id).await;
         return HandlerOutcome::Retry;
     }

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -398,6 +398,9 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
                     let _ = ctx.table_store.delete(&table_id).await;
                     return HandlerOutcome::Retry;
                 }
+                if ciphertext_bytes_received == expected_ciphertext_bytes {
+                    break;
+                }
             }
         } else {
             // All translation received — remaining data is ciphertext.
@@ -420,6 +423,9 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
                 error!(%peer_id, "ciphertext write failed for receive_garbling_table");
                 let _ = ctx.table_store.delete(&table_id).await;
                 return HandlerOutcome::Retry;
+            }
+            if ciphertext_bytes_received == expected_ciphertext_bytes {
+                break;
             }
         }
     }

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -398,9 +398,12 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
                     let _ = ctx.table_store.delete(&table_id).await;
                     return HandlerOutcome::Retry;
                 }
-                if ciphertext_bytes_received == expected_ciphertext_bytes {
-                    break;
-                }
+                // Don't break on `ciphertext_bytes_received == expected`:
+                // continue the loop so any trailing bytes from a buggy or
+                // malicious sender are caught by the `>` check above
+                // instead of being silently accepted. The loop exits via
+                // the existing branches at the top: `Closed` (FIN), an
+                // empty chunk, or the read timeout.
             }
         } else {
             // All translation received — remaining data is ciphertext.
@@ -424,9 +427,10 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
                 let _ = ctx.table_store.delete(&table_id).await;
                 return HandlerOutcome::Retry;
             }
-            if ciphertext_bytes_received == expected_ciphertext_bytes {
-                break;
-            }
+            // See above: keep reading rather than break on equality, so
+            // any trailing bytes are caught by the `>` check on the next
+            // chunk. Normal termination is the `Closed` / empty-chunk
+            // branches at the top of the loop.
         }
     }
 

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -210,6 +210,177 @@ pub(crate) async fn handle_verify_opened_input_shares<SP: StorageProvider, TS: T
 // Network handler (E4 — pool action, not circuit session)
 // ============================================================================
 
+/// Minimal stream interface used by [`drain_table_payload`]. Lets tests inject
+/// a scripted chunk source without spinning up a real QUIC stream.
+trait PayloadStream {
+    async fn read_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<mosaic_net_svc_api::PayloadBuf, BulkReadError>;
+}
+
+impl PayloadStream for mosaic_net_client::BulkReceiver {
+    async fn read_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<mosaic_net_svc_api::PayloadBuf, BulkReadError> {
+        mosaic_net_client::BulkReceiver::read_with_timeout(self, timeout).await
+    }
+}
+
+/// Outcome of [`drain_table_payload`]. The caller maps these onto
+/// `HandlerOutcome` + stream/store cleanup; the helper itself is I/O-free
+/// beyond the trait read.
+#[derive(Debug)]
+enum DrainOutcome {
+    /// Stream sent exactly `translation_size + expected_ciphertext_bytes`
+    /// bytes followed by FIN (or an empty frame), and every chunk was
+    /// successfully forwarded to the writer.
+    Complete {
+        translation_buf: Vec<u8>,
+        translate_hash: blake3::Hash,
+        ct_hash: blake3::Hash,
+    },
+    /// Stream sent more ciphertext bytes than the circuit header allowed.
+    OversizedCiphertext { received: usize, expected: usize },
+    /// Stream closed before all translation bytes were received.
+    TranslationIncomplete { remaining: usize },
+    /// Stream closed cleanly but the ciphertext count was short.
+    LengthMismatch { received: usize, expected: usize },
+    /// Writer rejected a chunk.
+    WriteFailed {
+        /// `true` if the failing chunk was the ciphertext spill-over from the
+        /// same frame that completed the translation segment; `false` for a
+        /// steady-state ciphertext chunk. Preserved so the caller can keep
+        /// the two paths distinguishable in logs/alerting.
+        during_translation_overflow: bool,
+    },
+    /// `read_with_timeout` returned `TimedOut` before the next chunk arrived.
+    ReadTimedOut,
+}
+
+/// Consume a bulk stream carrying translation bytes followed by ciphertext
+/// bytes, hashing each domain and forwarding the ciphertext to `writer`.
+///
+/// Termination is via:
+/// - `BulkReadError::Closed` (FIN) → fall through to the post-loop length checks; either
+///   `Complete`, `TranslationIncomplete`, or `LengthMismatch`.
+/// - Empty chunk → treated as Closed.
+/// - `BulkReadError::TimedOut` → returns `ReadTimedOut` immediately.
+/// - Trailing bytes past `expected_ciphertext_bytes` → returns `OversizedCiphertext` immediately
+///   (closing the trailing-garbage acceptance hole that earlier versions had with an early-equality
+///   `break`).
+#[allow(clippy::too_many_arguments)]
+async fn drain_table_payload<S, W>(
+    stream: &mut S,
+    writer: &mut W,
+    translation_size: usize,
+    expected_ciphertext_bytes: usize,
+    read_timeout: Duration,
+    read_warn_after: Duration,
+    peer_id: &PeerId,
+    index: Index,
+) -> DrainOutcome
+where
+    S: PayloadStream,
+    W: mosaic_storage_api::table_store::TableWriter,
+{
+    let mut translate_hasher = blake3::Hasher::new();
+    let mut ct_hasher = blake3::Hasher::new();
+    let mut translation_buf = Vec::with_capacity(translation_size);
+    let mut translation_remaining = translation_size;
+    let mut ciphertext_bytes_received = 0usize;
+
+    loop {
+        let read_started = Instant::now();
+        let chunk = match stream.read_with_timeout(read_timeout).await {
+            Ok(data) => {
+                let elapsed = read_started.elapsed();
+                if elapsed >= read_warn_after {
+                    warn!(
+                        %peer_id,
+                        ?index,
+                        ?elapsed,
+                        "bulk stream read was slower than expected for receive_garbling_table"
+                    );
+                }
+                data
+            }
+            Err(BulkReadError::TimedOut) => return DrainOutcome::ReadTimedOut,
+            Err(BulkReadError::Closed(_)) => break,
+        };
+
+        if chunk.is_empty() {
+            break;
+        }
+
+        if translation_remaining > 0 {
+            // Still reading translation material; split the chunk on the
+            // boundary so each domain hashes independently.
+            let take = chunk.len().min(translation_remaining);
+            let (translate_part, ct_part) = chunk.split_at(take);
+
+            translation_buf.extend_from_slice(translate_part);
+            translate_hasher.update(translate_part);
+            translation_remaining -= take;
+
+            if !ct_part.is_empty() {
+                let next_ciphertext_bytes = ciphertext_bytes_received + ct_part.len();
+                if next_ciphertext_bytes > expected_ciphertext_bytes {
+                    return DrainOutcome::OversizedCiphertext {
+                        received: next_ciphertext_bytes,
+                        expected: expected_ciphertext_bytes,
+                    };
+                }
+                ciphertext_bytes_received = next_ciphertext_bytes;
+                ct_hasher.update(ct_part);
+                if writer.write_ciphertext(ct_part).await.is_err() {
+                    return DrainOutcome::WriteFailed {
+                        during_translation_overflow: true,
+                    };
+                }
+            }
+        } else {
+            // Translation already consumed — everything else is ciphertext.
+            // Don't break on equality with `expected`; let the next iteration's
+            // `>` check catch any trailing bytes and exit via `Closed` /
+            // empty-chunk / timeout otherwise.
+            let next_ciphertext_bytes = ciphertext_bytes_received + chunk.len();
+            if next_ciphertext_bytes > expected_ciphertext_bytes {
+                return DrainOutcome::OversizedCiphertext {
+                    received: next_ciphertext_bytes,
+                    expected: expected_ciphertext_bytes,
+                };
+            }
+            ciphertext_bytes_received = next_ciphertext_bytes;
+            ct_hasher.update(&chunk);
+            if writer.write_ciphertext(&chunk).await.is_err() {
+                return DrainOutcome::WriteFailed {
+                    during_translation_overflow: false,
+                };
+            }
+        }
+    }
+
+    if translation_remaining > 0 {
+        return DrainOutcome::TranslationIncomplete {
+            remaining: translation_remaining,
+        };
+    }
+    if ciphertext_bytes_received != expected_ciphertext_bytes {
+        return DrainOutcome::LengthMismatch {
+            received: ciphertext_bytes_received,
+            expected: expected_ciphertext_bytes,
+        };
+    }
+
+    DrainOutcome::Complete {
+        translation_buf,
+        translate_hash: translate_hasher.finalize(),
+        ct_hash: ct_hasher.finalize(),
+    }
+}
+
 pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: TableStore>(
     ctx: &MosaicExecutor<SP, TS>,
     peer_id: &PeerId,
@@ -327,133 +498,85 @@ pub(crate) async fn handle_receive_garbling_table<SP: StorageProvider, TS: Table
         return HandlerOutcome::Retry;
     };
 
-    // Receive and process all data from the stream.
-    let mut translate_hasher = blake3::Hasher::new();
-    let mut ct_hasher = blake3::Hasher::new();
-    let mut translation_buf = Vec::with_capacity(translation_size);
-    let mut translation_remaining = translation_size;
-    let mut ciphertext_bytes_received = 0usize;
-
-    loop {
-        let read_started = Instant::now();
-        let chunk = match stream.read_with_timeout(BULK_READ_TIMEOUT).await {
-            Ok(data) => {
-                let elapsed = read_started.elapsed();
-                if elapsed >= BULK_READ_WARN_AFTER {
-                    warn!(
-                        %peer_id,
-                        ?index,
-                        ?elapsed,
-                        "bulk stream read was slower than expected for receive_garbling_table"
-                    );
-                }
-                data
-            }
-            Err(BulkReadError::TimedOut) => {
-                warn!(
-                    %peer_id,
-                    ?index,
-                    timeout = ?BULK_READ_TIMEOUT,
-                    "timed out waiting for bulk payload in receive_garbling_table"
-                );
-                stream.reset(0).await;
-                let _ = ctx.table_store.delete(&table_id).await;
-                return HandlerOutcome::Retry;
-            }
-            Err(BulkReadError::Closed(_closed)) => break,
-        };
-
-        if chunk.is_empty() {
-            break;
+    // Drain the bulk stream into `writer` and the translation buffer, hashing
+    // each domain along the way. The helper returns one of several outcomes;
+    // we apply stream-reset / table cleanup at this layer based on the outcome
+    // so the helper itself stays I/O-free below the read trait.
+    let (translation_buf, translate_hash, ct_hash) = match drain_table_payload(
+        &mut stream,
+        &mut writer,
+        translation_size,
+        expected_ciphertext_bytes,
+        BULK_READ_TIMEOUT,
+        BULK_READ_WARN_AFTER,
+        peer_id,
+        index,
+    )
+    .await
+    {
+        DrainOutcome::Complete {
+            translation_buf,
+            translate_hash,
+            ct_hash,
+        } => (translation_buf, translate_hash, ct_hash),
+        DrainOutcome::ReadTimedOut => {
+            warn!(
+                %peer_id,
+                ?index,
+                timeout = ?BULK_READ_TIMEOUT,
+                "timed out waiting for bulk payload in receive_garbling_table"
+            );
+            stream.reset(0).await;
+            let _ = ctx.table_store.delete(&table_id).await;
+            return HandlerOutcome::Retry;
         }
-
-        if translation_remaining > 0 {
-            // Still reading translation material.
-            let take = chunk.len().min(translation_remaining);
-            let (translate_part, ct_part) = chunk.split_at(take);
-
-            translation_buf.extend_from_slice(translate_part);
-            translate_hasher.update(translate_part);
-            translation_remaining -= take;
-
-            // Any overflow goes to ciphertext.
-            if !ct_part.is_empty() {
-                let next_ciphertext_bytes = ciphertext_bytes_received + ct_part.len();
-                if next_ciphertext_bytes > expected_ciphertext_bytes {
-                    error!(
-                        %peer_id,
-                        ?index,
-                        received = next_ciphertext_bytes,
-                        expected = expected_ciphertext_bytes,
-                        "received oversized ciphertext stream for receive_garbling_table"
-                    );
-                    stream.reset(0).await;
-                    let _ = ctx.table_store.delete(&table_id).await;
-                    return HandlerOutcome::Retry;
-                }
-                ciphertext_bytes_received = next_ciphertext_bytes;
-                ct_hasher.update(ct_part);
-                if writer.write_ciphertext(ct_part).await.is_err() {
-                    error!(%peer_id, "ciphertext write failed (translation overflow) for receive_garbling_table");
-                    let _ = ctx.table_store.delete(&table_id).await;
-                    return HandlerOutcome::Retry;
-                }
-                // Don't break on `ciphertext_bytes_received == expected`:
-                // continue the loop so any trailing bytes from a buggy or
-                // malicious sender are caught by the `>` check above
-                // instead of being silently accepted. The loop exits via
-                // the existing branches at the top: `Closed` (FIN), an
-                // empty chunk, or the read timeout.
-            }
-        } else {
-            // All translation received — remaining data is ciphertext.
-            let next_ciphertext_bytes = ciphertext_bytes_received + chunk.len();
-            if next_ciphertext_bytes > expected_ciphertext_bytes {
+        DrainOutcome::OversizedCiphertext { received, expected } => {
+            error!(
+                %peer_id,
+                ?index,
+                received,
+                expected,
+                "received oversized ciphertext stream for receive_garbling_table"
+            );
+            stream.reset(0).await;
+            let _ = ctx.table_store.delete(&table_id).await;
+            return HandlerOutcome::Retry;
+        }
+        DrainOutcome::WriteFailed {
+            during_translation_overflow,
+        } => {
+            if during_translation_overflow {
                 error!(
                     %peer_id,
-                    ?index,
-                    received = next_ciphertext_bytes,
-                    expected = expected_ciphertext_bytes,
-                    "received oversized ciphertext stream for receive_garbling_table"
+                    "ciphertext write failed (translation overflow) for receive_garbling_table"
                 );
-                stream.reset(0).await;
-                let _ = ctx.table_store.delete(&table_id).await;
-                return HandlerOutcome::Retry;
-            }
-            ciphertext_bytes_received = next_ciphertext_bytes;
-            ct_hasher.update(&chunk);
-            if writer.write_ciphertext(&chunk).await.is_err() {
+            } else {
                 error!(%peer_id, "ciphertext write failed for receive_garbling_table");
-                let _ = ctx.table_store.delete(&table_id).await;
-                return HandlerOutcome::Retry;
             }
-            // See above: keep reading rather than break on equality, so
-            // any trailing bytes are caught by the `>` check on the next
-            // chunk. Normal termination is the `Closed` / empty-chunk
-            // branches at the top of the loop.
+            let _ = ctx.table_store.delete(&table_id).await;
+            return HandlerOutcome::Retry;
         }
-    }
-
-    // Verify we received enough translation data.
-    if translation_remaining > 0 {
-        error!(%peer_id, translation_remaining, "incomplete translation data for receive_garbling_table");
-        let _ = ctx.table_store.delete(&table_id).await;
-        return HandlerOutcome::Retry;
-    }
-    if ciphertext_bytes_received != expected_ciphertext_bytes {
-        error!(
-            %peer_id,
-            ?index,
-            received = ciphertext_bytes_received,
-            expected = expected_ciphertext_bytes,
-            "ciphertext length mismatch for receive_garbling_table"
-        );
-        let _ = ctx.table_store.delete(&table_id).await;
-        return HandlerOutcome::Retry;
-    }
-
-    let translate_hash = translate_hasher.finalize();
-    let ct_hash = ct_hasher.finalize();
+        DrainOutcome::TranslationIncomplete { remaining } => {
+            error!(
+                %peer_id,
+                translation_remaining = remaining,
+                "incomplete translation data for receive_garbling_table"
+            );
+            let _ = ctx.table_store.delete(&table_id).await;
+            return HandlerOutcome::Retry;
+        }
+        DrainOutcome::LengthMismatch { received, expected } => {
+            error!(
+                %peer_id,
+                ?index,
+                received,
+                expected,
+                "ciphertext length mismatch for receive_garbling_table"
+            );
+            let _ = ctx.table_store.delete(&table_id).await;
+            return HandlerOutcome::Retry;
+        }
+    };
 
     // Load metadata from evaluator state. These were stored when the garbler's
     // CommitMsgHeader (aes keys, public S) and ChallengeResponseMsgHeader
@@ -976,4 +1099,597 @@ pub(crate) async fn setup_evaluation_session<SP: StorageProvider, TS: TableStore
         output_label_ct_bytes,
         header.total_gates(),
     ))
+}
+
+// ============================================================================
+// Tests for the bulk-payload drain helper
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use mosaic_storage_api::table_store::{TableMetadata, TableWriter};
+
+    use super::*;
+
+    /// Scripted `PayloadStream` for tests. Each `read_with_timeout` call pops
+    /// from the front of the queue; an empty queue returns `Closed` (FIN).
+    struct ScriptedStream {
+        chunks: VecDeque<StreamReply>,
+    }
+
+    enum StreamReply {
+        Chunk(Vec<u8>),
+        TimedOut,
+    }
+
+    impl ScriptedStream {
+        fn from_chunks<I>(chunks: I) -> Self
+        where
+            I: IntoIterator<Item = Vec<u8>>,
+        {
+            Self {
+                chunks: chunks.into_iter().map(StreamReply::Chunk).collect(),
+            }
+        }
+    }
+
+    impl PayloadStream for ScriptedStream {
+        async fn read_with_timeout(
+            &mut self,
+            _timeout: Duration,
+        ) -> Result<mosaic_net_svc_api::PayloadBuf, BulkReadError> {
+            match self.chunks.pop_front() {
+                Some(StreamReply::Chunk(c)) => Ok(c),
+                Some(StreamReply::TimedOut) => Err(BulkReadError::TimedOut),
+                // Empty queue = FIN. Build a `Closed(StreamClosed)` via the
+                // PeerFinished variant which models a clean stream close.
+                None => Err(BulkReadError::Closed(
+                    mosaic_net_svc_api::StreamClosed::PeerFinished,
+                )),
+            }
+        }
+    }
+
+    /// In-memory [`TableWriter`] that just records what was written. Lets us
+    /// verify the helper passed every accepted ciphertext byte through to the
+    /// writer in order.
+    struct CollectingWriter {
+        ciphertext: Vec<u8>,
+        /// When set, `write_ciphertext` returns `Err` after this many calls
+        /// (used to test the WriteFailed outcome).
+        fail_after_calls: Option<usize>,
+        calls: usize,
+    }
+
+    impl CollectingWriter {
+        fn new() -> Self {
+            Self {
+                ciphertext: Vec::new(),
+                fail_after_calls: None,
+                calls: 0,
+            }
+        }
+        fn failing_at(call: usize) -> Self {
+            Self {
+                ciphertext: Vec::new(),
+                fail_after_calls: Some(call),
+                calls: 0,
+            }
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("collecting-writer test failure")]
+    struct CollectingWriterError;
+
+    impl TableWriter for CollectingWriter {
+        type Error = CollectingWriterError;
+
+        async fn write_ciphertext(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+            self.calls += 1;
+            if let Some(threshold) = self.fail_after_calls
+                && self.calls > threshold
+            {
+                return Err(CollectingWriterError);
+            }
+            self.ciphertext.extend_from_slice(data);
+            Ok(())
+        }
+
+        async fn finish(
+            &mut self,
+            _translation: &[u8],
+            _metadata: TableMetadata,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    fn peer() -> PeerId {
+        PeerId::from_bytes([0xAB; 32])
+    }
+    fn idx() -> Index {
+        Index::new(1).unwrap()
+    }
+
+    const TRANSLATION_SIZE: usize = 32;
+    const READ_TIMEOUT: Duration = Duration::from_secs(1);
+    const READ_WARN: Duration = Duration::from_secs(1);
+
+    fn translation_input() -> Vec<u8> {
+        (0..TRANSLATION_SIZE as u8).collect()
+    }
+
+    fn ciphertext_input(n: usize) -> Vec<u8> {
+        (0..n).map(|i| (i as u8).wrapping_mul(7)).collect()
+    }
+
+    #[tokio::test]
+    async fn complete_on_exact_bytes_with_fin() {
+        let translation = translation_input();
+        let ciphertext = ciphertext_input(48);
+        let mut stream = ScriptedStream::from_chunks([translation.clone(), ciphertext.clone()]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            ciphertext.len(),
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::Complete {
+                translation_buf,
+                translate_hash,
+                ct_hash,
+            } => {
+                assert_eq!(translation_buf, translation);
+                assert_eq!(translate_hash, blake3::hash(&translation));
+                assert_eq!(ct_hash, blake3::hash(&ciphertext));
+                assert_eq!(writer.ciphertext, ciphertext);
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn oversized_ciphertext_in_later_frame_is_rejected() {
+        // This is the trailing-bytes attack from the codex P2 finding: peer
+        // sends exactly the expected count, then a *separate* trailing frame.
+        let translation = translation_input();
+        let ciphertext = ciphertext_input(48);
+        let trailing = vec![0xCC; 8];
+        let mut stream =
+            ScriptedStream::from_chunks([translation, ciphertext.clone(), trailing.clone()]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            ciphertext.len(),
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::OversizedCiphertext { received, expected } => {
+                assert_eq!(expected, ciphertext.len());
+                assert_eq!(received, ciphertext.len() + trailing.len());
+            }
+            other => panic!("expected OversizedCiphertext, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn oversized_ciphertext_in_same_frame_is_rejected() {
+        // Single chunk that includes trailing bytes past the expected count.
+        let translation = translation_input();
+        let mut combined = ciphertext_input(48);
+        combined.extend_from_slice(&[0xDD; 4]);
+        let mut stream = ScriptedStream::from_chunks([translation, combined]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            48,
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, DrainOutcome::OversizedCiphertext { .. }),
+            "expected OversizedCiphertext, got {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn translation_ciphertext_boundary_within_a_single_chunk() {
+        // One chunk straddles the translation/ciphertext boundary: the
+        // helper must hash the first `TRANSLATION_SIZE` bytes into
+        // `translate_hasher` and the rest into `ct_hasher`.
+        let translation = translation_input();
+        let ciphertext = ciphertext_input(16);
+        let mut combined = translation.clone();
+        combined.extend_from_slice(&ciphertext);
+        let mut stream = ScriptedStream::from_chunks([combined]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            ciphertext.len(),
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::Complete {
+                translation_buf,
+                translate_hash,
+                ct_hash,
+            } => {
+                assert_eq!(translation_buf, translation);
+                assert_eq!(translate_hash, blake3::hash(&translation));
+                assert_eq!(ct_hash, blake3::hash(&ciphertext));
+                assert_eq!(writer.ciphertext, ciphertext);
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn translation_incomplete_when_stream_closes_early() {
+        // Stream closes after partial translation.
+        let mut partial = vec![0u8; TRANSLATION_SIZE - 4];
+        partial[0] = 0x10;
+        let mut stream = ScriptedStream::from_chunks([partial]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            16,
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::TranslationIncomplete { remaining } => assert_eq!(remaining, 4),
+            other => panic!("expected TranslationIncomplete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn length_mismatch_when_ciphertext_short_then_close() {
+        let translation = translation_input();
+        let short = ciphertext_input(40);
+        let mut stream = ScriptedStream::from_chunks([translation, short]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            48,
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::LengthMismatch { received, expected } => {
+                assert_eq!(received, 40);
+                assert_eq!(expected, 48);
+            }
+            other => panic!("expected LengthMismatch, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_failed_surfaces_writer_error() {
+        let translation = translation_input();
+        let ciphertext = ciphertext_input(48);
+        let mut stream = ScriptedStream::from_chunks([translation, ciphertext.clone()]);
+        // Fail on the very first ciphertext write call.
+        let mut writer = CollectingWriter::failing_at(0);
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            ciphertext.len(),
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                outcome,
+                DrainOutcome::WriteFailed {
+                    during_translation_overflow: false,
+                }
+            ),
+            "expected WriteFailed{{during_translation_overflow: false}}, got {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_failed_during_translation_overflow_keeps_discriminator() {
+        // Single chunk straddling the translation/ciphertext boundary, so the
+        // first ciphertext write happens inside the translation-still-remaining
+        // branch. The writer is rigged to fail on that very call.
+        let mut combined = translation_input();
+        combined.extend_from_slice(&ciphertext_input(8));
+        let mut stream = ScriptedStream::from_chunks([combined]);
+        let mut writer = CollectingWriter::failing_at(0);
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            8,
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                outcome,
+                DrainOutcome::WriteFailed {
+                    during_translation_overflow: true,
+                }
+            ),
+            "expected WriteFailed{{during_translation_overflow: true}}, got {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn boundary_byte_lands_in_ciphertext_hash_not_translation() {
+        // Negative-direction boundary check: put a distinctive sentinel byte
+        // at the *first* ciphertext position in a chunk that straddles the
+        // translation/ciphertext boundary. If `split_at(take)` were ever
+        // flipped or off-by-one'd, the sentinel would leak into the
+        // translation hash instead of the ciphertext hash.
+        let translation = translation_input();
+        let mut chunk = translation.clone();
+        let sentinel: u8 = 0xAA;
+        chunk.push(sentinel); // first ciphertext byte
+        chunk.extend_from_slice(&[0u8; 7]); // pad to 8 bytes of ciphertext
+        let expected_ct: Vec<u8> = std::iter::once(sentinel).chain([0u8; 7]).collect();
+
+        let mut stream = ScriptedStream::from_chunks([chunk]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            8,
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::Complete {
+                translation_buf,
+                translate_hash,
+                ct_hash,
+            } => {
+                assert_eq!(translation_buf, translation);
+                // Translation hash must NOT include the sentinel.
+                assert_eq!(translate_hash, blake3::hash(&translation));
+                // Ciphertext hash MUST include the sentinel as its first byte.
+                assert_eq!(ct_hash, blake3::hash(&expected_ct));
+                assert_eq!(writer.ciphertext, expected_ct);
+                assert_eq!(writer.ciphertext[0], sentinel);
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_timed_out_returns_timeout_outcome() {
+        let translation = translation_input();
+        let mut stream = ScriptedStream {
+            chunks: [StreamReply::Chunk(translation), StreamReply::TimedOut]
+                .into_iter()
+                .collect(),
+        };
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            16,
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, DrainOutcome::ReadTimedOut),
+            "expected ReadTimedOut, got {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_chunk_terminates_loop_like_fin() {
+        let translation = translation_input();
+        let ciphertext = ciphertext_input(16);
+        let mut stream = ScriptedStream::from_chunks([
+            translation.clone(),
+            ciphertext.clone(),
+            Vec::new(), // empty frame = treat as FIN
+        ]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            ciphertext.len(),
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::Complete {
+                translation_buf,
+                translate_hash,
+                ct_hash,
+            } => {
+                assert_eq!(translation_buf, translation);
+                assert_eq!(translate_hash, blake3::hash(&translation));
+                assert_eq!(ct_hash, blake3::hash(&ciphertext));
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn zero_expected_ciphertext_completes_on_translation_only() {
+        // Edge case: a circuit with zero AND gates produces
+        // `expected_ciphertext_bytes == 0`. Stream sends only translation
+        // bytes followed by FIN; the helper must accept it.
+        let translation = translation_input();
+        let mut stream = ScriptedStream::from_chunks([translation.clone()]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            0,
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::Complete {
+                translation_buf,
+                ct_hash,
+                ..
+            } => {
+                assert_eq!(translation_buf, translation);
+                assert_eq!(ct_hash, blake3::hash(b""));
+                assert!(writer.ciphertext.is_empty());
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn zero_expected_ciphertext_rejects_any_trailing_bytes() {
+        let mut combined = translation_input();
+        combined.push(0xFF); // one extra byte past translation
+        let mut stream = ScriptedStream::from_chunks([combined]);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            0,
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::OversizedCiphertext { received, expected } => {
+                assert_eq!(received, 1);
+                assert_eq!(expected, 0);
+            }
+            other => panic!("expected OversizedCiphertext, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn many_small_chunks_accumulate_correctly() {
+        let translation = translation_input();
+        let ciphertext = ciphertext_input(64);
+        // Break each into 4-byte pieces to stress the chunk-handling loop.
+        let mut chunks: Vec<Vec<u8>> = Vec::new();
+        for c in translation.chunks(4) {
+            chunks.push(c.to_vec());
+        }
+        for c in ciphertext.chunks(4) {
+            chunks.push(c.to_vec());
+        }
+        let mut stream = ScriptedStream::from_chunks(chunks);
+        let mut writer = CollectingWriter::new();
+
+        let outcome = drain_table_payload(
+            &mut stream,
+            &mut writer,
+            TRANSLATION_SIZE,
+            ciphertext.len(),
+            READ_TIMEOUT,
+            READ_WARN,
+            &peer(),
+            idx(),
+        )
+        .await;
+
+        match outcome {
+            DrainOutcome::Complete {
+                translation_buf,
+                translate_hash,
+                ct_hash,
+            } => {
+                assert_eq!(translation_buf, translation);
+                assert_eq!(translate_hash, blake3::hash(&translation));
+                assert_eq!(ct_hash, blake3::hash(&ciphertext));
+                assert_eq!(writer.ciphertext, ciphertext);
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
 }

--- a/crates/job/executors/src/lib.rs
+++ b/crates/job/executors/src/lib.rs
@@ -95,7 +95,22 @@ impl<SP: StorageProvider, TS: TableStore> MosaicExecutor<SP, TS> {
             return Ok(bytes);
         }
 
-        let computed = compute_expected_table_ciphertext_bytes(&self.circuit_path)?;
+        // The circuit reader does synchronous file I/O. Run it on a
+        // dedicated OS thread so it cannot stall the runtime that called us
+        // (workers run on a thread-per-core monoio, where blocking I/O
+        // halts every cooperatively-scheduled task on that thread).
+        let circuit_path = self.circuit_path.clone();
+        let (tx, rx) = kanal::bounded_async(1);
+        std::thread::spawn(move || {
+            let _ = tx
+                .to_sync()
+                .send(compute_expected_table_ciphertext_bytes(&circuit_path));
+        });
+        let computed = rx
+            .recv()
+            .await
+            .map_err(|_| CircuitError::SetupFailed("circuit reader thread exited".into()))??;
+
         let mut cached = self.expected_ciphertext_bytes.lock();
         Ok(*cached.get_or_insert(computed))
     }

--- a/crates/job/executors/src/lib.rs
+++ b/crates/job/executors/src/lib.rs
@@ -50,6 +50,8 @@ pub struct MosaicExecutor<SP: StorageProvider, TS: TableStore> {
     pub table_store: TS,
     /// Path to the v5c circuit file used for garbling and evaluation.
     pub circuit_path: PathBuf,
+    /// Cached exact ciphertext length for one garbling table.
+    expected_ciphertext_bytes: parking_lot::Mutex<Option<usize>>,
 }
 
 impl<SP: StorageProvider, TS: TableStore> MosaicExecutor<SP, TS> {
@@ -66,6 +68,7 @@ impl<SP: StorageProvider, TS: TableStore> MosaicExecutor<SP, TS> {
             storage,
             table_store,
             circuit_path,
+            expected_ciphertext_bytes: parking_lot::Mutex::new(None),
         }
     }
 
@@ -83,8 +86,31 @@ impl<SP: StorageProvider, TS: TableStore> MosaicExecutor<SP, TS> {
             storage,
             table_store,
             circuit_path,
+            expected_ciphertext_bytes: parking_lot::Mutex::new(None),
         }
     }
+
+    async fn expected_table_ciphertext_bytes(&self) -> Result<usize, CircuitError> {
+        if let Some(bytes) = *self.expected_ciphertext_bytes.lock() {
+            return Ok(bytes);
+        }
+
+        let computed = compute_expected_table_ciphertext_bytes(&self.circuit_path)?;
+        let mut cached = self.expected_ciphertext_bytes.lock();
+        Ok(*cached.get_or_insert(computed))
+    }
+}
+
+fn compute_expected_table_ciphertext_bytes(
+    circuit_path: &std::path::Path,
+) -> Result<usize, CircuitError> {
+    let reader = ReaderV5c::open(circuit_path)
+        .map_err(|e| CircuitError::SetupFailed(format!("circuit open: {e}")))?;
+
+    usize::try_from(reader.header().and_gates)
+        .map_err(|_| CircuitError::SetupFailed("and gate count does not fit in usize".into()))?
+        .checked_mul(16)
+        .ok_or_else(|| CircuitError::SetupFailed("ciphertext byte count overflow".into()))
 }
 
 impl<SP: StorageProvider, TS: TableStore> std::fmt::Debug for MosaicExecutor<SP, TS> {

--- a/crates/net/client/src/bulk.rs
+++ b/crates/net/client/src/bulk.rs
@@ -1,10 +1,17 @@
 //! Thin bulk-transfer wrappers over net-svc streams.
 
+use std::{future::Future, time::Duration};
+
+use futures_util::{
+    FutureExt,
+    future::{Either, select},
+    pin_mut,
+};
 use mosaic_net_svc::{
     BulkTransferExpectation as SvcBulkTransferExpectation, PayloadBuf, PeerId, Stream, StreamClosed,
 };
 
-use crate::error::BulkReceiveError;
+use crate::error::{BulkReadError, BulkReceiveError};
 
 /// Sender-side wrapper for bulk transfer streams.
 ///
@@ -75,6 +82,18 @@ impl BulkReceiver {
         self.stream.read().await
     }
 
+    /// Read next payload chunk with a timeout.
+    pub async fn read_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<PayloadBuf, BulkReadError> {
+        match timeout_in_current_runtime(timeout, self.stream.read()).await {
+            Ok(Ok(payload)) => Ok(payload),
+            Ok(Err(err)) => Err(BulkReadError::Closed(err)),
+            Err(TimeoutElapsed) => Err(BulkReadError::TimedOut),
+        }
+    }
+
     /// Try reading next payload chunk without blocking.
     pub fn try_read(&mut self) -> Option<PayloadBuf> {
         self.stream.try_read()
@@ -83,6 +102,11 @@ impl BulkReceiver {
     /// Peer this stream is connected to.
     pub fn peer(&self) -> PeerId {
         self.stream.peer
+    }
+
+    /// Reset the stream.
+    pub async fn reset(self, code: u32) {
+        self.stream.reset(code).await;
     }
 }
 
@@ -112,10 +136,45 @@ impl BulkExpectation {
             .map(BulkReceiver::new)
             .map_err(|_| BulkReceiveError::Closed)
     }
+
+    /// Wait for the incoming bulk stream with a timeout.
+    pub async fn recv_with_timeout(
+        self,
+        timeout: Duration,
+    ) -> Result<BulkReceiver, BulkReceiveError> {
+        match timeout_in_current_runtime(timeout, self.inner.receiver().recv()).await {
+            Ok(Ok(stream)) => Ok(BulkReceiver::new(stream)),
+            Ok(Err(_)) => Err(BulkReceiveError::Closed),
+            Err(TimeoutElapsed) => {
+                self.cancel().await;
+                Err(BulkReceiveError::TimedOut)
+            }
+        }
+    }
+
+    /// Explicitly cancel the registered expectation.
+    pub async fn cancel(self) {
+        self.inner.cancel().await;
+    }
 }
 
 impl std::fmt::Debug for BulkExpectation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BulkExpectation").finish_non_exhaustive()
+    }
+}
+
+struct TimeoutElapsed;
+
+async fn timeout_in_current_runtime<T>(
+    duration: Duration,
+    fut: impl Future<Output = T>,
+) -> Result<T, TimeoutElapsed> {
+    let fut = fut.map(Ok::<T, TimeoutElapsed>);
+    let timeout = futures_timer::Delay::new(duration).map(|_| Err(TimeoutElapsed));
+    pin_mut!(fut);
+    pin_mut!(timeout);
+    match select(fut, timeout).await {
+        Either::Left((result, _)) | Either::Right((result, _)) => result,
     }
 }

--- a/crates/net/client/src/bulk.rs
+++ b/crates/net/client/src/bulk.rs
@@ -146,15 +146,24 @@ impl BulkExpectation {
             Ok(Ok(stream)) => Ok(BulkReceiver::new(stream)),
             Ok(Err(_)) => Err(BulkReceiveError::Closed),
             Err(TimeoutElapsed) => {
-                self.cancel().await;
+                // Narrow the race window: a stream may have been delivered
+                // to the channel after `select` chose the timer but before
+                // we got here. Take it if so.
+                if let Ok(Some(stream)) = self.inner.receiver().try_recv() {
+                    return Ok(BulkReceiver::new(stream));
+                }
+                self.cancel();
                 Err(BulkReceiveError::TimedOut)
             }
         }
     }
 
     /// Explicitly cancel the registered expectation.
-    pub async fn cancel(self) {
-        self.inner.cancel().await;
+    ///
+    /// Best-effort: cancellation is delivered by the inner expectation's
+    /// `Drop` via `try_send`, so this call never blocks.
+    pub fn cancel(self) {
+        self.inner.cancel();
     }
 }
 

--- a/crates/net/client/src/error.rs
+++ b/crates/net/client/src/error.rs
@@ -94,4 +94,20 @@ pub enum BulkReceiveError {
     /// Bulk expectation channel closed before stream arrival.
     #[error("failed to receive bulk stream from service")]
     Closed,
+
+    /// Timed out waiting for the bulk stream to arrive.
+    #[error("timed out waiting for bulk stream")]
+    TimedOut,
+}
+
+/// Error reading from a bulk receiver stream.
+#[derive(Debug, thiserror::Error)]
+pub enum BulkReadError {
+    /// The stream closed before a payload arrived.
+    #[error("bulk stream closed: {0}")]
+    Closed(#[from] StreamClosed),
+
+    /// Timed out waiting for the next payload chunk.
+    #[error("timed out waiting for bulk payload")]
+    TimedOut,
 }

--- a/crates/net/client/src/lib.rs
+++ b/crates/net/client/src/lib.rs
@@ -63,7 +63,9 @@ use std::{
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
 pub use bulk::{BulkExpectation, BulkReceiver, BulkSender};
-pub use error::{AckError, BulkExpectError, BulkOpenError, BulkReceiveError, RecvError, SendError};
+pub use error::{
+    AckError, BulkExpectError, BulkOpenError, BulkReadError, BulkReceiveError, RecvError, SendError,
+};
 use futures_util::{
     FutureExt,
     future::{Either, select},

--- a/crates/net/client/tests/integration.rs
+++ b/crates/net/client/tests/integration.rs
@@ -1050,3 +1050,63 @@ fn test_bulk_wrapper_pipelined_write_no_reclaim() {
         assert_eq!(received, expected);
     });
 }
+
+#[test]
+fn test_bulk_expectation_recv_timeout() {
+    let (peer_a, peer_b) = create_client_pair();
+
+    run_async(async {
+        stabilize_stream_path(&peer_a, &peer_b).await;
+
+        let mut identifier = [0x66u8; 32];
+        let tag = next_key_tag();
+        identifier[..8].copy_from_slice(&tag.to_le_bytes());
+
+        let expectation = peer_b
+            .client
+            .expect_bulk_receiver(peer_a.peer_id, identifier)
+            .await
+            .expect("register bulk expectation");
+
+        let err = expectation
+            .recv_with_timeout(Duration::from_millis(50))
+            .await
+            .expect_err("bulk receive should time out");
+        assert!(matches!(err, mosaic_net_client::BulkReceiveError::TimedOut));
+    });
+}
+
+#[test]
+fn test_bulk_receiver_read_timeout() {
+    let (peer_a, peer_b) = create_client_pair();
+
+    run_async(async {
+        stabilize_stream_path(&peer_a, &peer_b).await;
+
+        let mut identifier = [0x67u8; 32];
+        let tag = next_key_tag();
+        identifier[..8].copy_from_slice(&tag.to_le_bytes());
+
+        let expectation = peer_b
+            .client
+            .expect_bulk_receiver(peer_a.peer_id, identifier)
+            .await
+            .expect("register bulk expectation");
+
+        let sender = peer_a
+            .client
+            .open_bulk_sender(peer_b.peer_id, identifier, StreamPriority::Bulk.as_i32())
+            .await
+            .expect("open bulk sender");
+
+        let mut receiver = expectation.recv().await.expect("receive bulk stream");
+        let err = receiver
+            .read_with_timeout(Duration::from_millis(50))
+            .await
+            .expect_err("bulk read should time out");
+        assert!(matches!(err, mosaic_net_client::BulkReadError::TimedOut));
+
+        receiver.reset(0).await;
+        sender.reset(0).await;
+    });
+}

--- a/crates/net/svc-api/src/api.rs
+++ b/crates/net/svc-api/src/api.rs
@@ -659,6 +659,17 @@ impl BulkTransferExpectation {
         self.rx.recv().await
     }
 
+    /// Explicitly cancel the registered expectation.
+    pub async fn cancel(self) {
+        let _ = self
+            .command_tx
+            .send(NetCommand::CancelBulkTransfer {
+                peer: self.peer,
+                identifier: self.identifier,
+            })
+            .await;
+    }
+
     /// Borrow the underlying receiver.
     pub fn receiver(&self) -> &AsyncReceiver<Stream> {
         &self.rx

--- a/crates/net/svc-api/src/api.rs
+++ b/crates/net/svc-api/src/api.rs
@@ -660,15 +660,12 @@ impl BulkTransferExpectation {
     }
 
     /// Explicitly cancel the registered expectation.
-    pub async fn cancel(self) {
-        let _ = self
-            .command_tx
-            .send(NetCommand::CancelBulkTransfer {
-                peer: self.peer,
-                identifier: self.identifier,
-            })
-            .await;
-    }
+    ///
+    /// Cancellation is sent best-effort by the [`Drop`] impl, which uses
+    /// `try_send` so it never blocks the caller if net-svc's command queue
+    /// is full. Consuming `self` here makes intent explicit and lets the
+    /// `Drop` run immediately.
+    pub fn cancel(self) {}
 
     /// Borrow the underlying receiver.
     pub fn receiver(&self) -> &AsyncReceiver<Stream> {


### PR DESCRIPTION
Closes #188.
Closes #193.

## Summary
- add runtime-agnostic bulk open/read timeout helpers in `mosaic-net-client`
- add explicit expectation cancellation on bulk-open timeout
- add slow-path warning logs and hard timeouts in `ReceiveGarblingTable`
- enforce exact ciphertext length using the circuit header `and_gates` count
- reset timed-out bulk streams and delete partial table state on failure

## Validation
- cargo test -p mosaic-net-client --tests
- cargo test -p mosaic-job-executors --lib
- cargo check -p mosaic -p mosaic-job-executors -p mosaic-net-client -p mosaic-net-svc-api
- cargo clippy -p mosaic-job-executors -p mosaic-net-client -p mosaic-net-svc-api --tests --all-targets -- -D warnings
- cargo +nightly fmt --all --check
