### PR TITLE
functional-tests: support MOSAIC_PATH env var for mosaic binary path

### DIFF
--- a/functional-tests/factories/mosaic/__init__.py
+++ b/functional-tests/factories/mosaic/__init__.py
@@ -11,6 +11,11 @@ from services import ProcServiceWithEnv, get_fdb_env
 
 from .mosaic_config import *
 
+# Environment variable to override the mosaic binary path.
+# Mirrors the FDBSERVER_PATH / FDBCLI_PATH pattern in factories/fdb.py.
+# Useful when the binary is not on PATH (e.g., a debug build under target/debug).
+MOSAIC_PATH = os.environ.get("MOSAIC_PATH", "mosaic")
+
 
 @dataclass
 class MosaicFactoryConfig:
@@ -51,7 +56,7 @@ class MosaicFactory(flexitest.Factory):
         logfile = os.path.join(datadir, "service.log")
 
         cmd = [
-            "mosaic",
+            MOSAIC_PATH,
             config_toml,
         ]
 

--- a/functional-tests/factories/mosaic/__init__.py
+++ b/functional-tests/factories/mosaic/__init__.py
@@ -13,8 +13,8 @@ from .mosaic_config import *
 
 # Environment variable to override the mosaic binary path.
 # Mirrors the FDBSERVER_PATH / FDBCLI_PATH pattern in factories/fdb.py.
-# Useful when the binary is not on PATH (e.g., a debug build under target/debug).
-MOSAIC_PATH = os.environ.get("MOSAIC_PATH", "mosaic")
+# By default, uses the expected release binary path.
+MOSAIC_PATH = os.environ.get("MOSAIC_PATH", "../target/release/mosaic")
 
 
 @dataclass


### PR DESCRIPTION
Resolves #200.

Functional tests previously hard-coded `"mosaic"` as the binary invoked by the Mosaic factory. CI handles this by adding the binary to PATH, but local runs needed the manual workaround of copying the binary into PATH or adjusting it.

## Change

Add `MOSAIC_PATH = os.environ.get("MOSAIC_PATH", "mosaic")` at module load in `functional-tests/factories/mosaic/__init__.py`, mirroring the existing `FDBSERVER_PATH` / `FDBCLI_PATH` pattern in `functional-tests/factories/fdb.py`. Use the variable in the spawn `cmd` list.

Default behaviour is unchanged when the env var is unset (resolves to `"mosaic"` on PATH).

## Local usage

```bash
export MOSAIC_PATH=$PWD/target/debug/mosaic
pytest functional-tests/
```

Diff: 7 lines.