### PR TITLE
Fix: verify opened output shares

### DIFF
--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -5,10 +5,10 @@ use mosaic_cac_types::{
     AdaptorMsgChunk, AllGarblingTableCommitments, ChallengeIndices, ChallengeMsg,
     ChallengeResponseMsgChunk, ChallengeResponseMsgHeader, CommitMsgChunk, CommitMsgHeader,
     CompletedSignatures, DepositAdaptors, DepositId, GarblingTableCommitment, HeapArray, Index,
-    OpenedGarblingTableCommitments, PubKey, ReservedSetupInputShares, Seed, SetupInputs,
-    TableTransferReceiptMsg, WideLabelWirePolynomialCommitments,
-    WideLabelZerothPolynomialCoefficients, WithdrawalAdaptors, WithdrawalAdaptorsChunk,
-    WithdrawalInputs, state_machine::evaluator::*,
+    OpenedGarblingTableCommitments, OpenedOutputShares, OutputPolynomialCommitment, PubKey,
+    ReservedSetupInputShares, Seed, SetupInputs, TableTransferReceiptMsg,
+    WideLabelWirePolynomialCommitments, WideLabelZerothPolynomialCoefficients, WithdrawalAdaptors,
+    WithdrawalAdaptorsChunk, WithdrawalInputs, state_machine::evaluator::*,
 };
 use mosaic_common::constants::{
     N_ADAPTOR_MSG_CHUNKS, N_CHALLENGE_RESPONSE_CHUNKS, N_CIRCUITS, N_DEPOSIT_INPUT_WIRES,
@@ -824,6 +824,22 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
                 unchallenged_output_label_cts,
             } = response_msg_header;
 
+            let output_polynomial_commitment = state
+                .get_output_polynomial_commitment()
+                .await
+                .require("expected output poly commit")?;
+
+            if let Some(failure_reason) = verify_opened_output_shares(
+                &opened_output_shares,
+                &output_polynomial_commitment,
+            ) {
+                warn!(reason = %failure_reason, "evaluator opened output shares verification failed, aborting");
+                root_state.step = Step::Aborted {
+                    reason: format!("invalid opened output shares: {}", failure_reason),
+                };
+                return Ok(());
+            }
+
             state
                 .put_reserved_setup_input_shares(&reserved_setup_input_shares)
                 .await
@@ -1342,6 +1358,29 @@ fn verify_reserved_setup_input_shares(
             ));
         }
     }
+    None
+}
+
+/// Verify each opened output share against the output polynomial commitment.
+/// Returns failure reason or None.
+fn verify_opened_output_shares(
+    opened_output_shares: &OpenedOutputShares,
+    output_polynomial_commitment: &OutputPolynomialCommitment,
+) -> Option<String> {
+    let output_polynomial_commitment = &output_polynomial_commitment[0];
+
+    for opened_output_share in opened_output_shares {
+        if output_polynomial_commitment
+            .verify_share(*opened_output_share)
+            .is_err()
+        {
+            return Some(format!(
+                "opened output share at index {} failed verification",
+                opened_output_share.index()
+            ));
+        }
+    }
+
     None
 }
 

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -829,10 +829,9 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
                 .await
                 .require("expected output poly commit")?;
 
-            if let Some(failure_reason) = verify_opened_output_shares(
-                &opened_output_shares,
-                &output_polynomial_commitment,
-            ) {
+            if let Some(failure_reason) =
+                verify_opened_output_shares(&opened_output_shares, &output_polynomial_commitment)
+            {
                 warn!(reason = %failure_reason, "evaluator opened output shares verification failed, aborting");
                 root_state.step = Step::Aborted {
                     reason: format!("invalid opened output shares: {}", failure_reason),

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -829,9 +829,11 @@ async fn handle_recv_challenge_response_header<S: StateMut>(
                 .await
                 .require("expected output poly commit")?;
 
-            if let Some(failure_reason) =
-                verify_opened_output_shares(&opened_output_shares, &output_polynomial_commitment)
-            {
+            if let Some(failure_reason) = verify_opened_output_shares(
+                &opened_output_shares,
+                &output_polynomial_commitment,
+                &challenge_idxs,
+            ) {
                 warn!(reason = %failure_reason, "evaluator opened output shares verification failed, aborting");
                 root_state.step = Step::Aborted {
                     reason: format!("invalid opened output shares: {}", failure_reason),
@@ -1360,15 +1362,28 @@ fn verify_reserved_setup_input_shares(
     None
 }
 
-/// Verify each opened output share against the output polynomial commitment.
-/// Returns failure reason or None.
+/// Verify each opened output share matches its challenged index and the output
+/// polynomial commitment. Returns failure reason or None.
 fn verify_opened_output_shares(
     opened_output_shares: &OpenedOutputShares,
     output_polynomial_commitment: &OutputPolynomialCommitment,
+    challenge_indices: &ChallengeIndices,
 ) -> Option<String> {
     let output_polynomial_commitment = &output_polynomial_commitment[0];
 
-    for opened_output_share in opened_output_shares {
+    for (position, (opened_output_share, challenge_index)) in opened_output_shares
+        .iter()
+        .zip(challenge_indices.iter())
+        .enumerate()
+    {
+        if opened_output_share.index() != *challenge_index {
+            return Some(format!(
+                "opened output share at position {position} has index {}, expected {}",
+                opened_output_share.index(),
+                challenge_index
+            ));
+        }
+
         if output_polynomial_commitment
             .verify_share(*opened_output_share)
             .is_err()

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -943,7 +943,10 @@ async fn valid_opened_output_shares_are_persisted() {
         &mut actions,
     )
     .await;
-    assert!(result.is_ok(), "valid header must be accepted, got: {result:?}");
+    assert!(
+        result.is_ok(),
+        "valid header must be accepted, got: {result:?}"
+    );
 
     // Step still WaitingForChallengeResponse (chunks not yet received) but header flag flipped.
     let root = state.get_root_state().await.unwrap().unwrap();
@@ -984,7 +987,10 @@ async fn corrupted_opened_output_share_aborts_without_persisting() {
         &mut actions,
     )
     .await;
-    assert!(result.is_ok(), "corrupted header should abort, not error: {result:?}");
+    assert!(
+        result.is_ok(),
+        "corrupted header should abort, not error: {result:?}"
+    );
     assert!(actions.is_empty(), "abort path must not emit actions");
 
     // Step transitioned to Aborted with the expected reason prefix.

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -963,6 +963,51 @@ async fn valid_opened_output_shares_are_persisted() {
 }
 
 #[tokio::test]
+async fn opened_output_share_with_wrong_challenge_index_aborts_without_persisting() {
+    let mut rng = ChaCha20Rng::seed_from_u64(3);
+    let output_polynomial = Polynomial::rand(&mut rng);
+    let challenge_indices = ChallengeIndices::new(|i| Index::new(i + 1).unwrap());
+
+    let mut state = StoredEvaluatorState::default();
+    seed_evaluator_for_challenge_response(&mut state, &output_polynomial, &challenge_indices).await;
+
+    let (mut header, _) = build_valid_response_header(&output_polynomial, &challenge_indices);
+
+    // Duplicate a committed, otherwise valid share into another opened position.
+    // verify_share accepts the embedded index, so the evaluator must also
+    // require each opened share index to match the corresponding challenge.
+    header.opened_output_shares[1] = header.opened_output_shares[0];
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeResponseMsgHeader(header),
+        &mut actions,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "wrong-index header should abort, not error: {result:?}"
+    );
+    assert!(actions.is_empty(), "abort path must not emit actions");
+
+    let root = state.get_root_state().await.unwrap().unwrap();
+    match root.step {
+        Step::Aborted { reason } => {
+            assert!(
+                reason.contains("has index"),
+                "unexpected abort reason: {reason}"
+            );
+        }
+        other => panic!("expected Aborted, got: {other:?}"),
+    }
+
+    assert_eq!(state.get_opened_output_shares().await.unwrap(), None);
+    assert_eq!(state.get_reserved_setup_input_shares().await.unwrap(), None);
+    assert_eq!(state.get_opened_garbling_seeds().await.unwrap(), None);
+}
+
+#[tokio::test]
 async fn corrupted_opened_output_share_aborts_without_persisting() {
     let mut rng = ChaCha20Rng::seed_from_u64(2);
     let output_polynomial = Polynomial::rand(&mut rng);

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -4,12 +4,12 @@ use fasm::actions::Action as FasmAction;
 use mosaic_cac_types::{
     ChallengeIndices, ChallengeResponseMsgChunk, ChallengeResponseMsgHeader, CommitMsgChunk,
     CommitMsgHeader, DepositId, EvalGarblingTableCommitments, EvaluationIndices,
-    GarblingTableCommitment, HeapArray, Index, Polynomial,
+    GarblingTableCommitment, HeapArray, Index, OpenedOutputShares, Polynomial,
     state_machine::evaluator::{
         Action, ActionId, ActionResult, EvaluatorState, Input, StateMut, StateRead, Step,
     },
 };
-use mosaic_common::constants::N_EVAL_CIRCUITS;
+use mosaic_common::constants::{N_EVAL_CIRCUITS, N_OPEN_CIRCUITS};
 use mosaic_storage_inmemory::evaluator::StoredEvaluatorState;
 use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
@@ -867,4 +867,140 @@ async fn duplicate_garbling_table_received_with_mismatched_commitment_aborts() {
         "expected abort on commitment mismatch, got {:?}",
         stored.step
     );
+}
+
+// ============================================================================
+// Output share verification
+// ============================================================================
+
+/// Build a valid `ChallengeResponseMsgHeader` whose `opened_output_shares` are
+/// real evaluations of `output_polynomial` at each `challenge_indices` position.
+fn build_valid_response_header(
+    output_polynomial: &Polynomial,
+    challenge_indices: &ChallengeIndices,
+) -> (ChallengeResponseMsgHeader, OpenedOutputShares) {
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+    let dummy_share = Polynomial::rand(&mut rng).eval(Index::new(1).unwrap());
+
+    let opened_output_shares: OpenedOutputShares =
+        HeapArray::new(|i| output_polynomial.eval(challenge_indices[i]));
+
+    let header = ChallengeResponseMsgHeader {
+        reserved_setup_input_shares: HeapArray::from_elem(dummy_share),
+        opened_output_shares: opened_output_shares.clone(),
+        opened_garbling_seeds: HeapArray::from_elem([0u8; 32].into()),
+        unchallenged_output_label_cts: HeapArray::from_elem([0u8; 32].into()),
+    };
+
+    (header, opened_output_shares)
+}
+
+/// Seed evaluator storage with the prerequisites needed to enter
+/// `handle_recv_challenge_response_header` and reach the share-verification step.
+async fn seed_evaluator_for_challenge_response(
+    state: &mut StoredEvaluatorState,
+    output_polynomial: &Polynomial,
+    challenge_indices: &ChallengeIndices,
+) {
+    state
+        .put_output_polynomial_commitment(&HeapArray::from_elem(output_polynomial.commit()))
+        .await
+        .unwrap();
+    state
+        .put_challenge_indices(challenge_indices)
+        .await
+        .unwrap();
+
+    let remaining = get_remaining_challenge_response_chunks(challenge_indices);
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::WaitingForChallengeResponse {
+                header: false,
+                remaining_chunks: remaining,
+            },
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn valid_opened_output_shares_are_persisted() {
+    let mut rng = ChaCha20Rng::seed_from_u64(1);
+    let output_polynomial = Polynomial::rand(&mut rng);
+    let challenge_indices = ChallengeIndices::new(|i| Index::new(i + 1).unwrap());
+
+    let mut state = StoredEvaluatorState::default();
+    seed_evaluator_for_challenge_response(&mut state, &output_polynomial, &challenge_indices).await;
+
+    let (header, expected_opened) =
+        build_valid_response_header(&output_polynomial, &challenge_indices);
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeResponseMsgHeader(header),
+        &mut actions,
+    )
+    .await;
+    assert!(result.is_ok(), "valid header must be accepted, got: {result:?}");
+
+    // Step still WaitingForChallengeResponse (chunks not yet received) but header flag flipped.
+    let root = state.get_root_state().await.unwrap().unwrap();
+    match root.step {
+        Step::WaitingForChallengeResponse { header, .. } => {
+            assert!(header, "header flag should be set after valid header");
+        }
+        other => panic!("unexpected step after valid header: {other:?}"),
+    }
+
+    // Shares were persisted.
+    let stored = state.get_opened_output_shares().await.unwrap();
+    assert_eq!(stored, Some(expected_opened));
+}
+
+#[tokio::test]
+async fn corrupted_opened_output_share_aborts_without_persisting() {
+    let mut rng = ChaCha20Rng::seed_from_u64(2);
+    let output_polynomial = Polynomial::rand(&mut rng);
+    let challenge_indices = ChallengeIndices::new(|i| Index::new(i + 1).unwrap());
+
+    let mut state = StoredEvaluatorState::default();
+    seed_evaluator_for_challenge_response(&mut state, &output_polynomial, &challenge_indices).await;
+
+    let (mut header, _) = build_valid_response_header(&output_polynomial, &challenge_indices);
+
+    // Replace one opened share with a share from an unrelated polynomial at the same index —
+    // it will fail verify_share against the committed output polynomial.
+    let corrupt_idx = N_OPEN_CIRCUITS / 2;
+    let other_polynomial = Polynomial::rand(&mut rng);
+    header.opened_output_shares[corrupt_idx] =
+        other_polynomial.eval(challenge_indices[corrupt_idx]);
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeResponseMsgHeader(header),
+        &mut actions,
+    )
+    .await;
+    assert!(result.is_ok(), "corrupted header should abort, not error: {result:?}");
+    assert!(actions.is_empty(), "abort path must not emit actions");
+
+    // Step transitioned to Aborted with the expected reason prefix.
+    let root = state.get_root_state().await.unwrap().unwrap();
+    match root.step {
+        Step::Aborted { reason } => {
+            assert!(
+                reason.starts_with("invalid opened output shares"),
+                "unexpected abort reason: {reason}"
+            );
+        }
+        other => panic!("expected Aborted, got: {other:?}"),
+    }
+
+    // Crucially: nothing was persisted.
+    assert_eq!(state.get_opened_output_shares().await.unwrap(), None);
+    assert_eq!(state.get_reserved_setup_input_shares().await.unwrap(), None);
+    assert_eq!(state.get_opened_garbling_seeds().await.unwrap(), None);
 }


### PR DESCRIPTION
## Description

Updates evaluator stf to verify opened output shares, fixing a bug caught by audit. 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

The suggested fix in v12's audit is correct, and that's what this PR implements. Additionally, I've added tests that validate correct behavior. In particular, evaluator now aborts if an output share was corrupted (and does not store the shares), which wasn't happening earlier. 

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Fixes #195. 
