### PR TITLE
job/scheduler,sm-executor,net/svc: unbound internal channels

### DIFF
--- a/crates/job/scheduler/src/garbling/mod.rs
+++ b/crates/job/scheduler/src/garbling/mod.rs
@@ -300,7 +300,12 @@ impl GarblingCoordinator {
         completion_tx: kanal::AsyncSender<JobCompletion>,
         fault_tx: kanal::AsyncSender<SchedulerFault>,
     ) -> Self {
-        let (submit_tx, submit_rx) = kanal::bounded_async(config.max_concurrent * 2);
+        // Unbounded: the scheduler dispatch loop forwards each circuit
+        // action through this channel inline. Bounding it head-of-line
+        // blocks unrelated dispatch when a garbling pass is in progress
+        // (see #182). Volume is bounded upstream by per-peer protocol-message
+        // rate limiting (#220).
+        let (submit_tx, submit_rx) = kanal::unbounded_async();
 
         let coordinator_thread_name = "garbling-coordinator".to_string();
         let thread = std::thread::Builder::new()

--- a/crates/job/scheduler/src/scheduler.rs
+++ b/crates/job/scheduler/src/scheduler.rs
@@ -35,8 +35,15 @@ pub struct JobSchedulerConfig {
     /// Garbling coordinator: coordinated topology reads + garbling.
     pub garbling: GarblingConfig,
     /// Capacity of the submission channel.
+    ///
+    /// No longer load-bearing: the submission channel is now unbounded to
+    /// avoid bounded-queue cycle deadlocks with the SM executor (see #221).
+    /// Retained for config compatibility; ignored at runtime.
     pub submission_queue_size: usize,
     /// Capacity of the completion channel.
+    ///
+    /// No longer load-bearing: the completion channel is now unbounded for
+    /// the same reason as `submission_queue_size`.
     pub completion_queue_size: usize,
 }
 
@@ -134,11 +141,24 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
     /// After construction, call [`run`](Self::run) to start the dispatch loop.
     pub fn new(config: JobSchedulerConfig, dispatcher: D) -> (Self, JobSchedulerHandle) {
         // Channel for SM Scheduler → Job Scheduler (batch submissions).
-        let (submit_tx, submission_rx) = kanal::bounded_async(config.submission_queue_size);
+        //
+        // Unbounded: the SM scheduler's STF can produce these inline while
+        // processing a job completion. Bounding this channel created a
+        // cycle-deadlock against the worker → SM-executor completion channel
+        // under failure bursts (see #221). Volume here is bounded upstream
+        // by per-peer protocol-message rate limiting (#220).
+        let (submit_tx, submission_rx) = kanal::unbounded_async();
 
         // Channel for Job Scheduler → SM Scheduler (completed results).
-        let (completion_tx, completion_rx) = kanal::bounded_async(config.completion_queue_size);
-        let (fault_tx, fault_rx) = kanal::bounded_async(16);
+        //
+        // Unbounded for the same reason as the submission channel: workers
+        // produce completions at the rate jobs finish, and a bounded receive
+        // side could block them while the SM executor is mid-processing.
+        let (completion_tx, completion_rx) = kanal::unbounded_async();
+
+        // Worker fault reports. Unbounded so a faulting worker never blocks
+        // on send; volume is tiny (one per faulting thread).
+        let (fault_tx, fault_rx) = kanal::unbounded_async();
 
         let executor = Arc::new(dispatcher);
 

--- a/crates/net/svc/src/svc/mod.rs
+++ b/crates/net/svc/src/svc/mod.rs
@@ -32,7 +32,7 @@ use std::{
 };
 
 use ahash::{HashMap, HashMapExt};
-use kanal::{AsyncReceiver, AsyncSender, bounded_async};
+use kanal::{AsyncReceiver, AsyncSender, bounded_async, unbounded_async};
 use quinn::{Endpoint, ServerConfig};
 use state::{OpenRequestCancelRegistry, PeerConnectionState, ServiceEvent, ServiceState};
 use tokio::runtime::Builder;
@@ -156,10 +156,19 @@ impl NetService {
         // Precompute allowed peers set once (avoid per-accept allocation).
         let allowed_peers: Arc<HashSet<PeerId>> = Arc::new(config.peer_ids().copied().collect());
 
-        // Command channel (handles -> service)
-        let (command_tx, command_rx) = bounded_async(64);
+        // Command channel (handles -> service).
+        //
+        // Unbounded: producers are in-process (NetClient/BulkExpectation
+        // handles), volume is bounded by application code, and bounding it
+        // created a deadlock risk for callers that needed to send a cancel
+        // command from inside a worker (see #221, PR #198).
+        let (command_tx, command_rx) = unbounded_async();
 
-        // Protocol stream channel (service -> handles)
+        // Protocol stream channel (service -> handles).
+        //
+        // Stays bounded: this channel is fed by inbound peer streams. The
+        // boundary admission story (per-peer protocol-message rate limits,
+        // #220) bounds peer fan-in upstream of this channel.
         let (protocol_stream_tx, protocol_stream_rx) = bounded_async(64);
 
         // Shutdown channel

--- a/crates/sm-executor-api/src/config.rs
+++ b/crates/sm-executor-api/src/config.rs
@@ -3,7 +3,10 @@ use mosaic_net_svc_api::PeerId;
 /// Configuration for the SM executor.
 #[derive(Debug, Clone)]
 pub struct SmExecutorConfig {
-    /// Bounded queue size for incoming executor commands.
+    /// Capacity hint for the executor command channel.
+    ///
+    /// No longer load-bearing: the channel is now unbounded (see #221).
+    /// Retained for config compatibility; ignored at runtime.
     pub command_queue_size: usize,
     /// Peers to restore at startup.
     pub known_peers: Vec<PeerId>,

--- a/crates/sm-executor/src/lib.rs
+++ b/crates/sm-executor/src/lib.rs
@@ -226,7 +226,13 @@ where
         job_handle: JobSchedulerHandle,
         net_client: NetClient,
     ) -> (Self, SmExecutorHandle) {
-        let (command_tx, command_rx) = kanal::bounded_async(config.command_queue_size);
+        // Unbounded: this channel carries operator/RPC-driven commands
+        // (Init, DepositInit, etc.). The producers are in-process trusted
+        // components and volume is low. Keeping it unbounded avoids any
+        // possibility of an admin RPC call blocking the executor loop or
+        // vice versa under load (see #221).
+        let _ = config.command_queue_size; // retained for config compatibility; ignored.
+        let (command_tx, command_rx) = kanal::unbounded_async();
         let handle = SmExecutorHandle::new(command_tx);
 
         (


### PR DESCRIPTION
## Summary

Bounded internal channels with `send().await` create cycle-deadlock risk between trusted in-process components. The 2026-05-07 production incident (#221) and the scheduler-dispatch HOL block in #182 are both instances of the same pattern: a producer that submits inline while consuming from another bounded channel can wedge the system under bursty load.

This PR flips the internal job-system and control-plane channels to unbounded:

- `JobScheduler::submit_tx` — SM executor → scheduler dispatch
- `JobScheduler::completion_tx` — workers → SM executor
- `JobScheduler::fault_tx` — workers → scheduler fault
- `GarblingCoordinator::submit_tx` — scheduler dispatch → garbling coord (also closes #182)
- `SmExecutor::command_tx` — operator/RPC → SM executor
- `NetService::command_tx` — handles → net-svc service

External-facing channels stay bounded: `NetService::protocol_stream_tx` and the per-stream `payload_tx` / `buf_return_tx` are peer-fed and rely on the upcoming per-peer protocol-message rate limit (#220) for boundary admission control.

`submission_queue_size`, `completion_queue_size`, and `command_queue_size` config fields are retained for compatibility but are no longer load-bearing. `.len()` instrumentation on the now-unbounded channels is left as follow-up.

## Issues
Closes #182.
Closes #221.

## Validation
- `cargo check --workspace`
- `cargo clippy --workspace --tests --all-targets -- -D warnings`
- `cargo test -p mosaic-job-scheduler -p mosaic-sm-executor -p mosaic-net-svc -p mosaic-net-client -p mosaic-job-executors`
- `cargo +nightly fmt --all --check`

## Notes
- Functional tests not run locally; expecting CI to confirm the deadlock signature is gone (#198's functional-test failures should also clear once this lands and #198 rebases on top).
- Per-peer rate limiting (#220) is the upstream complement to this change and is filed but not started.