### PR TITLE
docker: bind FoundationDB to loopback only in Compose

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -18,8 +18,12 @@ services:
       - ./vol/fdb/fdb.cluster:/var/fdb/fdb.cluster:rw
       - ./vol/fdb/data:/var/fdb/data
     ports:
+      # Bind FoundationDB strictly to loopback so the database (which holds
+      # protocol-secret material) is reachable only from the local host.
+      # Inter-container traffic uses the Compose network at
+      # `foundationdb:4500` and is unaffected.
       # Keep this port in sync with ./vol/fdb/fdb.cluster
-      - "4500:4500"
+      - "127.0.0.1:4500:4500"
     healthcheck:
       test:
         [


### PR DESCRIPTION
## Summary

Closes #214.

The Compose-managed FoundationDB instance previously published `4500:4500`, which on Docker maps to `0.0.0.0:4500` on the host by default. Because the cluster file with the FDB connection string is also committed in the repo (`docker/vol/fdb/fdb.cluster`), anyone with reachability to the host's port 4500 could connect to the database using the public connection string and read, corrupt, or DoS protocol state — including persisted seed and fault-secret material.

Bind explicitly to `127.0.0.1:4500:4500`. Container-to-container traffic continues to use the Compose network at `foundationdb:4500` and is unaffected.

## Issues
Closes #214.