### PR TITLE
docker/entrypoint: require explicit confirmation for reduced-circuits binary

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,8 +8,19 @@
 # The config file's [circuit] section should reference:
 #   path = "/etc/mosaic/circuit.v5c"
 #
-# Set MOSAIC_UNSAFE_TEST=1 to run in test mode, which is faster.
-# **WARNING**: Test mode is UNSAFE, and MUST NOT be used in production.
+# Test-mode binary (built with --features=reduced-circuits): for CI/test
+# environments only. This binary uses cut-and-choose parameters that are
+# explicitly documented as insecure (see crates/common/src/constants.rs)
+# and provides ~3 bits of challenge entropy versus the 40-bit production
+# target. To enable it you must set BOTH:
+#
+#     MOSAIC_UNSAFE_TEST=1
+#     MOSAIC_UNSAFE_TEST_I_UNDERSTAND_THIS_IS_NOT_PRODUCTION=1
+#
+# Setting only MOSAIC_UNSAFE_TEST=1 will refuse to start. The double-flag
+# is a deliberate footgun mitigation: it prevents accidental enablement
+# via a single environment-variable injection or a stray test config
+# being copied into a production deploy.
 #
 # Any extra arguments are forwarded to the mosaic binary.
 
@@ -23,12 +34,48 @@ if [ ! -f "$CONFIG_PATH" ]; then
     exit 1
 fi
 
+is_truthy() {
+    case "${1:-}" in
+        1|true|TRUE|True|yes|YES|Yes|on|ON|On) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 MOSAIC_BIN="/usr/local/bin/mosaic"
 
-case "${MOSAIC_UNSAFE_TEST:-}" in
-    1|true|TRUE|yes|YES|on|ON)
-        MOSAIC_BIN="/usr/local/bin/mosaic-unsafe-test"
-        ;;
-esac
+if is_truthy "${MOSAIC_UNSAFE_TEST:-}"; then
+    if ! is_truthy "${MOSAIC_UNSAFE_TEST_I_UNDERSTAND_THIS_IS_NOT_PRODUCTION:-}"; then
+        cat >&2 <<'EOF'
+ERROR: MOSAIC_UNSAFE_TEST=1 is set, but
+       MOSAIC_UNSAFE_TEST_I_UNDERSTAND_THIS_IS_NOT_PRODUCTION is not.
+
+The reduced-circuits binary uses cut-and-choose parameters that are
+explicitly insecure (see crates/common/src/constants.rs) and must
+NEVER be deployed in production. To run it intentionally for testing,
+set both flags:
+
+    MOSAIC_UNSAFE_TEST=1
+    MOSAIC_UNSAFE_TEST_I_UNDERSTAND_THIS_IS_NOT_PRODUCTION=1
+
+Refusing to start.
+EOF
+        exit 1
+    fi
+
+    cat >&2 <<'EOF'
+================================================================================
+WARNING: Running mosaic-unsafe-test (reduced-circuits build).
+
+This binary uses test-only cut-and-choose parameters that provide ~3 bits
+of challenge entropy instead of the 40-bit production target. It is NOT
+SAFE for production use under any circumstances.
+
+If you see this message in a production environment, stop the container
+immediately and audit the deployment for environment-variable injection
+or test-config contamination.
+================================================================================
+EOF
+    MOSAIC_BIN="/usr/local/bin/mosaic-unsafe-test"
+fi
 
 exec "$MOSAIC_BIN" "$CONFIG_PATH" "$@"


### PR DESCRIPTION
## Summary

Refs #212.

The Docker image ships both `mosaic` (production) and `mosaic-unsafe-test` (built with `--features=reduced-circuits`) in the runtime image, with the entrypoint switching on `MOSAIC_UNSAFE_TEST`. The reduced-circuits build uses cut-and-choose parameters that are explicitly insecure (~3 bits of challenge entropy versus the 40-bit production target), so a single accidental env-var setting can flip a production deploy into a materially-weakened protocol-soundness state.

## Change

The entrypoint now requires **two** environment variables to enable the unsafe binary:

```
MOSAIC_UNSAFE_TEST=1
MOSAIC_UNSAFE_TEST_I_UNDERSTAND_THIS_IS_NOT_PRODUCTION=1
```

Setting only the first refuses to start with a clear error pointing to the second flag and the reason. When both are set, the entrypoint prints a loud multi-line warning before exec'ing the unsafe binary so the choice is visible in startup logs.

## Notes

This addresses the immediate footgun. The cleaner follow-up — splitting the unsafe binary into a separate Docker image so it is never present in production images at all — is tracked under the same issue (#212) and not closed by this PR.

CI environments that currently use `MOSAIC_UNSAFE_TEST=1` will need to add the second flag.

## Issues
Refs #212.

## Validation
- Manual entrypoint review (no Rust changes).