### PR TITLE
ci(docker-publish-ecr): refuse reserved image tags from workflow_dispatch

### DIFF
--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -71,6 +71,27 @@ jobs:
               echo "::error::image_tag must match [A-Za-z0-9._-]{1,128}"
               exit 1
             fi
+
+            # Refuse user-supplied image_tag values that could overwrite
+            # production-meaningful tags from an arbitrary ref. The default
+            # path (no override) tags by short SHA, which cannot collide.
+            #
+            # Reserved exact tags:
+            case "${INPUT_IMAGE_TAG}" in
+              latest|main|master|stable|prod|production|release)
+                echo "::error::image_tag '${INPUT_IMAGE_TAG}' is reserved; not allowed via workflow_dispatch"
+                exit 1
+                ;;
+            esac
+            # Reserved release-shaped tags (e.g. v1.2.3, 1.2.3, release-*).
+            if [[ "${INPUT_IMAGE_TAG}" =~ ^v?[0-9]+\.[0-9]+(\.[0-9]+)?([._-].*)?$ ]]; then
+              echo "::error::image_tag '${INPUT_IMAGE_TAG}' looks like a release tag; release tags must come from a release workflow, not workflow_dispatch"
+              exit 1
+            fi
+            if [[ "${INPUT_IMAGE_TAG}" =~ ^release([._-].*)?$ ]]; then
+              echo "::error::image_tag '${INPUT_IMAGE_TAG}' is reserved (release-*); not allowed via workflow_dispatch"
+              exit 1
+            fi
           fi
 
       # Workflow scripts (render_trivy_summary.py, cleanup action) always come from


### PR DESCRIPTION
## Summary

Refs #211.

The Docker → ECR publish workflow accepts arbitrary `ref` and `image_tag` inputs. A workflow dispatcher can therefore build an image from an unreviewed branch or commit and push it to a production-meaningful tag, overwriting the trusted image at that tag.

This PR rejects `image_tag` values that could overwrite production-meaningful tags when supplied via `workflow_dispatch`:

- Exact reserved names: `latest`, `main`, `master`, `stable`, `prod`, `production`, `release`
- Release-shaped tags: `v?N.M[.K][...]` (matches `v1.2.3`, `1.0`, etc.)
- Release-prefixed tags: `release-*`, `release_*`, `release.*`

The default tagging path (resolved short SHA) is unchanged. Release tags must come from a separate, reviewed release workflow rather than from a manual dispatch against an arbitrary ref.

## Notes

This is the in-YAML mitigation. Stronger gating — a GitHub `environment` with required reviewers on the AWS environment — is an org-level configuration change tracked under #211 and not addressed by this PR. Doing both gives defense-in-depth.

## Issues
Refs #211.

## Validation
- Workflow file YAML is unchanged outside the validate step; the bash logic uses standard `bash` constructs already used elsewhere in the file.