### PR TITLE
storage/kvstore: reject trailing bytes when decoding postcard rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,6 +2653,7 @@ dependencies = [
  "mosaic-storage-api",
  "mosaic-vs3",
  "postcard",
+ "serde",
  "thiserror 2.0.18",
 ]
 

--- a/crates/storage/kvstore/Cargo.toml
+++ b/crates/storage/kvstore/Cargo.toml
@@ -21,6 +21,7 @@ ark-serialize.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 postcard.workspace = true
+serde.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/storage/kvstore/src/row_spec/common.rs
+++ b/crates/storage/kvstore/src/row_spec/common.rs
@@ -9,6 +9,7 @@ use mosaic_cac_types::{
     WideLabelZerothPolynomialCoefficients, WithdrawalAdaptorsChunk, WithdrawalInputs,
 };
 use mosaic_common::Byte32;
+use serde::de::DeserializeOwned;
 
 use crate::row_spec::{
     PackableKey, SerializableValue,
@@ -436,5 +437,65 @@ impl SerializableValue for Byte32 {
         let mut value = [0u8; 32];
         value.copy_from_slice(bytes);
         Ok(Byte32::from(value))
+    }
+}
+
+/// Decode a postcard-encoded value, rejecting any trailing bytes.
+///
+/// `postcard::from_bytes` succeeds even when the input contains extra bytes
+/// after the encoded value, which the storage format does not intend. This
+/// helper enforces canonical decoding: the input must be exactly the encoded
+/// value with no extra suffix.
+pub(crate) fn decode_postcard_canonical<T: DeserializeOwned>(
+    bytes: &[u8],
+) -> Result<T, postcard::Error> {
+    let (value, rest) = postcard::take_from_bytes::<T>(bytes)?;
+    if !rest.is_empty() {
+        return Err(postcard::Error::DeserializeUnexpectedEnd);
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use mosaic_cac_types::state_machine::{evaluator::EvaluatorState, garbler::GarblerState};
+
+    use super::*;
+    use crate::row_spec::SerializableValue;
+
+    #[test]
+    fn decode_postcard_canonical_rejects_trailing_bytes() {
+        let value: u32 = 0xDEADBEEF;
+        let mut encoded = postcard::to_allocvec(&value).unwrap();
+        encoded.push(0xFF);
+        let result: Result<u32, _> = decode_postcard_canonical(&encoded);
+        assert!(
+            result.is_err(),
+            "trailing bytes must be rejected, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn decode_postcard_canonical_round_trips_clean_input() {
+        let value: u32 = 0xCAFE_F00D;
+        let encoded = postcard::to_allocvec(&value).unwrap();
+        let decoded: u32 = decode_postcard_canonical(&encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn garbler_state_decoder_rejects_trailing_bytes() {
+        let value = GarblerState::default();
+        let mut bytes = <GarblerState as SerializableValue>::serialize(&value).unwrap();
+        bytes.push(0x00);
+        assert!(<GarblerState as SerializableValue>::deserialize(&bytes).is_err());
+    }
+
+    #[test]
+    fn evaluator_state_decoder_rejects_trailing_bytes() {
+        let value = EvaluatorState::default();
+        let mut bytes = <EvaluatorState as SerializableValue>::serialize(&value).unwrap();
+        bytes.push(0x00);
+        assert!(<EvaluatorState as SerializableValue>::deserialize(&bytes).is_err());
     }
 }

--- a/crates/storage/kvstore/src/row_spec/evaluator/state.rs
+++ b/crates/storage/kvstore/src/row_spec/evaluator/state.rs
@@ -45,7 +45,7 @@ impl SerializableValue for EvaluatorState {
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self, Self::DeserializeError> {
-        postcard::from_bytes(bytes)
+        crate::row_spec::common::decode_postcard_canonical(bytes)
     }
 }
 
@@ -102,7 +102,7 @@ impl SerializableValue for DepositState {
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self, Self::DeserializeError> {
-        postcard::from_bytes(bytes)
+        crate::row_spec::common::decode_postcard_canonical(bytes)
     }
 }
 

--- a/crates/storage/kvstore/src/row_spec/garbler/deposit.rs
+++ b/crates/storage/kvstore/src/row_spec/garbler/deposit.rs
@@ -49,7 +49,7 @@ impl SerializableValue for DepositState {
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self, Self::DeserializeError> {
-        postcard::from_bytes(bytes)
+        crate::row_spec::common::decode_postcard_canonical(bytes)
     }
 }
 

--- a/crates/storage/kvstore/src/row_spec/garbler/state.rs
+++ b/crates/storage/kvstore/src/row_spec/garbler/state.rs
@@ -41,7 +41,7 @@ impl SerializableValue for GarblerState {
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self, Self::DeserializeError> {
-        postcard::from_bytes(bytes)
+        crate::row_spec::common::decode_postcard_canonical(bytes)
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #186.

Several persisted state and deposit rows in the KV storage layer call `postcard::from_bytes(bytes)` directly. `postcard::from_bytes` silently ignores any bytes after the encoded value, which the storage format does not intend — the nearby Ark-backed value decoders and the key decoders explicitly reject trailing bytes for the same reason.

## Change

Add a `decode_postcard_canonical` helper in `row_spec::common` that uses `postcard::take_from_bytes` and errors when any byte remains after decode. Switch all four postcard call sites to use it:

- `row_spec::garbler::state` (root state)
- `row_spec::garbler::deposit` (per-deposit state)
- `row_spec::evaluator::state` (root state and per-deposit state)

## Tests

Four new regression tests in `row_spec::common::tests`:

- helper rejects trailing bytes
- helper round-trips clean input
- garbler-state decoder rejects trailing bytes
- evaluator-state decoder rejects trailing bytes

## Issues
Closes #186.

## Validation
- `cargo check --workspace`
- `cargo clippy --workspace --tests --all-targets -- -D warnings`
- `cargo test -p mosaic-storage-kvstore` (38 lib tests pass; 4 new tests included)
- `cargo +nightly fmt --all --check`