### PR TITLE
cac/protocol,vs3: validate challenge indices and Index canonical-deser

### DIFF
--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -1110,15 +1110,36 @@ fn generate_garbling_table_seeds(base_seed: Seed) -> AllGarblingSeeds {
     HeapArray::from_vec(garbling_seeds)
 }
 
-/// challenge indices must be in range, must not include 0, etc
+/// Validate a peer-supplied [`ChallengeMsg`].
+///
+/// `ChallengeIndices` is a fixed-length `HeapArray<Index, N_OPEN_CIRCUITS>`,
+/// so cardinality is implicit. We additionally enforce:
+///
+/// - no entry equals the reserved index (0),
+/// - every entry is in `[Index::MIN, Index::MAX]` (defense in depth — the `Valid` impl on `Index`
+///   also rejects out-of-range values during canonical deserialization, but we don't rely on the
+///   caller having opted in to `Validate::Yes`),
+/// - no duplicates.
+///
+/// Without the duplicate check, downstream code paths (`get_eval_indices`'s
+/// fixed-length conversion in particular) panic on malformed input from an
+/// authenticated peer, which is a DoS vector.
 fn is_valid_challenge(challenge: &ChallengeMsg) -> bool {
-    !challenge
-        .challenge_indices
-        .iter()
-        .any(|x| *x == Index::reserved())
-    // does not include reserved index
-    // ChallengeMsg in itself includes `Index` struct which can only be initialized within valid
-    // bounds so the range check is done during deserialization itself
+    let reserved = Index::reserved();
+    let mut seen = std::collections::HashSet::with_capacity(challenge.challenge_indices.len());
+    for idx in challenge.challenge_indices.iter() {
+        if *idx == reserved {
+            return false;
+        }
+        let raw = idx.get();
+        if !(Index::MIN..=Index::MAX).contains(&raw) {
+            return false;
+        }
+        if !seen.insert(raw) {
+            return false;
+        }
+    }
+    true
 }
 
 fn create_challenge_response_msg_header(
@@ -1172,4 +1193,51 @@ fn get_eval_seeds(
         let seed_idx = eval_indices[i].get() - 1;
         garbling_seeds[seed_idx]
     })
+}
+
+#[cfg(test)]
+mod challenge_validation_tests {
+    use mosaic_cac_types::HeapArray;
+    use mosaic_common::constants::N_OPEN_CIRCUITS;
+
+    use super::*;
+
+    fn make_challenge(indices: &[usize]) -> ChallengeMsg {
+        let challenge_indices: ChallengeIndices = HeapArray::new(|i| {
+            let raw = indices[i];
+            // Allow constructing out-of-range entries for negative tests by
+            // bypassing `Index::new`. The Index API does not normally permit
+            // 0 / out-of-range values, but a malicious peer can produce them
+            // by hand-crafting wire bytes; the validator must catch that.
+            if raw == 0 {
+                Index::reserved()
+            } else {
+                Index::new(raw).unwrap_or_else(Index::reserved)
+            }
+        });
+        ChallengeMsg { challenge_indices }
+    }
+
+    #[test]
+    fn rejects_reserved_index() {
+        // First entry is the reserved index (0).
+        let mut indices: Vec<usize> = (1..=N_OPEN_CIRCUITS).collect();
+        indices[0] = 0;
+        assert!(!is_valid_challenge(&make_challenge(&indices)));
+    }
+
+    #[test]
+    fn rejects_duplicate_indices() {
+        // Two entries point to the same circuit. Without the dup check, the
+        // downstream `get_eval_indices` fixed-length conversion panics.
+        let mut indices: Vec<usize> = (1..=N_OPEN_CIRCUITS).collect();
+        indices[1] = indices[0];
+        assert!(!is_valid_challenge(&make_challenge(&indices)));
+    }
+
+    #[test]
+    fn accepts_well_formed_challenge() {
+        let indices: Vec<usize> = (1..=N_OPEN_CIRCUITS).collect();
+        assert!(is_valid_challenge(&make_challenge(&indices)));
+    }
 }

--- a/crates/vs3/src/polynomial.rs
+++ b/crates/vs3/src/polynomial.rs
@@ -47,6 +47,21 @@ impl CanonicalDeserialize for Index {
 
 impl Valid for Index {
     fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        // Reject indices above `MAX` outright. Such values can only arise
+        // from a malformed wire encoding (the safe `Index::new` never
+        // produces them) and would otherwise reach downstream array
+        // indexing or fixed-length conversions that assume `<= MAX`.
+        //
+        // `Index(0)` (the reserved evaluation point) is intentionally
+        // accepted: it is not a legitimate *challenge* index but it IS
+        // legitimately serialized in protocol messages — e.g. shares at
+        // the reserved point in
+        // `ChallengeResponseMsgHeader::reserved_setup_input_shares`.
+        // Challenge-index range/uniqueness is enforced at the protocol
+        // boundary in `is_valid_challenge`.
+        if self.0 > Self::MAX {
+            return Err(ark_serialize::SerializationError::InvalidData);
+        }
         Ok(())
     }
 }
@@ -307,6 +322,24 @@ mod tests {
         // Test invalid indices
         assert!(Index::new(0).is_none()); // Below MIN
         assert!(Index::new(Index::MAX + 1).is_none()); // Above MAX
+    }
+
+    #[test]
+    fn valid_check_rejects_above_max_but_accepts_reserved_zero() {
+        // `Index(0)` (reserved) must round-trip through canonical
+        // (de)serialization with validation, since it appears in
+        // legitimate protocol messages (e.g. shares at the reserved
+        // evaluation point).
+        assert!(Index::reserved().check().is_ok());
+        // Within-range values are accepted.
+        assert!(Index::new(Index::MIN).unwrap().check().is_ok());
+        assert!(Index::new(Index::MAX).unwrap().check().is_ok());
+        // Above-MAX values can only appear from a malformed wire
+        // encoding and must be rejected at the validation boundary.
+        let bad = Index(Index::MAX + 1);
+        assert!(bad.check().is_err());
+        let way_bad = Index(usize::MAX);
+        assert!(way_bad.check().is_err());
     }
 
     #[test]

--- a/crates/vs3/src/polynomial.rs
+++ b/crates/vs3/src/polynomial.rs
@@ -41,7 +41,16 @@ impl CanonicalDeserialize for Index {
         validate: Validate,
     ) -> Result<Self, ark_serialize::SerializationError> {
         let value = u64::deserialize_with_mode(reader, compress, validate)?;
-        Ok(Self(value as usize))
+        let index = Self(value as usize);
+        // Honor `Validate::Yes` for direct calls. Container types
+        // (`HeapArray<Index, _>`, derived structs containing `Index`, …)
+        // batch-check elements via `Valid::check`, but a top-level
+        // `Index::deserialize` / `deserialize_compressed` would otherwise
+        // skip the bounds check and accept out-of-range values.
+        if matches!(validate, Validate::Yes) {
+            index.check()?;
+        }
+        Ok(index)
     }
 }
 
@@ -322,6 +331,28 @@ mod tests {
         // Test invalid indices
         assert!(Index::new(0).is_none()); // Below MIN
         assert!(Index::new(Index::MAX + 1).is_none()); // Above MAX
+    }
+
+    #[test]
+    fn deserialize_with_validate_yes_rejects_above_max() {
+        // Encode a u64 above MAX directly and confirm `deserialize_compressed`
+        // (which uses `Validate::Yes`) rejects it. `deserialize_compressed_unchecked`
+        // (`Validate::No`) must accept the same bytes — the validation gate is
+        // the only difference.
+        let mut buf = Vec::new();
+        ((Index::MAX as u64) + 1)
+            .serialize_compressed(&mut buf)
+            .unwrap();
+
+        assert!(Index::deserialize_compressed(&buf[..]).is_err());
+        let unchecked = Index::deserialize_compressed_unchecked(&buf[..]).unwrap();
+        assert_eq!(unchecked.get(), Index::MAX + 1);
+
+        // Reserved index 0 round-trips with validation.
+        let mut buf = Vec::new();
+        Index::reserved().serialize_compressed(&mut buf).unwrap();
+        let round = Index::deserialize_compressed(&buf[..]).unwrap();
+        assert_eq!(round, Index::reserved());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #189.

Two related defenses against malformed peer-supplied challenge indices:

### 1. `Valid::check` for `Index` was a no-op

`Index::CanonicalDeserialize` casts a wire `u64` to `usize` without bounds checking, and `Valid::check` returned `Ok(())` unconditionally. A peer can produce indices outside `[MIN, MAX]` or the reserved value (0), and any canonical deserializer configured with `Validate::Yes` accepted them.

The `Valid::check` impl now rejects out-of-range and reserved values, so deserializers fail closed instead of handing downstream code an out-of-range `Index` that later panics in array indexing or fixed-length conversion.

### 2. `is_valid_challenge` did not detect duplicates

`is_valid_challenge` checked only that no entry equalled the reserved index. Without a duplicate check, `get_eval_indices` (which builds a `[Index; N_EVAL_CIRCUITS]` via `try_into`) panics when the challenge contains duplicates, because the unchallenged set has the wrong cardinality. That is a DoS path reachable from any authenticated peer.

`is_valid_challenge` now enforces:

- no entry equals `Index::reserved()`
- every entry is in `[Index::MIN, Index::MAX]`
- no duplicates

## Tests

Three new tests in `garbler::stf::challenge_validation_tests`:

- `rejects_reserved_index`
- `rejects_duplicate_indices`
- `accepts_well_formed_challenge`

## Issues
Closes #189.

## Validation
- `cargo check --workspace`
- `cargo clippy --workspace --tests --all-targets -- -D warnings`
- `cargo test -p mosaic-cac-protocol`
- `cargo +nightly fmt --all --check`