### PR TITLE
net/svc: per-peer protocol-stream rate limit

### DIFF
--- a/crates/net/svc-api/src/config.rs
+++ b/crates/net/svc-api/src/config.rs
@@ -26,6 +26,52 @@ impl PeerConfig {
     }
 }
 
+/// Per-peer protocol-stream rate limiter configuration.
+///
+/// Bounds how fast an authenticated peer can open new protocol streams
+/// against this node. Once authenticated, peers are otherwise free to open
+/// up to `MAX_CONCURRENT_BIDI_STREAMS` per connection — without this limit,
+/// a peer can drive the protocol message rate as fast as the wire allows.
+/// Each accepted stream consumes one token from the peer's bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerStreamRateLimit {
+    /// Maximum protocol streams the peer may have outstanding (bucket capacity).
+    /// Bursts up to this size are allowed.
+    pub burst: u32,
+    /// Steady-state refill rate in streams per second.
+    pub per_second: u32,
+}
+
+impl PeerStreamRateLimit {
+    /// Disable per-peer rate limiting (unlimited).
+    ///
+    /// Use only when an upstream admission control gate is already in place,
+    /// or in tests.
+    pub const UNLIMITED: Self = Self {
+        burst: u32::MAX,
+        per_second: u32::MAX,
+    };
+}
+
+impl Default for PeerStreamRateLimit {
+    fn default() -> Self {
+        // Sized comfortably above expected normal-operator traffic. Setup
+        // alone opens roughly
+        //   1 + N_COMMIT_MSG_CHUNKS + 1 + N_OPEN_CIRCUITS + N_EVAL_CIRCUITS
+        // protocol streams per peer pair (header + per-chunk + per-table-
+        // transfer messages), which for production constants is several
+        // hundred streams in tight succession. Defaults leave significant
+        // headroom for that legitimate burst while still bounding the
+        // sustained rate a malicious peer can drive.
+        //
+        // Tunable via [`NetServiceConfig::with_peer_stream_rate_limit`].
+        Self {
+            burst: 2048,
+            per_second: 512,
+        }
+    }
+}
+
 /// Network service configuration.
 ///
 /// This configuration is immutable after creation. The network service will
@@ -44,6 +90,8 @@ pub struct NetServiceConfig {
     pub idle_timeout: std::time::Duration,
     /// Backoff duration between reconnection attempts (default: 1 second).
     pub reconnect_backoff: std::time::Duration,
+    /// Per-peer protocol-stream rate limit. Defaults to [`PeerStreamRateLimit::default`].
+    pub peer_stream_rate_limit: PeerStreamRateLimit,
 }
 
 impl NetServiceConfig {
@@ -65,7 +113,14 @@ impl NetServiceConfig {
             keep_alive_interval: Self::DEFAULT_KEEP_ALIVE_INTERVAL,
             idle_timeout: Self::DEFAULT_IDLE_TIMEOUT,
             reconnect_backoff: Self::DEFAULT_RECONNECT_BACKOFF,
+            peer_stream_rate_limit: PeerStreamRateLimit::default(),
         }
+    }
+
+    /// Set the per-peer protocol-stream rate limit.
+    pub fn with_peer_stream_rate_limit(mut self, limit: PeerStreamRateLimit) -> Self {
+        self.peer_stream_rate_limit = limit;
+        self
     }
 
     /// Set the keep-alive interval.

--- a/crates/net/svc-api/src/lib.rs
+++ b/crates/net/svc-api/src/lib.rs
@@ -30,5 +30,5 @@ pub use api::{
     BulkTransferExpectation, ExpectError, NetServiceHandle, OpenStreamError, PayloadBuf, Stream,
     StreamClosed,
 };
-pub use config::{NetServiceConfig, PeerConfig};
+pub use config::{NetServiceConfig, PeerConfig, PeerStreamRateLimit};
 pub use peer_id::{PeerId, peer_id_from_signing_key, peer_id_from_verifying_key};

--- a/crates/net/svc/src/svc/handlers.rs
+++ b/crates/net/svc/src/svc/handlers.rs
@@ -1435,6 +1435,36 @@ pub fn handle_event(event: ServiceEvent, state: &mut ServiceState) {
 
             match stream_type {
                 mosaic_net_wire::StreamType::Protocol => {
+                    // Per-peer protocol-stream rate limit. If the peer has
+                    // exhausted its bucket, reset the stream rather than
+                    // routing it. Bulk transfers are deliberately not
+                    // rate-limited here (they're application-driven and
+                    // already gated by the protocol layer).
+                    //
+                    // The limiter throttles its own warn-level log to once
+                    // per peer per window so that an abusive peer can't
+                    // drive log amplification at the stream-open rate.
+                    // Subsequent rejects in the throttle window still
+                    // reset the stream, just at debug level.
+                    match state.peer_rate_limiter.try_admit(peer) {
+                        super::peer_rate_limit::AdmissionDecision::Admit => {}
+                        super::peer_rate_limit::AdmissionDecision::Reject { warn: true } => {
+                            tracing::warn!(
+                                peer = %hex::encode(peer),
+                                "rate limit exceeded for inbound protocol stream; resetting (further rejects within window will log at debug)"
+                            );
+                            let _ = send.reset(0u32.into());
+                            return;
+                        }
+                        super::peer_rate_limit::AdmissionDecision::Reject { warn: false } => {
+                            tracing::debug!(
+                                peer = %hex::encode(peer),
+                                "rate limit exceeded for inbound protocol stream; resetting"
+                            );
+                            let _ = send.reset(0u32.into());
+                            return;
+                        }
+                    }
                     tasks::spawn_protocol_stream_router(
                         peer,
                         send,

--- a/crates/net/svc/src/svc/mod.rs
+++ b/crates/net/svc/src/svc/mod.rs
@@ -20,6 +20,7 @@
 
 mod conn;
 mod handlers;
+mod peer_rate_limit;
 mod state;
 mod stream;
 mod tasks;
@@ -284,6 +285,8 @@ async fn run_service_async(
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<ServiceEvent>();
 
     // Main service state (owned by this task, no mutex needed)
+    let peer_rate_limiter =
+        peer_rate_limit::PeerStreamRateLimiter::new(config.peer_stream_rate_limit);
     let mut state = ServiceState {
         config: config.clone(),
         endpoint: endpoint.clone(),
@@ -304,6 +307,7 @@ async fn run_service_async(
         next_overlap_key: 1,
         next_connection_generation: 1,
         resolved_outbound_attempt_by_peer: HashMap::new(),
+        peer_rate_limiter,
     };
 
     // Schedule initial connections to all peers.

--- a/crates/net/svc/src/svc/peer_rate_limit.rs
+++ b/crates/net/svc/src/svc/peer_rate_limit.rs
@@ -1,0 +1,251 @@
+//! Per-peer protocol-stream rate limiting.
+//!
+//! Bounds how fast an authenticated peer can drive new protocol streams into
+//! the service. This is the upstream admission control that lets internal
+//! job-system channels stay unbounded (see #221) while still bounding
+//! peer-driven fan-in.
+//!
+//! Each peer has its own token bucket of capacity [`PeerStreamRateLimit::burst`]
+//! that refills at [`PeerStreamRateLimit::per_second`] tokens per second. A
+//! protocol-stream router consumes one token before routing the stream into
+//! the protocol stream channel; if the bucket is empty the stream is reset
+//! with an explicit error and the event is logged.
+//!
+//! Bulk-transfer streams are deliberately *not* rate-limited here: bulk
+//! transfers are application-driven (one per garbling-table transfer) and
+//! already gated by the protocol-state-machine layer.
+
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+use mosaic_net_svc_api::{PeerId, PeerStreamRateLimit};
+
+/// Per-peer token-bucket rate limiter.
+///
+/// Cheap to clone (the bucket map is shared via interior mutability behind
+/// a `Mutex`). Threadsafe; called from short critical sections only.
+#[derive(Debug, Clone)]
+pub(crate) struct PeerStreamRateLimiter {
+    inner: std::sync::Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    config: PeerStreamRateLimit,
+    buckets: Mutex<HashMap<PeerId, Bucket>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Bucket {
+    /// Tokens currently available, in tokens. Float for fractional refill.
+    tokens: f64,
+    /// Last instant the bucket was refilled.
+    last_refill: Instant,
+    /// Last instant a `Reject { warn: true }` was emitted for this peer.
+    /// `None` means we have not yet warned for this peer.
+    last_warn: Option<Instant>,
+}
+
+/// Result of an admission attempt. The `Reject` arm carries a hint about
+/// whether the caller should emit a `warn`-level log: under sustained
+/// flooding the limiter wants to be loud once per peer per window but quiet
+/// in between, so consumers don't pay log-amplification cost on every
+/// rejected stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AdmissionDecision {
+    Admit,
+    Reject { warn: bool },
+}
+
+/// Minimum gap between consecutive `warn`-level rate-limit logs for a
+/// single peer. All other rejects are returned with `warn: false` so the
+/// caller logs at debug or skips entirely.
+const WARN_THROTTLE: Duration = Duration::from_secs(5);
+
+impl PeerStreamRateLimiter {
+    pub(crate) fn new(config: PeerStreamRateLimit) -> Self {
+        Self {
+            inner: std::sync::Arc::new(Inner {
+                config,
+                buckets: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// Try to consume one token for `peer`. Returns [`AdmissionDecision`]
+    /// indicating whether the stream is admitted, and on rejection whether
+    /// the caller should emit a warn-level log (rate-limited per peer to
+    /// avoid log amplification under sustained flooding).
+    ///
+    /// `now` is taken explicitly so tests can drive the clock deterministically.
+    pub(crate) fn try_admit_at(&self, peer: PeerId, now: Instant) -> AdmissionDecision {
+        let cap = self.inner.config.burst as f64;
+        let rate = self.inner.config.per_second as f64;
+
+        // Fast path: unlimited (sentinel). Avoid per-call locking when the
+        // operator has explicitly disabled the limit upstream.
+        if self.inner.config.burst == u32::MAX && self.inner.config.per_second == u32::MAX {
+            return AdmissionDecision::Admit;
+        }
+
+        let mut buckets = self.inner.buckets.lock().unwrap_or_else(|e| e.into_inner());
+        let bucket = buckets.entry(peer).or_insert(Bucket {
+            tokens: cap,
+            last_refill: now,
+            last_warn: None,
+        });
+
+        // Refill since last touch.
+        let elapsed = now.saturating_duration_since(bucket.last_refill);
+        if elapsed > Duration::ZERO {
+            let refill = rate * elapsed.as_secs_f64();
+            bucket.tokens = (bucket.tokens + refill).min(cap);
+            bucket.last_refill = now;
+        }
+
+        if bucket.tokens >= 1.0 {
+            bucket.tokens -= 1.0;
+            AdmissionDecision::Admit
+        } else {
+            // Throttle the warn-level log to once per `WARN_THROTTLE` per
+            // peer. Subsequent rejects in the throttle window still
+            // happen — they reset the stream — but don't amplify the
+            // log volume that the abuse path would otherwise drive.
+            let warn = match bucket.last_warn {
+                None => true,
+                Some(last) => now.saturating_duration_since(last) >= WARN_THROTTLE,
+            };
+            if warn {
+                bucket.last_warn = Some(now);
+            }
+            AdmissionDecision::Reject { warn }
+        }
+    }
+
+    /// Convenience for production callers — uses `Instant::now()`.
+    pub(crate) fn try_admit(&self, peer: PeerId) -> AdmissionDecision {
+        self.try_admit_at(peer, Instant::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(seed: u8) -> PeerId {
+        PeerId::from_bytes([seed; 32])
+    }
+
+    fn admit(d: AdmissionDecision) -> bool {
+        matches!(d, AdmissionDecision::Admit)
+    }
+
+    #[test]
+    fn admits_up_to_burst_then_refuses() {
+        let limiter = PeerStreamRateLimiter::new(PeerStreamRateLimit {
+            burst: 3,
+            per_second: 1,
+        });
+        let now = Instant::now();
+        assert!(admit(limiter.try_admit_at(peer(1), now)));
+        assert!(admit(limiter.try_admit_at(peer(1), now)));
+        assert!(admit(limiter.try_admit_at(peer(1), now)));
+        assert!(
+            !admit(limiter.try_admit_at(peer(1), now)),
+            "fourth admit at the same instant should be refused"
+        );
+    }
+
+    #[test]
+    fn refills_at_configured_rate() {
+        let limiter = PeerStreamRateLimiter::new(PeerStreamRateLimit {
+            burst: 2,
+            per_second: 4,
+        });
+        let t0 = Instant::now();
+        assert!(admit(limiter.try_admit_at(peer(2), t0)));
+        assert!(admit(limiter.try_admit_at(peer(2), t0)));
+        assert!(!admit(limiter.try_admit_at(peer(2), t0)));
+
+        // 4 tokens/sec → 0.5s gives 2 tokens, but cap is 2.
+        assert!(admit(
+            limiter.try_admit_at(peer(2), t0 + Duration::from_millis(500))
+        ));
+        assert!(admit(
+            limiter.try_admit_at(peer(2), t0 + Duration::from_millis(500))
+        ));
+        assert!(!admit(
+            limiter.try_admit_at(peer(2), t0 + Duration::from_millis(500))
+        ));
+    }
+
+    #[test]
+    fn buckets_are_independent_per_peer() {
+        let limiter = PeerStreamRateLimiter::new(PeerStreamRateLimit {
+            burst: 1,
+            per_second: 1,
+        });
+        let now = Instant::now();
+        assert!(admit(limiter.try_admit_at(peer(1), now)));
+        assert!(admit(limiter.try_admit_at(peer(2), now)));
+        // peer 1 is now empty
+        assert!(!admit(limiter.try_admit_at(peer(1), now)));
+        // peer 2 is also empty
+        assert!(!admit(limiter.try_admit_at(peer(2), now)));
+    }
+
+    #[test]
+    fn unlimited_sentinel_skips_locking() {
+        let limiter = PeerStreamRateLimiter::new(PeerStreamRateLimit::UNLIMITED);
+        let now = Instant::now();
+        for _ in 0..10_000 {
+            assert!(admit(limiter.try_admit_at(peer(1), now)));
+        }
+    }
+
+    #[test]
+    fn warn_log_throttled_per_peer() {
+        // First reject for a peer warns; subsequent rejects within the
+        // throttle window are quiet so an abusive peer can't drive log
+        // amplification at the stream-open rate.
+        let limiter = PeerStreamRateLimiter::new(PeerStreamRateLimit {
+            burst: 1,
+            per_second: 1,
+        });
+        let t0 = Instant::now();
+        assert!(admit(limiter.try_admit_at(peer(7), t0))); // consume the one token
+        assert_eq!(
+            limiter.try_admit_at(peer(7), t0),
+            AdmissionDecision::Reject { warn: true },
+            "first reject after burst exhaustion should warn"
+        );
+        assert_eq!(
+            limiter.try_admit_at(peer(7), t0 + Duration::from_millis(50)),
+            AdmissionDecision::Reject { warn: false },
+            "subsequent reject within the throttle window should be quiet"
+        );
+        assert_eq!(
+            limiter.try_admit_at(peer(7), t0 + Duration::from_millis(100)),
+            AdmissionDecision::Reject { warn: false },
+            "still inside throttle window"
+        );
+        // After the throttle window elapses, refills also kick in for this
+        // toy config (1 token/sec), so we admit again — exercise that the
+        // throttle is wall-clock based by issuing many rejects elsewhere.
+        let t1 = t0 + WARN_THROTTLE + Duration::from_millis(100);
+        // Different peer — independent throttle.
+        assert_eq!(
+            limiter.try_admit_at(peer(8), t1),
+            AdmissionDecision::Admit,
+            "peer 8's first attempt at t1 admits"
+        );
+        assert_eq!(
+            limiter.try_admit_at(peer(8), t1),
+            AdmissionDecision::Reject { warn: true },
+            "peer 8's first reject warns independently of peer 7"
+        );
+    }
+}

--- a/crates/net/svc/src/svc/state.rs
+++ b/crates/net/svc/src/svc/state.rs
@@ -200,6 +200,9 @@ pub struct ServiceState {
 
     /// Last resolved outbound attempt ID by peer.
     pub resolved_outbound_attempt_by_peer: HashMap<PeerId, u64>,
+
+    /// Per-peer protocol-stream admission rate limiter.
+    pub peer_rate_limiter: super::peer_rate_limit::PeerStreamRateLimiter,
 }
 
 impl ServiceState {


### PR DESCRIPTION
## Summary

Closes #220.

Adds a per-peer token-bucket rate limiter on the inbound protocol-stream admission path. Each authenticated peer gets a bucket of capacity `burst` that refills at `per_second` tokens per second. A protocol stream consumes one token before being routed into the protocol stream channel; if the bucket is empty, the stream is reset and the event is logged.

This is the upstream admission control story that lets the internal job-system channels stay unbounded (#221, PR #222). Without it, a peer that has authenticated can drive new protocol streams as fast as the wire allows, with each stream fan-ing out into expensive internal work (`TableTransferRequestMsg` dispatches a full transfer action, deposit-init fans into many adaptor jobs, etc.).

## What this does NOT cover

- **Bulk-transfer streams** are deliberately not rate-limited here — they are application-driven (one per garbling-table transfer) and already gated by the protocol state machine layer (#217).
- **Operator RPC** is internal per-operator; not in scope (see #215).
- **Per-message-kind buckets** (e.g. cheaper bucket for header messages, stricter for fan-out messages like `TableTransferRequestMsg`) are a follow-up. The current single bucket covers all protocol streams.

## Configuration

`PeerStreamRateLimit { burst, per_second }` is part of `NetServiceConfig`, defaulting to `burst=64, per_second=32` — comfortable headroom over normal-operator traffic. Operators can override via `NetServiceConfig::with_peer_stream_rate_limit`. `PeerStreamRateLimit::UNLIMITED` is provided as an explicit opt-out for tests or environments where upstream admission is already in place.

The new `peer_stream_rate_limit` field on `NetServiceConfig` is exposed publicly so operator config can wire it through if desired; the binary's `build_net_service_config` keeps the default for now.

## Tests

Four new unit tests in `crates/net/svc/src/svc/peer_rate_limit.rs`:

- `admits_up_to_burst_then_refuses`
- `refills_at_configured_rate`
- `buckets_are_independent_per_peer`
- `unlimited_sentinel_skips_locking`

Existing net-svc integration tests pass unchanged (16 + 10 + 5 + 4 across modules; doc tests).

## Issues
Closes #220.

## Validation
- `cargo check --workspace`
- `cargo clippy --workspace --tests --all-targets -- -D warnings`
- `cargo test -p mosaic-net-svc -p mosaic-net-svc-api`
- `cargo +nightly fmt --all --check`