### PR TITLE
Allow deposits on tablesets after setup consumption

### DIFF
--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -164,7 +164,7 @@ pub(crate) async fn handle_event<S: StateMut>(
         },
         Input::DisputedWithdrawal(deposit_id, EvaluatorDisputedWithdrawalData { signatures }) => {
             match root_state.step {
-                Step::SetupComplete | Step::SetupConsumed { .. } => {
+                Step::SetupComplete => {
                     let deposit_state = require_deposit(state, &deposit_id).await?;
 
                     match deposit_state.step {

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -1191,60 +1191,7 @@ pub(crate) async fn restore<S: StateRead>(
             }
         }
         Step::SetupComplete => {
-            let mut all_deposits = pin!(state.stream_all_deposits());
-
-            while let Some(res) = all_deposits.next().await {
-                let (deposit_id, deposit_state) = res.map_err(SMError::storage)?;
-
-                match &deposit_state.step {
-                    DepositStep::GeneratingAdaptors {
-                        deposit,
-                        withdrawal_chunks,
-                    } => {
-                        if !deposit {
-                            emit(actions, Action::GenerateDepositAdaptors(deposit_id));
-                        }
-                        for (idx, generated) in withdrawal_chunks.iter().enumerate() {
-                            if !*generated {
-                                emit(
-                                    actions,
-                                    Action::GenerateWithdrawalAdaptorsChunk(
-                                        deposit_id,
-                                        ChunkIndex(idx as u8),
-                                    ),
-                                );
-                            }
-                        }
-                    }
-                    DepositStep::SendingAdaptors { acked } => {
-                        let deposit_adaptors = state
-                            .get_deposit_adaptors(&deposit_id)
-                            .await
-                            .require("expected deposit adaptors")?;
-
-                        let withdrawal_adaptors = state
-                            .get_withdrawal_adaptors(&deposit_id)
-                            .await
-                            .require("expected withdrawal adaptors")?;
-
-                        for chunk in create_adaptor_message_chunks(
-                            deposit_id,
-                            deposit_adaptors,
-                            withdrawal_adaptors,
-                        ) {
-                            if !acked[chunk.chunk_index as usize] {
-                                emit(
-                                    actions,
-                                    Action::DepositSendAdaptorMsgChunk(deposit_id, chunk),
-                                );
-                            }
-                        }
-                    }
-                    DepositStep::DepositReady => {}
-                    DepositStep::WithdrawnUndisputed => {}
-                    DepositStep::Aborted { .. } => {}
-                }
-            }
+            restore_deposits(state, actions).await?;
         }
         Step::EvaluatingTables {
             eval_indices,

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -25,6 +25,10 @@ use crate::{
     common::{derive_stage_seed, get_eval_commitments, get_eval_indices},
 };
 
+// Note: deposit operations are accepted in any post-setup state (SetupComplete,
+// EvaluatingTables, SetupConsumed), not only SetupComplete. This allows new deposits
+// to be created on a tableset even after the setup has been consumed by a withdrawal.
+
 // ============================================================================
 // External event handler
 // ============================================================================
@@ -92,7 +96,7 @@ pub(crate) async fn handle_event<S: StateMut>(
                 deposit_inputs,
             },
         ) => match root_state.step {
-            Step::SetupComplete => {
+            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. } => {
                 if state
                     .get_deposit(&deposit_id)
                     .await
@@ -393,7 +397,9 @@ pub(crate) async fn handle_action_result<S: StateMut>(
         }
         ActionResult::DepositAdaptorsGenerated(deposit_id, deposit_adaptors) => {
             match root_state.step {
-                Step::SetupComplete => {
+                Step::SetupComplete
+                | Step::EvaluatingTables { .. }
+                | Step::SetupConsumed { .. } => {
                     let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                     match &mut deposit_state.step {
@@ -451,7 +457,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
             chunk_idx,
             withdrawal_adaptor_chunk,
         ) => match root_state.step {
-            Step::SetupComplete => {
+            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. } => {
                 let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                 match &mut deposit_state.step {
@@ -516,7 +522,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
             _ => return Err(SMError::UnexpectedInput),
         },
         ActionResult::DepositAdaptorChunkSent(deposit_id) => match root_state.step {
-            Step::SetupComplete => {
+            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. } => {
                 let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                 match &mut deposit_state.step {
@@ -1255,8 +1261,12 @@ pub(crate) async fn restore<S: StateRead>(
                     Action::EvaluateGarblingTable(eval_indices[ii], eval_commitments[ii]),
                 );
             }
+
+            restore_deposits(state, actions).await?;
         }
-        Step::SetupConsumed { .. } => {}
+        Step::SetupConsumed { .. } => {
+            restore_deposits(state, actions).await?;
+        }
         // NOTE: an abort transition from `ReceivingGarblingTables` (commitment
         // mismatch in `handle_table_received`) can leave earlier slots'
         // `SendTableTransferReceipt` actions in flight, which this branch
@@ -1265,6 +1275,62 @@ pub(crate) async fn restore<S: StateRead>(
         // garbler peer without those receipts. Cleaner abort-propagation is
         // tracked as a follow-up (see PR #257 review thread).
         Step::Aborted { .. } => {}
+    }
+
+    Ok(())
+}
+
+/// Restore actions for in-progress deposits.
+async fn restore_deposits<S: StateRead>(state: &S, actions: &mut ActionContainer) -> SMResult<()> {
+    let mut all_deposits = pin!(state.stream_all_deposits());
+
+    while let Some(res) = all_deposits.next().await {
+        let (deposit_id, deposit_state) = res.map_err(SMError::storage)?;
+
+        match &deposit_state.step {
+            DepositStep::GeneratingAdaptors {
+                deposit,
+                withdrawal_chunks,
+            } => {
+                if !deposit {
+                    emit(actions, Action::GenerateDepositAdaptors(deposit_id));
+                }
+                for (idx, generated) in withdrawal_chunks.iter().enumerate() {
+                    if !*generated {
+                        emit(
+                            actions,
+                            Action::GenerateWithdrawalAdaptorsChunk(
+                                deposit_id,
+                                ChunkIndex(idx as u8),
+                            ),
+                        );
+                    }
+                }
+            }
+            DepositStep::SendingAdaptors { acked } => {
+                let deposit_adaptors = state
+                    .get_deposit_adaptors(&deposit_id)
+                    .await
+                    .require("expected deposit adaptors")?;
+
+                let withdrawal_adaptors = state
+                    .get_withdrawal_adaptors(&deposit_id)
+                    .await
+                    .require("expected withdrawal adaptors")?;
+
+                for chunk in
+                    create_adaptor_message_chunks(deposit_id, deposit_adaptors, withdrawal_adaptors)
+                {
+                    if !acked[chunk.chunk_index as usize] {
+                        emit(
+                            actions,
+                            Action::DepositSendAdaptorMsgChunk(deposit_id, chunk),
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
     Ok(())

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -144,7 +144,7 @@ pub(crate) async fn handle_event<S: StateMut>(
             _ => return Err(SMError::UnexpectedInput),
         },
         Input::DepositUndisputedWithdrawal(deposit_id) => match root_state.step {
-            Step::SetupComplete => {
+            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. } => {
                 let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                 match deposit_state.step {
@@ -164,7 +164,7 @@ pub(crate) async fn handle_event<S: StateMut>(
         },
         Input::DisputedWithdrawal(deposit_id, EvaluatorDisputedWithdrawalData { signatures }) => {
             match root_state.step {
-                Step::SetupComplete => {
+                Step::SetupComplete | Step::SetupConsumed { .. } => {
                     let deposit_state = require_deposit(state, &deposit_id).await?;
 
                     match deposit_state.step {

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -295,7 +295,7 @@ pub(crate) async fn handle_event<S: StateMut>(
         },
         Input::DisputedWithdrawal(deposit_id, withdrawal_input) => {
             match &mut root_state.step {
-                Step::SetupComplete | Step::SetupConsumed { .. } => {
+                Step::SetupComplete => {
                     let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                     match &mut deposit_state.step {

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -22,6 +22,10 @@ use crate::{
     common::{derive_stage_seed, get_eval_commitments, get_eval_indices},
 };
 
+// Note: deposit operations are accepted in any post-setup state (SetupComplete,
+// CompletingAdaptors, SetupConsumed), not only SetupComplete. This allows new deposits
+// to be created on a tableset even after the setup has been consumed by a withdrawal.
+
 // ============================================================================
 // External event handler
 // ============================================================================
@@ -225,7 +229,7 @@ pub(crate) async fn handle_event<S: StateMut>(
                 deposit_inputs,
             },
         ) => match root_state.step {
-            Step::SetupComplete => {
+            Step::SetupComplete | Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. } => {
                 if state
                     .get_deposit(&deposit_id)
                     .await
@@ -533,7 +537,9 @@ pub(crate) async fn handle_action_result<S: StateMut>(
 
         ActionResult::DepositAdaptorVerificationResult(deposit_id, verification_success) => {
             match root_state.step {
-                Step::SetupComplete => {
+                Step::SetupComplete
+                | Step::CompletingAdaptors { .. }
+                | Step::SetupConsumed { .. } => {
                     let mut deposit_state = require_deposit(state, &deposit_id).await?;
                     match &mut deposit_state.step {
                         DepositStep::VerifyingAdaptors => {
@@ -773,7 +779,7 @@ async fn handle_recv_deposit_adaptor_msg_chunk<S: StateMut>(
     actions: &mut ActionContainer,
 ) -> SMResult<()> {
     match &mut root_state.step {
-        Step::SetupComplete => {
+        Step::SetupComplete | Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. } => {
             if adaptor_msg_chunk.deposit_id != deposit_id {
                 return Err(SMError::invalid_input_data());
             }
@@ -989,10 +995,29 @@ pub(crate) async fn restore<S: StateRead>(
             }
 
             emit(actions, Action::CompleteAdaptorSignatures(*deposit_id));
+
+            restore_deposits(state, actions).await?;
         }
-        Step::SetupConsumed { .. } => {}
+        Step::SetupConsumed { .. } => {
+            restore_deposits(state, actions).await?;
+        }
         Step::Aborted { .. } => {}
     };
+
+    Ok(())
+}
+
+/// Restore adaptor verification actions for in-progress deposits.
+async fn restore_deposits<S: StateRead>(state: &S, actions: &mut ActionContainer) -> SMResult<()> {
+    let mut all_deposits = pin!(state.stream_all_deposits());
+
+    while let Some(res) = all_deposits.next().await {
+        let (deposit_id, deposit_state) = res.map_err(SMError::storage)?;
+
+        if let DepositStep::VerifyingAdaptors = &deposit_state.step {
+            emit(actions, Action::DepositVerifyAdaptors(deposit_id));
+        }
+    }
 
     Ok(())
 }

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -275,7 +275,7 @@ pub(crate) async fn handle_event<S: StateMut>(
             .await?;
         }
         Input::DepositUndisputedWithdrawal(deposit_id) => match root_state.step {
-            Step::SetupComplete => {
+            Step::SetupComplete | Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. } => {
                 let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                 match &mut deposit_state.step {
@@ -295,7 +295,7 @@ pub(crate) async fn handle_event<S: StateMut>(
         },
         Input::DisputedWithdrawal(deposit_id, withdrawal_input) => {
             match &mut root_state.step {
-                Step::SetupComplete => {
+                Step::SetupComplete | Step::SetupConsumed { .. } => {
                     let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                     match &mut deposit_state.step {

--- a/crates/rpc/service/src/default.rs
+++ b/crates/rpc/service/src/default.rs
@@ -461,10 +461,18 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for Defa
                     .map_err(ServiceError::storage)?
                     .ok_or(ServiceError::StateMachineNotFound(*sm_id))?;
 
-                if statemachine.step != garbler::Step::SetupComplete {
-                    return Err(ServiceError::InvalidInputForState(
-                        statemachine.step.step_name().into(),
-                    ));
+                {
+                    use garbler::Step;
+                    if !matches!(
+                        statemachine.step,
+                        Step::SetupComplete
+                            | Step::CompletingAdaptors { .. }
+                            | Step::SetupConsumed { .. }
+                    ) {
+                        return Err(ServiceError::InvalidInputForState(
+                            statemachine.step.step_name().into(),
+                        ));
+                    }
                 }
 
                 let deposit = self
@@ -492,10 +500,18 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for Defa
                     .map_err(ServiceError::storage)?
                     .ok_or(ServiceError::StateMachineNotFound(*sm_id))?;
 
-                if statemachine.step != evaluator::Step::SetupComplete {
-                    return Err(ServiceError::InvalidInputForState(
-                        statemachine.step.step_name().into(),
-                    ));
+                {
+                    use evaluator::Step;
+                    if !matches!(
+                        statemachine.step,
+                        Step::SetupComplete
+                            | Step::EvaluatingTables { .. }
+                            | Step::SetupConsumed { .. }
+                    ) {
+                        return Err(ServiceError::InvalidInputForState(
+                            statemachine.step.step_name().into(),
+                        ));
+                    }
                 }
 
                 let deposit = self

--- a/crates/rpc/service/src/default.rs
+++ b/crates/rpc/service/src/default.rs
@@ -294,7 +294,11 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for Defa
             .map_err(ServiceError::storage)?
             .ok_or(ServiceError::StateMachineNotFound(*sm_id))?;
 
-        if statemachine.step != garbler::Step::SetupComplete {
+        use garbler::Step;
+        if !matches!(
+            statemachine.step,
+            Step::SetupComplete | Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. }
+        ) {
             return Err(ServiceError::InvalidInputForState(
                 statemachine.step.step_name().into(),
             ));
@@ -337,7 +341,11 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for Defa
             .map_err(ServiceError::storage)?
             .ok_or(ServiceError::StateMachineNotFound(*sm_id))?;
 
-        if statemachine.step != evaluator::Step::SetupComplete {
+        use evaluator::Step;
+        if !matches!(
+            statemachine.step,
+            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. }
+        ) {
             return Err(ServiceError::InvalidInputForState(
                 statemachine.step.step_name().into(),
             ));

--- a/crates/rpc/service/src/tests.rs
+++ b/crates/rpc/service/src/tests.rs
@@ -673,6 +673,32 @@ async fn init_garbler_deposit_accepts_setup_consumed() {
 }
 
 #[tokio::test]
+async fn init_evaluator_deposit_accepts_evaluating_tables() {
+    let h = TestHarness::new();
+    h.setup_evaluator(evaluator::Step::EvaluatingTables {
+        deposit_id: test_deposit_id(99),
+        eval_indices: std::array::from_fn(|i| Index::new(i + 1).expect("valid index")),
+        eval_commitments: HeapArray::new(|i| [i as u8; 32].into()),
+        evaluated: HeapArray::from_elem(false),
+    })
+    .await;
+
+    let deposit_id = test_deposit_id(1);
+    let init = EvaluatorDepositInit {
+        sighashes: test_sighashes(),
+        deposit_inputs: [0u8; N_DEPOSIT_INPUT_WIRES],
+    };
+
+    h.api
+        .init_evaluator_deposit(&h.evaluator_sm_id(), &deposit_id, init)
+        .await
+        .unwrap();
+
+    let cmd = h.recv_command().await;
+    assert!(matches!(cmd.kind, SmCommandKind::DepositInit { .. }));
+}
+
+#[tokio::test]
 async fn init_evaluator_deposit_accepts_setup_consumed() {
     let h = TestHarness::new();
     h.setup_evaluator(evaluator::Step::SetupConsumed {

--- a/crates/rpc/service/src/tests.rs
+++ b/crates/rpc/service/src/tests.rs
@@ -540,8 +540,7 @@ async fn init_garbler_deposit_rejects_duplicate_deposit() {
 #[tokio::test]
 async fn init_evaluator_deposit_rejects_wrong_step() {
     let h = TestHarness::new();
-    h.setup_evaluator_with_config(evaluator::Step::Uninit, None)
-        .await;
+    h.setup_evaluator(evaluator::Step::Uninit).await;
 
     let deposit_id = test_deposit_id(1);
     let init = EvaluatorDepositInit {
@@ -613,6 +612,88 @@ async fn init_evaluator_deposit_dispatches_correct_input() {
         }
         other => panic!("expected Evaluator DepositInit, got {other:?}"),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Group 5b: deposit init accepted in post-setup states
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn init_garbler_deposit_accepts_completing_adaptors() {
+    let h = TestHarness::new();
+    h.setup_garbler(garbler::Step::CompletingAdaptors {
+        deposit_id: test_deposit_id(99),
+    })
+    .await;
+
+    let deposit_id = test_deposit_id(1);
+    let init = GarblerDepositInit {
+        adaptor_pk: try_into_x_only_pubkey(
+            KeyPair::rand(&mut ChaCha20Rng::seed_from_u64(0)).public_key(),
+        )
+        .unwrap(),
+        sighashes: test_sighashes(),
+        deposit_inputs: [0u8; N_DEPOSIT_INPUT_WIRES],
+    };
+
+    h.api
+        .init_garbler_deposit(&h.garbler_sm_id(), &deposit_id, init)
+        .await
+        .unwrap();
+
+    let cmd = h.recv_command().await;
+    assert!(matches!(cmd.kind, SmCommandKind::DepositInit { .. }));
+}
+
+#[tokio::test]
+async fn init_garbler_deposit_accepts_setup_consumed() {
+    let h = TestHarness::new();
+    h.setup_garbler(garbler::Step::SetupConsumed {
+        deposit_id: test_deposit_id(99),
+    })
+    .await;
+
+    let deposit_id = test_deposit_id(1);
+    let init = GarblerDepositInit {
+        adaptor_pk: try_into_x_only_pubkey(
+            KeyPair::rand(&mut ChaCha20Rng::seed_from_u64(0)).public_key(),
+        )
+        .unwrap(),
+        sighashes: test_sighashes(),
+        deposit_inputs: [0u8; N_DEPOSIT_INPUT_WIRES],
+    };
+
+    h.api
+        .init_garbler_deposit(&h.garbler_sm_id(), &deposit_id, init)
+        .await
+        .unwrap();
+
+    let cmd = h.recv_command().await;
+    assert!(matches!(cmd.kind, SmCommandKind::DepositInit { .. }));
+}
+
+#[tokio::test]
+async fn init_evaluator_deposit_accepts_setup_consumed() {
+    let h = TestHarness::new();
+    h.setup_evaluator(evaluator::Step::SetupConsumed {
+        deposit_id: test_deposit_id(99),
+        success: true,
+    })
+    .await;
+
+    let deposit_id = test_deposit_id(1);
+    let init = EvaluatorDepositInit {
+        sighashes: test_sighashes(),
+        deposit_inputs: [0u8; N_DEPOSIT_INPUT_WIRES],
+    };
+
+    h.api
+        .init_evaluator_deposit(&h.evaluator_sm_id(), &deposit_id, init)
+        .await
+        .unwrap();
+
+    let cmd = h.recv_command().await;
+    assert!(matches!(cmd.kind, SmCommandKind::DepositInit { .. }));
 }
 
 // ---------------------------------------------------------------------------

--- a/functional-tests/tests/e2e/fn_e2e_deposit_after_withdrawal.py
+++ b/functional-tests/tests/e2e/fn_e2e_deposit_after_withdrawal.py
@@ -1,0 +1,116 @@
+import secrets
+
+import flexitest
+
+from common.base_test import BaseTest
+from common.mosaic_e2e import (
+    check_setup_consumed,
+    handle_deposit,
+    handle_setup,
+)
+from common.rpc import RpcError
+from common.wait import wait_until
+from envs.mosaic_env import MosaicEnv
+
+
+@flexitest.register
+class MosaicE2EDepositAfterWithdrawalTest(BaseTest):
+    """
+    Tests that after a withdrawal is initiated and after it completes:
+    1. A new deposit can be created on the same tableset.
+    2. A new withdrawal on the consumed setup fails with InvalidInputForState.
+    """
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(MosaicEnv(2))
+
+    def main(self, ctx: flexitest.RunContext):
+        garbler = ctx.get_service("mosaic_0").create_rpc()
+        evaluator = ctx.get_service("mosaic_1").create_rpc()
+
+        setup_inputs = secrets.token_hex(32)
+        garbler_tsid, evaluator_tsid = handle_setup(self.logger, garbler, evaluator, setup_inputs)
+        self.logger.info("*** SETUP COMPLETED ***")
+
+        # even deposit idx -> evaluator wins
+        deposit_idx = 2
+        deposit_id = handle_deposit(
+            self.logger, garbler, evaluator, garbler_tsid, evaluator_tsid, deposit_idx
+        )
+        self.logger.info("*** DEPOSIT COMPLETED ***")
+
+        # -- Initiate withdrawal (garbler side only) --
+        withdrawal_inputs = secrets.token_hex(128)
+        garbler.mosaic_completeAdaptorSigs(garbler_tsid, deposit_id, withdrawal_inputs)
+
+        wait_until(
+            lambda: check_setup_consumed(self.logger, "garbler withdrawal", garbler_tsid, garbler),
+            error_msg="garbler withdrawal did not complete within timeout",
+        )
+        self.logger.info("*** WITHDRAWAL INITIATED (garbler consumed) ***")
+
+        # -- Checks after withdrawal initiated (garbler consumed, evaluator still SetupComplete) --
+
+        # Check 2: re-initiating withdrawal on the same deposit should fail
+        # RPC error code 12 = InvalidInputForState (tableset is no longer SetupComplete)
+        try:
+            garbler.mosaic_completeAdaptorSigs(garbler_tsid, deposit_id, secrets.token_hex(128))
+            raise AssertionError("expected withdrawal to fail on consumed garbler")
+        except RpcError as e:
+            self.logger.info(
+                f"withdrawal on consumed garbler correctly rejected: code={e.code} msg={e.msg}"
+            )
+            assert e.code == 12, f"expected error code 12 (InvalidInputForState), got {e.code}"
+
+        # Check 1: new deposit should be allowed on the same tableset
+        new_deposit_idx_1 = 4
+        handle_deposit(
+            self.logger, garbler, evaluator, garbler_tsid, evaluator_tsid, new_deposit_idx_1
+        )
+        self.logger.info("new deposit after withdrawal initiated: OK")
+
+        # -- Complete withdrawal (evaluator side) --
+        completed_adaptor_sigs = garbler.mosaic_getCompletedAdaptorSigs(garbler_tsid)
+        evaluator.mosaic_evaluateTableset(
+            evaluator_tsid,
+            deposit_id,
+            {
+                "withdrawal_inputs": withdrawal_inputs,
+                "completed_signatures": completed_adaptor_sigs,
+            },
+        )
+
+        wait_until(
+            lambda: check_setup_consumed(
+                self.logger, "evaluator withdrawal", evaluator_tsid, evaluator
+            ),
+            error_msg="evaluator withdrawal did not complete within timeout",
+        )
+        self.logger.info("*** WITHDRAWAL COMPLETED (both consumed) ***")
+
+        # -- Checks after withdrawal completed (both sides consumed) --
+
+        # Check 2: re-initiating withdrawal on the same deposit should fail
+        # RPC error code 12 = InvalidInputForState (tableset is no longer SetupComplete)
+        try:
+            evaluator.mosaic_evaluateTableset(
+                evaluator_tsid,
+                deposit_id,
+                {
+                    "withdrawal_inputs": secrets.token_hex(128),
+                    "completed_signatures": completed_adaptor_sigs,
+                },
+            )
+            raise AssertionError("expected withdrawal to fail on consumed evaluator")
+        except RpcError as e:
+            self.logger.info(
+                f"withdrawal on consumed evaluator correctly rejected: code={e.code} msg={e.msg}"
+            )
+            assert e.code == 12, f"expected error code 12 (InvalidInputForState), got {e.code}"
+
+        # Check 1: new deposit should be allowed on the same tableset
+        new_deposit_idx_2 = 6
+        handle_deposit(
+            self.logger, garbler, evaluator, garbler_tsid, evaluator_tsid, new_deposit_idx_2
+        )
+        self.logger.info("new deposit after withdrawal completed: OK")


### PR DESCRIPTION
Deposit init is now accepted in post-setup states (EvaluatingTables/ CompletingAdaptors, SetupConsumed), not just SetupComplete. 

Adds RPC unit tests for deposit init in post-setup states and an E2E test for deposit-after-withdrawal.

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
