### PR TITLE
ci: enforce Trivy as hard gate before ECR push

### DIFF
--- a/.github/scripts/render_trivy_summary.py
+++ b/.github/scripts/render_trivy_summary.py
@@ -1,122 +1,58 @@
 #!/usr/bin/env python3
-"""render_trivy_summary.py — Convert a Trivy JSON report to a Markdown summary table.
-
-Called by the "Render Trivy markdown summary" step in docker-publish-ecr.yml after
-the JSON-format Trivy scan completes. Reads trivy-results/mosaic.json and writes
-trivy-results/mosaic.md, which is then appended to $GITHUB_STEP_SUMMARY so the
-table appears on the workflow summary page.
-
-A separate SARIF-format scan uploads structured results to the GitHub Security tab
-for tracking; this script handles only the human-readable workflow summary.
-
-Why JSON → Python instead of the built-in Trivy table format?
-  The Trivy `table` format emits plain text which renders as a code block in
-  $GITHUB_STEP_SUMMARY. JSON → Python lets us produce a proper Markdown table
-  (rendered natively by GitHub) that matches the strata-bridge workflow layout.
-
-Expected env vars (injected by the workflow step's env: block):
-    IMAGE_REF  — full ECR image reference shown in the summary header
-    IMAGE_TAG  — short SHA tag (unused in output, available for future use)
-
-Output:
-    trivy-results/mosaic.md
-"""
+"""Parse trivy-results/mosaic.json and write a Markdown summary to trivy-results/mosaic.md."""
 
 import json
 import os
-from collections import Counter
+import sys
 from pathlib import Path
 
+IMAGE_REF = os.environ.get("IMAGE_REF", "unknown")
+IMAGE_TAG = os.environ.get("IMAGE_TAG", "unknown")
 
-# Canonical ordering used for the severity count table columns and finding sort.
-SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"]
-
-# Maximum number of individual findings to list in the summary.
-# Keeps the summary page scannable — full results are in the uploaded artifact.
-MAX_FINDINGS = 10
+INPUT = Path("trivy-results/mosaic.json")
+OUTPUT = Path("trivy-results/mosaic.md")
 
 
-def iter_items(value: object) -> list[dict]:
-    """Normalise a Trivy result field to a flat list of dicts.
+def main():
+    if not INPUT.exists():
+        print(f"::warning::Trivy JSON not found at {INPUT}, skipping summary", file=sys.stderr)
+        return
 
-    Trivy can emit a list, a dict, or null for the same field depending on the
-    scanner mode and image content. This handles all three cases without fragile
-    shell conditionals.
-    """
-    if isinstance(value, list):
-        return [item for item in value if isinstance(item, dict)]
-    if isinstance(value, dict):
-        return [item for item in value.values() if isinstance(item, dict)]
-    return []
+    data = json.loads(INPUT.read_text())
 
+    vulns = []
+    for result in data.get("Results", []):
+        for v in result.get("Vulnerabilities") or []:
+            vulns.append({
+                "severity": v.get("Severity", ""),
+                "id": v.get("VulnerabilityID", ""),
+                "pkg": v.get("PkgName", ""),
+                "installed": v.get("InstalledVersion", ""),
+                "fixed": v.get("FixedVersion", "") or "—",
+                "title": v.get("Title", ""),
+            })
 
-def main() -> None:
-    image_ref = os.environ.get("IMAGE_REF", "mosaic")
-    json_path = Path("trivy-results/mosaic.json")
+    lines = [f"### Trivy vulnerability scan — `{IMAGE_TAG}`", ""]
 
-    lines: list[str] = [
-        "### Trivy Summary: Mosaic",
-        "",
-        f"`{image_ref}`",
-        "",
-        "- Scanners: `vuln`",
-        "- Severity filter: `HIGH,CRITICAL` (unfixed vulnerabilities ignored)",
-        "",
-    ]
-
-    if not json_path.exists():
-        # JSON scan step may have been skipped or failed; emit a placeholder rather
-        # than crashing the summary step.
-        lines += ["Trivy did not produce a JSON report for this image.", ""]
+    if not vulns:
+        lines.append(f":white_check_mark: No HIGH or CRITICAL vulnerabilities found in `{IMAGE_REF}`.")
     else:
-        results = json.loads(json_path.read_text(encoding="utf-8"))
-        counts: Counter = Counter()
-        findings: list[dict] = []
-
-        for target in results.get("Results", []):
-            if not isinstance(target, dict):
-                continue
-            target_name = target.get("Target", "unknown")
-
-            for vuln in iter_items(target.get("Vulnerabilities")):
-                sev = vuln.get("Severity", "UNKNOWN")
-                counts[sev] += 1
-                findings.append({
-                    "severity": sev,
-                    "target": target_name,
-                    "kind": "vuln",
-                    "id": vuln.get("VulnerabilityID", "unknown"),
-                })
-
-        # Sort CRITICAL → HIGH → MEDIUM → LOW → UNKNOWN, then alphabetically by ID
-        # for stable ordering across runs.
-        findings.sort(key=lambda f: (
-            SEVERITY_ORDER.index(f["severity"]) if f["severity"] in SEVERITY_ORDER else len(SEVERITY_ORDER),
-            f["id"],
-        ))
-
-        # Severity count summary table
         lines += [
-            "| CRITICAL | HIGH | MEDIUM | LOW | UNKNOWN |",
-            "| --- | --- | --- | --- | --- |",
-            "| " + " | ".join(str(counts.get(s, 0)) for s in SEVERITY_ORDER) + " |",
+            f":x: **{len(vulns)} HIGH/CRITICAL vulnerability(ies)** found in `{IMAGE_REF}`.",
             "",
+            "| Severity | CVE | Package | Installed | Fixed | Summary |",
+            "|---|---|---|---|---|---|",
         ]
+        severity_order = {"CRITICAL": 0, "HIGH": 1}
+        for v in sorted(vulns, key=lambda x: (severity_order.get(x["severity"], 9), x["id"])):
+            title = (v["title"][:57] + "…") if len(v["title"]) > 60 else v["title"]
+            lines.append(
+                f"| {v['severity']} | {v['id']} | `{v['pkg']}` "
+                f"| {v['installed']} | {v['fixed']} | {title} |"
+            )
 
-        if findings:
-            lines += [
-                f"Top findings (showing {min(len(findings), MAX_FINDINGS)} of {len(findings)}):",
-                "",
-                "| Severity | Type | ID | Target |",
-                "| --- | --- | --- | --- |",
-            ]
-            for f in findings[:MAX_FINDINGS]:
-                lines.append(f"| {f['severity']} | {f['kind']} | `{f['id']}` | `{f['target']}` |")
-            lines.append("")
-        else:
-            lines += ["No HIGH/CRITICAL unfixed vulnerabilities found.", ""]
-
-    Path("trivy-results/mosaic.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    OUTPUT.write_text("\n".join(lines) + "\n")
+    print(f"Written: {OUTPUT}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -1,6 +1,9 @@
 name: Docker Publish to ECR
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -171,8 +171,8 @@ jobs:
             touch build-src/.trivyignore
           fi
 
-      # Hard gate — build fails and no image is pushed if any unfixed vulnerability
-      # is found at any severity. Add justified exceptions to build-src/.trivyignore.
+      # Hard gate — build fails and no image is pushed if CRITICAL or HIGH unfixed
+      # vulnerabilities are found. Add justified exceptions to build-src/.trivyignore.
       - name: Scan Mosaic image with Trivy (hard gate)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -180,7 +180,7 @@ jobs:
           format: json
           output: trivy-results/mosaic.json
           scanners: vuln
-          severity: CRITICAL,HIGH,MEDIUM,LOW
+          severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: "1"
           trivyignores: build-src/.trivyignore
@@ -197,6 +197,7 @@ jobs:
           output: trivy-results/mosaic.sarif
           scanners: vuln
           severity: CRITICAL,HIGH,MEDIUM,LOW
+
           ignore-unfixed: true
           exit-code: "0"
           trivyignores: build-src/.trivyignore

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -164,11 +164,16 @@ jobs:
       - name: Create Trivy output directory
         run: mkdir -p trivy-results
 
+      # Ensure .trivyignore exists in the build source — older refs may not have it.
+      - name: Ensure .trivyignore exists in build-src
+        run: |
+          if [[ ! -f build-src/.trivyignore ]]; then
+            touch build-src/.trivyignore
+          fi
+
       # Hard gate — build fails and no image is pushed if CRITICAL or HIGH unfixed
-      # vulnerabilities are found. Add justified exceptions to .trivyignore.
-      # TODO(STR-2637): remove continue-on-error once base image CVEs are resolved.
+      # vulnerabilities are found. Add justified exceptions to build-src/.trivyignore.
       - name: Scan Mosaic image with Trivy (hard gate)
-        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.IMAGE_REF }}
@@ -178,7 +183,7 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: "1"
-          trivyignores: .trivyignore
+          trivyignores: build-src/.trivyignore
 
       # Advisory SARIF scan — runs even if the hard gate failed so that findings
       # are always visible in the Security tab for triage.
@@ -194,7 +199,7 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: "0"
-          trivyignores: .trivyignore
+          trivyignores: build-src/.trivyignore
 
       # Advisory SBOM — CycloneDX artifact for supply chain tracking.
       - name: Generate SBOM with Trivy (CycloneDX)
@@ -207,7 +212,7 @@ jobs:
           output: trivy-results/mosaic.sbom.json
           scanners: vuln
           exit-code: "0"
-          trivyignores: .trivyignore
+          trivyignores: build-src/.trivyignore
 
       # Converts trivy-results/mosaic.json → trivy-results/mosaic.md.
       # The .md file is appended to $GITHUB_STEP_SUMMARY in the "Append publish summary"

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -166,7 +166,9 @@ jobs:
 
       # Hard gate — build fails and no image is pushed if CRITICAL or HIGH unfixed
       # vulnerabilities are found. Add justified exceptions to .trivyignore.
+      # TODO(STR-2637): remove continue-on-error once base image CVEs are resolved.
       - name: Scan Mosaic image with Trivy (hard gate)
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.IMAGE_REF }}

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -11,12 +11,7 @@ on:
         description: Optional image tag override. Defaults to the resolved short SHA.
         required: false
         type: string
-  push:
-    branches:
-      - 'infra/**'
-    paths:
-      - 'docker/**'
-      - '.github/workflows/docker-publish-ecr.yml'
+
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -164,15 +164,17 @@ jobs:
       - name: Create Trivy output directory
         run: mkdir -p trivy-results
 
-      # Ensure .trivyignore exists in the build source — older refs may not have it.
-      - name: Ensure .trivyignore exists in build-src
+      # .trivyignore lives in the root checkout (always main) so only reviewed,
+      # merged code can suppress CVEs — an untrusted inputs.ref cannot manipulate it.
+      # Guard creates an empty file for runs against refs that pre-date the file.
+      - name: Ensure .trivyignore exists
         run: |
-          if [[ ! -f build-src/.trivyignore ]]; then
-            touch build-src/.trivyignore
+          if [[ ! -f .trivyignore ]]; then
+            touch .trivyignore
           fi
 
       # Hard gate — build fails and no image is pushed if CRITICAL or HIGH unfixed
-      # vulnerabilities are found. Add justified exceptions to build-src/.trivyignore.
+      # vulnerabilities are found. Add justified exceptions to .trivyignore via PR.
       - name: Scan Mosaic image with Trivy (hard gate)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -183,7 +185,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: "1"
-          trivyignores: build-src/.trivyignore
+          trivyignores: .trivyignore
 
       # Advisory SARIF scan — runs even if the hard gate failed so that findings
       # are always visible in the Security tab for triage.
@@ -197,10 +199,9 @@ jobs:
           output: trivy-results/mosaic.sarif
           scanners: vuln
           severity: CRITICAL,HIGH,MEDIUM,LOW
-
           ignore-unfixed: true
           exit-code: "0"
-          trivyignores: build-src/.trivyignore
+          trivyignores: .trivyignore
 
       # Advisory SBOM — CycloneDX artifact for supply chain tracking.
       - name: Generate SBOM with Trivy (CycloneDX)
@@ -213,7 +214,7 @@ jobs:
           output: trivy-results/mosaic.sbom.json
           scanners: vuln
           exit-code: "0"
-          trivyignores: build-src/.trivyignore
+          trivyignores: .trivyignore
 
       # Converts trivy-results/mosaic.json → trivy-results/mosaic.md.
       # The .md file is appended to $GITHUB_STEP_SUMMARY in the "Append publish summary"

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -11,6 +11,12 @@ on:
         description: Optional image tag override. Defaults to the resolved short SHA.
         required: false
         type: string
+  push:
+    branches:
+      - 'infra/**'
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-publish-ecr.yml'
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
@@ -142,7 +148,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Build and push Mosaic image to private ECR
+      # Build to local Docker daemon so Trivy can scan the image before any push.
+      - name: Build Mosaic image
         run: |
           set -euo pipefail
           docker buildx build \
@@ -151,11 +158,93 @@ jobs:
             --cache-from "type=gha,scope=mosaic" \
             --cache-to "type=gha,scope=mosaic,mode=max" \
             --tag "${IMAGE_REF}" \
-            --push \
+            --load \
             build-src
 
-      - name: Pull image from private ECR
-        run: docker pull "${IMAGE_REF}"
+      - name: Create Trivy output directory
+        run: mkdir -p trivy-results
+
+      # Hard gate — build fails and no image is pushed if CRITICAL or HIGH unfixed
+      # vulnerabilities are found. Add justified exceptions to .trivyignore.
+      - name: Scan Mosaic image with Trivy (hard gate)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_REF }}
+          format: json
+          output: trivy-results/mosaic.json
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore
+
+      # Advisory SARIF scan — runs even if the hard gate failed so that findings
+      # are always visible in the Security tab for triage.
+      - name: Scan Mosaic image with Trivy (SARIF — Security tab)
+        if: always()
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_REF }}
+          format: sarif
+          output: trivy-results/mosaic.sarif
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "0"
+          trivyignores: .trivyignore
+
+      # Advisory SBOM — CycloneDX artifact for supply chain tracking.
+      - name: Generate SBOM with Trivy (CycloneDX)
+        if: always()
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_REF }}
+          format: cyclonedx
+          output: trivy-results/mosaic.sbom.json
+          scanners: vuln
+          exit-code: "0"
+          trivyignores: .trivyignore
+
+      # Converts trivy-results/mosaic.json → trivy-results/mosaic.md.
+      # The .md file is appended to $GITHUB_STEP_SUMMARY in the "Append publish summary"
+      # step below. See .github/scripts/render_trivy_summary.py for rendering logic.
+      - name: Render Trivy markdown summary
+        if: always()
+        continue-on-error: true
+        env:
+          IMAGE_REF: ${{ env.IMAGE_REF }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+        run: python3 .github/scripts/render_trivy_summary.py
+
+      # Uploads SARIF to the repository's Security → Code scanning tab.
+      # Requires security-events: write permission (set at job level above).
+      - name: Upload Trivy SARIF to GitHub Security tab
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: trivy-results/mosaic.sarif
+          category: mosaic-ecr
+
+      # Bundles JSON, SARIF, SBOM, and Markdown as a downloadable artifact.
+      # Artifact name includes the image tag so runs can be compared side-by-side.
+      - name: Upload Trivy results artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-mosaic-${{ env.IMAGE_TAG }}
+          if-no-files-found: ignore
+          path: |
+            trivy-results/mosaic.json
+            trivy-results/mosaic.sarif
+            trivy-results/mosaic.sbom.json
+            trivy-results/mosaic.md
+
+      # Push only reaches this step if the hard gate scan above passed.
+      - name: Push Mosaic image to private ECR
+        run: docker push "${IMAGE_REF}"
 
       - name: Configure public ECR credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
@@ -196,72 +285,6 @@ jobs:
             --output text)"
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
 
-      - name: Create Trivy output directory
-        run: mkdir -p trivy-results
-
-      # Two Trivy scans are intentional:
-      #   1. JSON  → parsed by .github/scripts/render_trivy_summary.py to produce a
-      #              Markdown table that renders natively in the workflow summary page.
-      #   2. SARIF → uploaded to the GitHub Security tab for structured CVE tracking.
-      # Both scans are advisory (exit-code: "0") — findings never block the publish.
-      - name: Scan Mosaic image with Trivy (JSON — summary table)
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_REF }}
-          format: json
-          output: trivy-results/mosaic.json
-          scanners: vuln
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: "0"
-
-      - name: Scan Mosaic image with Trivy (SARIF — Security tab)
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_REF }}
-          format: sarif
-          output: trivy-results/mosaic.sarif
-          scanners: vuln
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: "0"
-
-      # Converts trivy-results/mosaic.json → trivy-results/mosaic.md.
-      # The .md file is appended to $GITHUB_STEP_SUMMARY in the "Append publish summary"
-      # step below. See .github/scripts/render_trivy_summary.py for rendering logic.
-      - name: Render Trivy markdown summary
-        if: always()
-        continue-on-error: true
-        env:
-          IMAGE_REF: ${{ env.IMAGE_REF }}
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-        run: python3 .github/scripts/render_trivy_summary.py
-
-      # Uploads SARIF to the repository's Security → Code scanning tab.
-      # Requires security-events: write permission (set at job level above).
-      - name: Upload Trivy SARIF to GitHub Security tab
-        if: always()
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
-        with:
-          sarif_file: trivy-results/mosaic.sarif
-          category: mosaic-ecr
-
-      # Bundles all three Trivy output formats as a downloadable artifact.
-      # Artifact name includes the image tag so runs can be compared side-by-side.
-      - name: Upload Trivy results artifact
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: trivy-mosaic-${{ env.IMAGE_TAG }}
-          if-no-files-found: ignore
-          path: |
-            trivy-results/mosaic.json
-            trivy-results/mosaic.sarif
-            trivy-results/mosaic.md
-
       - name: Append publish summary
         if: always()
         env:
@@ -275,7 +298,7 @@ jobs:
             echo "- Resolved SHA: \`${RESOLVED_SHA}\`"
             echo "- Image: \`${IMAGE_REF}\`"
             echo "- Public image: \`${PUBLIC_IMAGE_REF}\`"
-            echo "- Digest: \`${IMAGE_DIGEST}\`"
+            echo "- Digest: \`${IMAGE_DIGEST:-not pushed}\`"
             echo "- Trivy artifact: \`${trivy_artifact}\`"
             echo
             # Render the Trivy markdown table produced by render_trivy_summary.py.

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -171,8 +171,8 @@ jobs:
             touch build-src/.trivyignore
           fi
 
-      # Hard gate — build fails and no image is pushed if CRITICAL or HIGH unfixed
-      # vulnerabilities are found. Add justified exceptions to build-src/.trivyignore.
+      # Hard gate — build fails and no image is pushed if any unfixed vulnerability
+      # is found at any severity. Add justified exceptions to build-src/.trivyignore.
       - name: Scan Mosaic image with Trivy (hard gate)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -180,7 +180,7 @@ jobs:
           format: json
           output: trivy-results/mosaic.json
           scanners: vuln
-          severity: HIGH,CRITICAL
+          severity: CRITICAL,HIGH,MEDIUM,LOW
           ignore-unfixed: true
           exit-code: "1"
           trivyignores: build-src/.trivyignore
@@ -196,7 +196,7 @@ jobs:
           format: sarif
           output: trivy-results/mosaic.sarif
           scanners: vuln
-          severity: HIGH,CRITICAL
+          severity: CRITICAL,HIGH,MEDIUM,LOW
           ignore-unfixed: true
           exit-code: "0"
           trivyignores: build-src/.trivyignore

--- a/.trivyignore
+++ b/.trivyignore
@@ -11,14 +11,3 @@
 # Example:
 #   # CVE-2023-12345: affects x86 only; Mosaic targets amd64 via distroless base — review by 2024-06-01
 #   CVE-2023-12345
-
-# --- Active suppressions ---
-
-# CVE-2026-2219: MEDIUM — dpkg base image package; fix available in 1.22.6ubuntu6.5, pending upstream base image update — review by 2026-06-15
-CVE-2026-2219
-
-# CVE-2026-4878: MEDIUM — libcap2 base image package; fix available in 1:2.66-5ubuntu2.2, pending upstream base image update — review by 2026-06-15
-CVE-2026-4878
-
-# CVE-2026-5958: MEDIUM — sed base image package; fix available in 4.9-2build1, pending upstream base image update — review by 2026-06-15
-CVE-2026-5958

--- a/.trivyignore
+++ b/.trivyignore
@@ -11,3 +11,14 @@
 # Example:
 #   # CVE-2023-12345: affects x86 only; Mosaic targets amd64 via distroless base — review by 2024-06-01
 #   CVE-2023-12345
+
+# --- Active suppressions ---
+
+# CVE-2026-2219: MEDIUM — dpkg base image package; fix available in 1.22.6ubuntu6.5, pending upstream base image update — review by 2026-06-15
+CVE-2026-2219
+
+# CVE-2026-4878: MEDIUM — libcap2 base image package; fix available in 1:2.66-5ubuntu2.2, pending upstream base image update — review by 2026-06-15
+CVE-2026-4878
+
+# CVE-2026-5958: MEDIUM — sed base image package; fix available in 4.9-2build1, pending upstream base image update — review by 2026-06-15
+CVE-2026-5958

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# .trivyignore — CVE suppressions for Trivy image scans
+#
+# Format: one CVE ID per line; blank lines and lines starting with # are ignored.
+#
+# Before adding an entry:
+#   1. Confirm the CVE does not affect this project (wrong arch, unexposed code path, etc.)
+#   2. Add the CVE ID with a comment explaining why it is safe to suppress
+#   3. Include a review-by date if a patched release is expected soon
+#   4. Open a PR — all exceptions require security review
+#
+# Example:
+#   # CVE-2023-12345: affects x86 only; Mosaic targets amd64 via distroless base — review by 2024-06-01
+#   CVE-2023-12345

--- a/docs/trivy-scanning.md
+++ b/docs/trivy-scanning.md
@@ -1,0 +1,52 @@
+# Trivy Container Image Scanning
+
+All Mosaic images must pass a Trivy vulnerability scan before being pushed to ECR.
+This is enforced as a hard gate in the [Docker Publish to ECR](../.github/workflows/docker-publish-ecr.yml) workflow.
+
+## How it works
+
+The workflow builds the image locally (no push yet), then runs three Trivy scans:
+
+| Scan | Format | Severity | Behaviour |
+|---|---|---|---|
+| Hard gate | JSON | HIGH, CRITICAL | Fails the build; image is never pushed if unfixed vulns are found |
+| Security tab | SARIF | HIGH, CRITICAL | Advisory — always runs; uploaded to GitHub Code Scanning |
+| SBOM | CycloneDX | all | Advisory — attached as a workflow artifact |
+
+CVE suppressions live in [`.trivyignore`](../.trivyignore) at the repo root.
+
+## Reading scan results
+
+**Workflow summary** — every run appends a vulnerability table to the run's Summary page.
+Open the run → **Summary** to see a ranked table of any HIGH/CRITICAL findings.
+
+**GitHub Security tab** — SARIF results appear under **Security → Code scanning alerts**.
+Filter by `Tool: Trivy` to see all findings across runs.
+
+**Artifact download** — download the `trivy-mosaic-<tag>` artifact from the workflow run
+to get the raw JSON, SARIF, and CycloneDX SBOM files for offline analysis.
+
+## Fixing a blocked build
+
+If the hard gate fails:
+
+1. Open the **Scan Mosaic image with Trivy (hard gate)** step log to see which CVEs fired.
+2. Update the base image in `docker/Dockerfile` to a version with a fix available, **or**
+3. Add a justified exception to `.trivyignore` (see below) and open a PR for review.
+4. Re-trigger via **Actions → Docker Publish to ECR → Run workflow**, or push to an `infra/**` branch.
+
+## Adding a CVE exception
+
+Only suppress a CVE when you can demonstrate it does not affect this project
+(wrong architecture, unexposed code path, dependency not reachable at runtime, etc.).
+
+```
+# CVE-2023-12345: affects x86 only; Mosaic targets amd64 via distroless base — review by 2024-06-01
+CVE-2023-12345
+```
+
+Steps:
+
+1. Add the CVE ID to `.trivyignore` with a comment that explains the rationale and a review-by date.
+2. Open a PR — exceptions are subject to security team review.
+3. Revisit suppressed CVEs on the stated review-by date and remove them once a fix is available.


### PR DESCRIPTION
## Description

Implements STR-2637. Adds Trivy vulnerability scanning as a hard gate in the ECR publish pipeline — no image reaches ECR unless it passes a CRITICAL/HIGH scan.

Builds on the two-checkout isolation introduced in #173 and addresses the one security gap that remained in that PR.

### Type of Change

- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Security fix

## What changed

**Pipeline order** — previously the image was pushed first, then scanned. Scan now runs against the locally built image before any push. A failed gate means ECR is never touched.

| Step | Before | After |
|---|---|---|
| Build | `--push` (immediate ECR push) | `--load` (local daemon only) |
| Hard gate | advisory, post-push | blocking, pre-push, `exit-code: 1` |
| SARIF | advisory post-push | advisory pre-push, `if: always()` so results appear even on gate failure |
| SBOM (CycloneDX) | not present | advisory, attached as artifact |
| Push to ECR | immediate on build | only after gate passes |

**Severity** — gate blocks on `CRITICAL,HIGH` with `ignore-unfixed: true`. SARIF captures `CRITICAL,HIGH,MEDIUM,LOW` for full visibility in the Security tab without blocking.

**`.trivyignore`** — anchored to the root checkout (always `main`). Only reviewed, merged code can suppress CVEs. An untrusted `inputs.ref` cannot manipulate the ignore list — this closes the bypass vector noted in #173's review.

**Branch trigger** — added `push: branches: ['infra/**']` with path filter so the pipeline is exercisable on feature branches without a manual dispatch.

**Supporting files**
- `.trivyignore` — empty with format docs; add justified exceptions here via PR
- `.github/scripts/render_trivy_summary.py` — renders the JSON report as a Markdown table in the workflow summary
- `docs/trivy-scanning.md` — how to read results and add CVE exceptions

## Notes to Reviewers

The `trivyignores` path was intentionally kept at `.trivyignore` (root/main checkout) rather than `build-src/.trivyignore`. This mirrors the same trust boundary established in #173 for workflow scripts — the ignore list requires a reviewed PR to change, preventing an untrusted `inputs.ref` from suppressing real CVEs.

Three CI runs on this branch validated the full flow:
1. Gate fired correctly on zero-unfixed-CVE image → passed, image pushed ✅
2. Gate fired correctly when MEDIUM/LOW gate was tested → blocked, no push ✅
3. Final config (CRITICAL/HIGH gate, all-severity SARIF) → passed, image pushed ✅

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.

## Related Issues

closes STR-2637