### PR TITLE
refactor(rpc): drop unused withdrawal_inputs from evaluator API (#199)

### DIFF
--- a/crates/rpc/server/src/server.rs
+++ b/crates/rpc/server/src/server.rs
@@ -258,7 +258,6 @@ impl<Svc: MosaicApi> MosaicRpcServer for RpcServerImpl<Svc> {
         let deposit_id = DepositId::from(deposit_id);
 
         let data = EvaluatorWithdrawalData {
-            withdrawal_inputs: withdrawal_data.withdrawal_inputs.into_inner(),
             signatures: withdrawal_data.completed_signatures.into_inner().to_vec(),
         };
 

--- a/crates/rpc/service/src/tests.rs
+++ b/crates/rpc/service/src/tests.rs
@@ -903,7 +903,6 @@ async fn evaluate_tableset_dispatches_disputed_withdrawal() {
         .await;
 
     let data = EvaluatorWithdrawalData {
-        withdrawal_inputs: [0xEEu8; N_WITHDRAWAL_INPUT_WIRES],
         signatures: test_completed_schnorr_signatures(),
     };
 
@@ -929,7 +928,6 @@ async fn evaluate_tableset_rejects_garbler_role() {
     let h = TestHarness::new();
 
     let data = EvaluatorWithdrawalData {
-        withdrawal_inputs: [0u8; N_WITHDRAWAL_INPUT_WIRES],
         signatures: test_completed_schnorr_signatures(),
     };
 
@@ -954,7 +952,6 @@ async fn evaluate_tableset_rejects_wrong_step() {
     .await;
 
     let data = EvaluatorWithdrawalData {
-        withdrawal_inputs: [0u8; N_WITHDRAWAL_INPUT_WIRES],
         signatures: test_completed_schnorr_signatures(),
     };
 

--- a/crates/rpc/service/src/types.rs
+++ b/crates/rpc/service/src/types.rs
@@ -5,7 +5,7 @@
 
 use bitcoin::{XOnlyPublicKey, secp256k1::schnorr::Signature as SchnorrSignature};
 use mosaic_cac_types::{
-    DepositId, DepositInputs, HeapArray, SetupInputs, Sighashes, WithdrawalInputs,
+    DepositId, DepositInputs, HeapArray, SetupInputs, Sighashes,
     state_machine::{
         Role,
         evaluator::{self},
@@ -121,8 +121,6 @@ pub struct EvaluatorDepositInit {
 /// Data for an evaluator contested withdrawal.
 #[derive(Debug)]
 pub struct EvaluatorWithdrawalData {
-    /// Withdrawal input wire values.
-    pub withdrawal_inputs: WithdrawalInputs,
     /// Completed adaptor signatures from the garbler (bitcoin Schnorr format).
     pub signatures: Vec<SchnorrSignature>,
 }

--- a/crates/rpc/types/src/deposit.rs
+++ b/crates/rpc/types/src/deposit.rs
@@ -37,10 +37,6 @@ pub struct EvaluatorDepositConfig {
 }
 
 /// Configuration provided as part of contested withdrawal for evaluator.
-///
-/// The evaluator recovers the withdrawal input wire values from the completed adaptor
-/// signatures using locally stored adaptor state, so callers no longer need to supply
-/// withdrawal-input hints.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EvaluatorWithdrawalConfig {
     /// Completed adaptor signatures.

--- a/crates/rpc/types/src/deposit.rs
+++ b/crates/rpc/types/src/deposit.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     RpcCompletedSignatures, RpcDepositId, RpcDepositInputs, RpcInputSighashes, RpcTablesetId,
-    RpcWithdrawalInputs,
 };
 
 /// Configuration provided as part of deposit setup for garbler.
@@ -38,15 +37,12 @@ pub struct EvaluatorDepositConfig {
 }
 
 /// Configuration provided as part of contested withdrawal for evaluator.
+///
+/// The evaluator recovers the withdrawal input wire values from the completed adaptor
+/// signatures using locally stored adaptor state, so callers no longer need to supply
+/// withdrawal-input hints.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EvaluatorWithdrawalConfig {
-    /// Input values for withdrawal input wires.
-    /// Provided by the corresponding garbler node, this should be considered fast but potentially
-    /// invalid values to extract corresponding shares for evaluation. If these values are
-    /// invalid, fallback to checking all combination of values for withdrawal wires (max 128 * 256
-    /// checks) to get withdrawal inputs. It is guaranteed that atleast one set of values will be
-    /// valid.
-    pub withdrawal_inputs: RpcWithdrawalInputs,
     /// Completed adaptor signatures.
     pub completed_signatures: RpcCompletedSignatures,
 }


### PR DESCRIPTION
## Description

Resolves #199.

Removes the `withdrawal_inputs` field from the evaluator contested-withdrawal API on Mosaic `main`. The field was still on the RPC type and forwarded through the service-domain `EvaluatorWithdrawalData`, but `DefaultMosaicApi::evaluate_tableset` only consumed `data.signatures`. The evaluator state machine recovers the withdrawal input wire values from completed adaptor signatures + locally stored adaptor state in `extract_withdrawal_input_from_signatures(...)`, so callers don't need to provide them.

This matches the implementation flow @AaronFeickert confirmed in the issue thread: "we don't need to accept the (redundant and possibly inconsistent) counterproof."

### Type of Change

- [x] Refactor

## Changes

- `crates/rpc/types/src/deposit.rs`: drop `withdrawal_inputs: RpcWithdrawalInputs` from `EvaluatorWithdrawalConfig`; remove now-unused import; add a short doc note pointing readers at the signatures-only flow.
- `crates/rpc/server/src/server.rs`: drop the now-vestigial line that copied `withdrawal_inputs` into `EvaluatorWithdrawalData`.
- `crates/rpc/service/src/types.rs`: drop `withdrawal_inputs` from `EvaluatorWithdrawalData`; remove now-unused `WithdrawalInputs` import.
- `crates/rpc/service/src/tests.rs`: drop the three `withdrawal_inputs:` lines in `evaluate_tableset_*` tests that now reflect the new struct shape.

`complete_adaptor_sigs` still accepts and forwards `withdrawal_inputs` on the garbler side - that path is the actual consumer of the value and is unchanged.

## Notes to Reviewers

The RPC type comment for `withdrawal_inputs` said it was a "fast but potentially invalid hint with fallback to all combinations". The service-side `extract_withdrawal_input_from_signatures` in `crates/cac/protocol/src/evaluator/stf.rs` is the all-combinations path, so removing the hint just drops the fast-path-that-wasn't-wired. If you want to add the hint back as a real optimization later, it should land alongside its consumer in the evaluator STF.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed (RPC type doc comment).
- [x] My changes do not introduce new warnings (`cargo check --workspace` clean).
- [x] I have added tests that prove my changes are effective or that my feature works (existing `evaluate_tableset_*` tests updated and still pass).
- [x] New and existing tests pass with my changes (`cargo test -p mosaic-rpc-service evaluate_tableset` - 3/3 pass).
