### PR TITLE
cac/protocol: defer evaluator SetupComplete until every receipt is acked

### DIFF
--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -1137,15 +1137,25 @@ pub(crate) async fn restore<S: StateRead>(
             receipt_acked,
             ..
         } => {
-            for ii in 0..eval_commitments.len() {
-                let commitment = eval_commitments[ii];
-                if !received[ii] {
+            for i in 0..eval_commitments.len() {
+                let commitment = eval_commitments[i];
+                // (!received && receipt_acked) is unreachable by construction:
+                // `receipt_acked[i]` can only be set inside this step, and the
+                // ack handler requires `received[i] = true` to have been set
+                // previously (the receipt was emitted in
+                // `handle_table_received`). Asserting the invariant here keeps
+                // the loop honest if future changes accidentally violate it.
+                debug_assert!(
+                    !receipt_acked[i] || received[i],
+                    "receipt_acked[{i}] must imply received[{i}]"
+                );
+                if !received[i] {
                     // Combined action: registers expectation, sends request,
                     // receives table.
                     emit(actions, Action::ReceiveGarblingTable(commitment));
                     continue;
                 }
-                if !receipt_acked[ii] {
+                if !receipt_acked[i] {
                     // Receipt for this slot was emitted in `handle_table_received`
                     // but not yet acked by the network layer. Re-emit so the
                     // garbler is guaranteed to learn this table was received.

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -1047,6 +1047,18 @@ async fn handle_table_received<S: StateMut>(
                 return Err(SMError::InvalidInputData);
             };
 
+            // Validate the commitment first so a mismatched duplicate still
+            // aborts (matching the original behaviour) instead of being
+            // silently dropped by the idempotency guard below.
+            let expected_commitment = eval_commitments[pos];
+            if table_commitment != expected_commitment {
+                warn!(%index, "evaluator received garbling table with mismatched commitment, aborting");
+                root_state.step = Step::Aborted {
+                    reason: format!("invalid table for index {}", index),
+                };
+                return Ok(());
+            }
+
             // Idempotency: a duplicate `GarblingTableReceived` for an already-
             // marked slot would otherwise emit a stray `SendTableTransferReceipt`.
             // The framework should not deliver completions twice, but the
@@ -1054,15 +1066,6 @@ async fn handle_table_received<S: StateMut>(
             // guard in `TableTransferReceiptAcked`.
             if received[pos] {
                 debug!(%index, "duplicate GarblingTableReceived; ignoring");
-                return Ok(());
-            }
-
-            let expected_commitment = eval_commitments[pos];
-            if table_commitment != expected_commitment {
-                warn!(%index, "evaluator received garbling table with mismatched commitment, aborting");
-                root_state.step = Step::Aborted {
-                    reason: format!("invalid table for index {}", index),
-                };
                 return Ok(());
             }
 
@@ -1254,6 +1257,13 @@ pub(crate) async fn restore<S: StateRead>(
             }
         }
         Step::SetupConsumed { .. } => {}
+        // NOTE: an abort transition from `ReceivingGarblingTables` (commitment
+        // mismatch in `handle_table_received`) can leave earlier slots'
+        // `SendTableTransferReceipt` actions in flight, which this branch
+        // does not re-emit. Functionally acceptable here because the SM is
+        // terminating and will not act on the result, but it does leave the
+        // garbler peer without those receipts. Cleaner abort-propagation is
+        // tracked as a follow-up (see PR #257 review thread).
         Step::Aborted { .. } => {}
     }
 

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -384,6 +384,10 @@ pub(crate) async fn handle_action_result<S: StateMut>(
                 | Step::Aborted { .. } => {
                     debug!("late table transfer receipt ack after step advanced; ignoring");
                 }
+                // `SendTableTransferReceipt` is only emitted from
+                // `ReceivingGarblingTables`, and the step never moves
+                // backward. An ack landing here would imply a framework
+                // bug or stale id; fail closed.
                 _ => return Err(SMError::UnexpectedInput),
             }
         }
@@ -1042,6 +1046,16 @@ async fn handle_table_received<S: StateMut>(
             let Some(pos) = eval_idxs.iter().position(|&x| x == index) else {
                 return Err(SMError::InvalidInputData);
             };
+
+            // Idempotency: a duplicate `GarblingTableReceived` for an already-
+            // marked slot would otherwise emit a stray `SendTableTransferReceipt`.
+            // The framework should not deliver completions twice, but the
+            // handler stays robust to that — symmetric to the duplicate-ack
+            // guard in `TableTransferReceiptAcked`.
+            if received[pos] {
+                debug!(%index, "duplicate GarblingTableReceived; ignoring");
+                return Ok(());
+            }
 
             let expected_commitment = eval_commitments[pos];
             if table_commitment != expected_commitment {

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -332,9 +332,60 @@ pub(crate) async fn handle_action_result<S: StateMut>(
             handle_table_received(&mut root_state, state, index, table_commitment, actions).await?;
         }
         ActionResult::TableTransferReceiptAcked => {
-            // The table transfer receipt message was sent. No further state change needed —
-            // state was already advanced to SetupComplete when
-            // we emitted the SendTableTransferReceipt action.
+            let ActionId::SendTableTransferReceipt(commitment) = id else {
+                return Err(SMError::InvalidInputData);
+            };
+            match &mut root_state.step {
+                Step::ReceivingGarblingTables {
+                    eval_commitments,
+                    received,
+                    receipt_acked,
+                    ..
+                } => {
+                    let Some(pos) = eval_commitments.iter().position(|c| *c == commitment) else {
+                        // Ack for a commitment we don't know about — only
+                        // possible from a corrupted action id.
+                        return Err(SMError::InvalidInputData);
+                    };
+
+                    if receipt_acked[pos] {
+                        // Duplicate ack for the same receipt: idempotent
+                        // (a redundant `SendTableTransferReceipt` re-emitted
+                        // by `restore()` can still produce an ack).
+                        debug!(pos, "duplicate table transfer receipt ack; ignored");
+                        return Ok(());
+                    }
+
+                    receipt_acked[pos] = true;
+                    debug!(
+                        pos,
+                        done = receipt_acked.count_ones(),
+                        total = receipt_acked.len(),
+                        "evaluator table transfer receipt acked"
+                    );
+
+                    // SetupComplete requires every receipt to have been
+                    // acked. Until then the step must remain
+                    // `ReceivingGarblingTables` so `restore()` can
+                    // re-emit any in-flight `SendTableTransferReceipt`
+                    // tracked actions on crash.
+                    if received.all() && receipt_acked.all() {
+                        info!("all garbling tables received and receipts acked, setup complete");
+                        root_state.step = Step::SetupComplete;
+                    }
+                }
+                // Late acks past the transition are no-ops. They can land
+                // after `SetupComplete` if a duplicate receipt was emitted
+                // (e.g. from a prior restore re-emit) and acked after the
+                // step had already moved forward via the original ack.
+                Step::SetupComplete
+                | Step::EvaluatingTables { .. }
+                | Step::SetupConsumed { .. }
+                | Step::Aborted { .. } => {
+                    debug!("late table transfer receipt ack after step advanced; ignoring");
+                }
+                _ => return Err(SMError::UnexpectedInput),
+            }
         }
         ActionResult::DepositAdaptorsGenerated(deposit_id, deposit_adaptors) => {
             match root_state.step {
@@ -964,6 +1015,7 @@ async fn handle_table_commitment_generated<S: StateMut>(
                     eval_indices,
                     eval_commitments,
                     received: HeapArray::from_elem(false),
+                    receipt_acked: HeapArray::from_elem(false),
                 };
             }
 
@@ -985,6 +1037,7 @@ async fn handle_table_received<S: StateMut>(
             eval_indices: eval_idxs,
             eval_commitments,
             received,
+            ..
         } => {
             let Some(pos) = eval_idxs.iter().position(|&x| x == index) else {
                 return Err(SMError::InvalidInputData);
@@ -1007,10 +1060,13 @@ async fn handle_table_received<S: StateMut>(
             received[pos] = true;
             debug!(%index, done = received.count_ones(), total = received.len(), "evaluator garbling table received");
 
-            if received.all() {
-                info!("all garbling tables received, setup complete");
-                root_state.step = Step::SetupComplete;
-            }
+            // SetupComplete transition deferred to the
+            // `TableTransferReceiptAcked` handler: both `received.all()` and
+            // `receipt_acked.all()` must hold. Transitioning here on
+            // `received.all()` alone would leave in-flight
+            // `SendTableTransferReceipt` actions unreachable to `restore()`
+            // (the `SetupComplete` branch cannot re-emit them), permanently
+            // orphaning them on crash.
 
             Ok(())
         }
@@ -1078,19 +1134,27 @@ pub(crate) async fn restore<S: StateRead>(
         Step::ReceivingGarblingTables {
             eval_commitments,
             received,
+            receipt_acked,
             ..
         } => {
-            for (commitment, received) in eval_commitments.iter().zip(received.iter()) {
-                if *received {
-                    // Notify the garbler that these tables have been received already.
-                    emit(
-                        actions,
-                        Action::SendTableTransferReceipt(TableTransferReceiptMsg::new(*commitment)),
-                    );
+            for ii in 0..eval_commitments.len() {
+                let commitment = eval_commitments[ii];
+                if !received[ii] {
+                    // Combined action: registers expectation, sends request,
+                    // receives table.
+                    emit(actions, Action::ReceiveGarblingTable(commitment));
                     continue;
                 }
-                // Combined action: registers expectation, sends request, receives table.
-                emit(actions, Action::ReceiveGarblingTable(*commitment));
+                if !receipt_acked[ii] {
+                    // Receipt for this slot was emitted in `handle_table_received`
+                    // but not yet acked by the network layer. Re-emit so the
+                    // garbler is guaranteed to learn this table was received.
+                    emit(
+                        actions,
+                        Action::SendTableTransferReceipt(TableTransferReceiptMsg::new(commitment)),
+                    );
+                }
+                // received && receipt_acked: nothing in flight for this slot.
             }
         }
         Step::SetupComplete => {

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -811,3 +811,60 @@ async fn duplicate_garbling_table_received_is_idempotent() {
     assert_eq!(received.count_ones(), 1);
     assert_eq!(receipt_acked.count_ones(), 0);
 }
+
+#[tokio::test]
+async fn ack_with_wrong_action_id_variant_is_invalid_input() {
+    // `ActionResult::TableTransferReceiptAcked` must be paired with
+    // `ActionId::SendTableTransferReceipt`. A mismatched pairing (only
+    // reachable from a framework bug or a corrupted id) must fail closed.
+    let mut state = StoredEvaluatorState::default();
+    let (root, _, _) =
+        receiving_garbling_tables_state(HeapArray::from_elem(true), HeapArray::from_elem(false));
+    state.put_root_state(&root).await.unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_action_result(
+        &mut state,
+        ActionId::SendChallengeMsg, // wrong variant
+        ActionResult::TableTransferReceiptAcked,
+        &mut actions,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "mismatched ActionId variant must be InvalidInputData"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_garbling_table_received_with_mismatched_commitment_aborts() {
+    // A duplicate `GarblingTableReceived` with a *wrong* commitment for an
+    // already-received slot must still abort, not be swallowed by the
+    // idempotency guard. Defends the original abort-on-mismatch contract.
+    let mut state = StoredEvaluatorState::default();
+    let mut received = HeapArray::from_elem(false);
+    received[0] = true;
+    let (root, _eval_commitments, eval_indices) =
+        receiving_garbling_tables_state(received, HeapArray::from_elem(false));
+    state.put_root_state(&root).await.unwrap();
+
+    let mut actions = Vec::new();
+    handle_action_result(
+        &mut state,
+        ActionId::ReceiveGarblingTable(GarblingTableCommitment::from([0xAAu8; 32])),
+        ActionResult::GarblingTableReceived(
+            eval_indices[0],
+            GarblingTableCommitment::from([0xAAu8; 32]), // wrong commitment
+        ),
+        &mut actions,
+    )
+    .await
+    .expect("mismatch must produce Aborted, not Err");
+
+    let stored = state.get_root_state().await.unwrap().unwrap();
+    assert!(
+        matches!(stored.step, Step::Aborted { .. }),
+        "expected abort on commitment mismatch, got {:?}",
+        stored.step
+    );
+}

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -772,3 +772,42 @@ async fn ack_with_unknown_commitment_is_invalid_input() {
         "unknown commitment must be InvalidInputData"
     );
 }
+
+#[tokio::test]
+async fn duplicate_garbling_table_received_is_idempotent() {
+    // If `GarblingTableReceived` is delivered twice for the same slot, the
+    // second delivery must not emit a stray `SendTableTransferReceipt` or
+    // perturb state. Symmetric to the duplicate-ack guard.
+    let mut state = StoredEvaluatorState::default();
+    let mut received = HeapArray::from_elem(false);
+    received[0] = true;
+    let (root, eval_commitments, eval_indices) =
+        receiving_garbling_tables_state(received, HeapArray::from_elem(false));
+    state.put_root_state(&root).await.unwrap();
+
+    let mut actions = Vec::new();
+    handle_action_result(
+        &mut state,
+        ActionId::ReceiveGarblingTable(eval_commitments[0]),
+        ActionResult::GarblingTableReceived(eval_indices[0], eval_commitments[0]),
+        &mut actions,
+    )
+    .await
+    .expect("duplicate GarblingTableReceived must succeed");
+
+    assert!(
+        actions.is_empty(),
+        "duplicate GarblingTableReceived must not emit anything"
+    );
+    let stored = state.get_root_state().await.unwrap().unwrap();
+    let Step::ReceivingGarblingTables {
+        received,
+        receipt_acked,
+        ..
+    } = stored.step
+    else {
+        panic!("expected ReceivingGarblingTables");
+    };
+    assert_eq!(received.count_ones(), 1);
+    assert_eq!(receipt_acked.count_ones(), 0);
+}

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -3,14 +3,17 @@ use std::collections::BTreeSet;
 use fasm::actions::Action as FasmAction;
 use mosaic_cac_types::{
     ChallengeIndices, ChallengeResponseMsgChunk, ChallengeResponseMsgHeader, CommitMsgChunk,
-    CommitMsgHeader, DepositId, EvaluationIndices, HeapArray, Index, Polynomial,
-    state_machine::evaluator::{Action, EvaluatorState, Input, StateMut, Step},
+    CommitMsgHeader, DepositId, EvalGarblingTableCommitments, EvaluationIndices,
+    GarblingTableCommitment, HeapArray, Index, Polynomial,
+    state_machine::evaluator::{
+        Action, ActionId, ActionResult, EvaluatorState, Input, StateMut, StateRead, Step,
+    },
 };
 use mosaic_common::constants::N_EVAL_CIRCUITS;
 use mosaic_storage_inmemory::evaluator::StoredEvaluatorState;
 use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
-use super::stf::{handle_event, restore};
+use super::stf::{handle_action_result, handle_event, restore};
 use crate::evaluator::stf::get_remaining_challenge_response_chunks;
 
 #[tokio::test]
@@ -482,4 +485,290 @@ async fn challenge_response_chunk_after_verifying_is_ack_and_ignore() {
 
     assert!(result.is_ok(), "should ack and ignore, got: {result:?}");
     assert!(actions.is_empty(), "should produce no actions");
+}
+
+// ============================================================================
+// ReceivingGarblingTables -> SetupComplete transition + restore correctness
+//
+// The step transitions to `SetupComplete` only after every `received[i]` AND
+// `receipt_acked[i]` is true. Until then, `restore()` must be able to re-emit
+// any in-flight `SendTableTransferReceipt` tracked action, so the state stays
+// in `ReceivingGarblingTables` until the framework delivers every receipt's
+// ack via `ActionResult::TableTransferReceiptAcked`.
+// ============================================================================
+
+fn receiving_garbling_tables_state(
+    received: HeapArray<bool, N_EVAL_CIRCUITS>,
+    receipt_acked: HeapArray<bool, N_EVAL_CIRCUITS>,
+) -> (
+    EvaluatorState,
+    EvalGarblingTableCommitments,
+    EvaluationIndices,
+) {
+    let eval_indices: EvaluationIndices =
+        std::array::from_fn(|i| Index::new(i + 1).expect("valid index"));
+    let eval_commitments: EvalGarblingTableCommitments =
+        HeapArray::new(|i| GarblingTableCommitment::from([i as u8 + 1; 32]));
+    let state = EvaluatorState {
+        config: None,
+        step: Step::ReceivingGarblingTables {
+            eval_indices,
+            eval_commitments: eval_commitments.clone(),
+            received,
+            receipt_acked,
+        },
+    };
+    (state, eval_commitments, eval_indices)
+}
+
+#[tokio::test]
+async fn handle_table_received_does_not_advance_to_setup_complete() {
+    // Even when `received.all()` becomes true, the step must remain
+    // `ReceivingGarblingTables` so restore can re-emit any in-flight
+    // `SendTableTransferReceipt` actions.
+    let mut state = StoredEvaluatorState::default();
+
+    // Pre-fill so the (N-1) `received[i]` are already true; the last
+    // GarblingTableReceived will be the one that would have triggered the
+    // (old, buggy) eager transition.
+    let mut received = HeapArray::from_elem(true);
+    received[N_EVAL_CIRCUITS - 1] = false;
+    let (root, eval_commitments, eval_indices) =
+        receiving_garbling_tables_state(received, HeapArray::from_elem(false));
+    state.put_root_state(&root).await.unwrap();
+
+    let last_pos = N_EVAL_CIRCUITS - 1;
+    let mut actions = Vec::new();
+    handle_action_result(
+        &mut state,
+        ActionId::ReceiveGarblingTable(eval_commitments[last_pos]),
+        ActionResult::GarblingTableReceived(eval_indices[last_pos], eval_commitments[last_pos]),
+        &mut actions,
+    )
+    .await
+    .expect("final GarblingTableReceived must succeed");
+
+    let stored = state.get_root_state().await.unwrap().unwrap();
+    let Step::ReceivingGarblingTables {
+        received,
+        receipt_acked,
+        ..
+    } = stored.step
+    else {
+        panic!(
+            "expected step to remain ReceivingGarblingTables before any receipt ack, got something else"
+        );
+    };
+    assert!(received.all(), "all tables should be received now");
+    assert_eq!(
+        receipt_acked.count_ones(),
+        0,
+        "no receipt has been acked yet"
+    );
+    assert_eq!(
+        actions.len(),
+        1,
+        "exactly one SendTableTransferReceipt should be emitted for the final table"
+    );
+}
+
+#[tokio::test]
+async fn table_transfer_receipt_acked_advances_only_when_all_received_and_acked() {
+    // Drive the full ack sequence and verify SetupComplete fires on the last
+    // ack, not the last GarblingTableReceived.
+    let mut state = StoredEvaluatorState::default();
+    let (root, eval_commitments, _eval_indices) =
+        receiving_garbling_tables_state(HeapArray::from_elem(true), HeapArray::from_elem(false));
+    state.put_root_state(&root).await.unwrap();
+
+    let mut actions = Vec::new();
+    for i in 0..N_EVAL_CIRCUITS - 1 {
+        handle_action_result(
+            &mut state,
+            ActionId::SendTableTransferReceipt(eval_commitments[i]),
+            ActionResult::TableTransferReceiptAcked,
+            &mut actions,
+        )
+        .await
+        .expect("intermediate ack must succeed");
+
+        let stored = state.get_root_state().await.unwrap().unwrap();
+        assert!(
+            matches!(stored.step, Step::ReceivingGarblingTables { .. }),
+            "step must not advance until every receipt is acked"
+        );
+    }
+
+    handle_action_result(
+        &mut state,
+        ActionId::SendTableTransferReceipt(eval_commitments[N_EVAL_CIRCUITS - 1]),
+        ActionResult::TableTransferReceiptAcked,
+        &mut actions,
+    )
+    .await
+    .expect("final ack must succeed");
+
+    let stored = state.get_root_state().await.unwrap().unwrap();
+    assert!(
+        matches!(stored.step, Step::SetupComplete),
+        "step must advance to SetupComplete after the final receipt ack"
+    );
+    assert!(
+        actions.is_empty(),
+        "no actions should be emitted on the transition"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_receipt_ack_is_idempotent() {
+    // A duplicate `TableTransferReceiptAcked` (e.g. for a receipt re-emitted by
+    // restore on a previous boot whose ack also arrives) must be a no-op, not
+    // an error.
+    let mut state = StoredEvaluatorState::default();
+    let mut receipt_acked = HeapArray::from_elem(false);
+    receipt_acked[0] = true;
+    let (root, eval_commitments, _) =
+        receiving_garbling_tables_state(HeapArray::from_elem(true), receipt_acked);
+    state.put_root_state(&root).await.unwrap();
+
+    let mut actions = Vec::new();
+    handle_action_result(
+        &mut state,
+        ActionId::SendTableTransferReceipt(eval_commitments[0]),
+        ActionResult::TableTransferReceiptAcked,
+        &mut actions,
+    )
+    .await
+    .expect("duplicate ack must be idempotent");
+
+    let stored = state.get_root_state().await.unwrap().unwrap();
+    let Step::ReceivingGarblingTables { receipt_acked, .. } = stored.step else {
+        panic!("expected ReceivingGarblingTables");
+    };
+    assert_eq!(
+        receipt_acked.count_ones(),
+        1,
+        "duplicate ack must not double-count"
+    );
+    assert!(actions.is_empty());
+}
+
+#[tokio::test]
+async fn late_receipt_ack_after_setup_complete_is_ignored() {
+    // Once the step has advanced past `ReceivingGarblingTables`, a stale
+    // ack (e.g. for a duplicate receipt re-emitted earlier) must be
+    // silently ignored rather than rejected as `UnexpectedInput`.
+    let mut state = StoredEvaluatorState::default();
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::SetupComplete,
+        })
+        .await
+        .unwrap();
+
+    let mut actions = Vec::new();
+    handle_action_result(
+        &mut state,
+        ActionId::SendTableTransferReceipt(GarblingTableCommitment::from([7u8; 32])),
+        ActionResult::TableTransferReceiptAcked,
+        &mut actions,
+    )
+    .await
+    .expect("late ack past SetupComplete must succeed (ack and ignore)");
+    assert!(actions.is_empty());
+}
+
+#[tokio::test]
+async fn restore_receiving_tables_re_emits_unacked_receipts_and_pending_receives() {
+    // Mixed state covering all three slot kinds:
+    //   - slot 0: !received                  → re-emit ReceiveGarblingTable
+    //   - slot 1: received but !receipt_acked → re-emit SendTableTransferReceipt
+    //   - slot 2+: received && receipt_acked  → no action
+    // Confirms the audit's required restore behaviour.
+    let mut state = StoredEvaluatorState::default();
+    let mut received = HeapArray::from_elem(true);
+    received[0] = false;
+    let mut receipt_acked = HeapArray::from_elem(true);
+    receipt_acked[0] = false;
+    receipt_acked[1] = false;
+    let (root, eval_commitments, _) = receiving_garbling_tables_state(received, receipt_acked);
+    state.put_root_state(&root).await.unwrap();
+
+    let mut actions = Vec::new();
+    restore(&state, &mut actions)
+        .await
+        .expect("restore succeeds");
+
+    let mut receive_targets: BTreeSet<GarblingTableCommitment> = BTreeSet::new();
+    let mut receipt_targets: BTreeSet<GarblingTableCommitment> = BTreeSet::new();
+    for action in actions {
+        let FasmAction::Tracked(tracked) = action;
+        let (_id, action) = tracked.into_parts();
+        match action {
+            Action::ReceiveGarblingTable(c) => {
+                receive_targets.insert(c);
+            }
+            Action::SendTableTransferReceipt(msg) => {
+                receipt_targets.insert(msg.garbling_table_commitment);
+            }
+            other => panic!("unexpected action in ReceivingGarblingTables restore: {other:?}"),
+        }
+    }
+
+    assert_eq!(
+        receive_targets,
+        BTreeSet::from([eval_commitments[0]]),
+        "ReceiveGarblingTable must re-emit only for the unreceived slot"
+    );
+    assert_eq!(
+        receipt_targets,
+        BTreeSet::from([eval_commitments[1]]),
+        "SendTableTransferReceipt must re-emit only for received-but-unacked slots"
+    );
+}
+
+#[tokio::test]
+async fn restore_receiving_tables_emits_nothing_when_all_received_and_acked() {
+    // Steady state inside `ReceivingGarblingTables` just before the final ack
+    // would land: every receipt is acked but the transition has not yet
+    // happened. Restore must not re-emit anything (no in-flight tracked
+    // actions remain).
+    let mut state = StoredEvaluatorState::default();
+    let (root, _, _) =
+        receiving_garbling_tables_state(HeapArray::from_elem(true), HeapArray::from_elem(true));
+    state.put_root_state(&root).await.unwrap();
+
+    let mut actions = Vec::new();
+    restore(&state, &mut actions)
+        .await
+        .expect("restore succeeds");
+    assert!(
+        actions.is_empty(),
+        "no actions expected when every slot is received and acked"
+    );
+}
+
+#[tokio::test]
+async fn ack_with_unknown_commitment_is_invalid_input() {
+    // If the ActionId doesn't match any commitment in the current step (only
+    // possible from a corrupted id), the handler must error rather than
+    // silently mutate.
+    let mut state = StoredEvaluatorState::default();
+    let (root, _, _) =
+        receiving_garbling_tables_state(HeapArray::from_elem(true), HeapArray::from_elem(false));
+    state.put_root_state(&root).await.unwrap();
+
+    let mut actions = Vec::new();
+    let result = handle_action_result(
+        &mut state,
+        ActionId::SendTableTransferReceipt(GarblingTableCommitment::from([0xFFu8; 32])),
+        ActionResult::TableTransferReceiptAcked,
+        &mut actions,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "unknown commitment must be InvalidInputData"
+    );
 }

--- a/crates/cac/protocol/src/tests.rs
+++ b/crates/cac/protocol/src/tests.rs
@@ -777,10 +777,16 @@ async fn handle_evaluator_processes_table<SP: StorageProvider + StorageProviderM
             .await
             .unwrap();
     }
-    assert_eq!(eval_actions.len(), N_EVAL_CIRCUITS); // Step::SetupComplete, Action::SendTableTransferReceipt
-    assert_eq!(
-        eval_state.get_root_state().await.unwrap().unwrap().step,
-        EvalStep::SetupComplete
+    assert_eq!(eval_actions.len(), N_EVAL_CIRCUITS); // one Action::SendTableTransferReceipt per slot
+    // Step is still ReceivingGarblingTables: SetupComplete now waits for every
+    // SendTableTransferReceipt to be acked (see Step variant docs). The
+    // transition happens after `handle_evaluator_consumes_receipt_ack` runs.
+    assert!(
+        matches!(
+            eval_state.get_root_state().await.unwrap().unwrap().step,
+            EvalStep::ReceivingGarblingTables { .. }
+        ),
+        "expected ReceivingGarblingTables before receipt acks land"
     );
 }
 
@@ -852,7 +858,8 @@ async fn handle_evaluator_consumes_receipt_ack<SP: StorageProvider + StorageProv
         >,
     >,
 ) {
-    // Stf ignores ack as state has been transitioned to SetupComplete already
+    // Each TableTransferReceiptAcked sets receipt_acked[pos] = true; the
+    // step transitions to SetupComplete once every slot is acked.
     let mut eval_state = eval_exec
         .storage
         .evaluator_state_mut(garbler_peer_id)

--- a/crates/cac/types/src/state_machine/evaluator/action.rs
+++ b/crates/cac/types/src/state_machine/evaluator/action.rs
@@ -74,7 +74,9 @@ pub enum ActionResult {
     /// Garbling table received from garbler and verified.
     GarblingTableReceived(Index, GarblingTableCommitment),
     /// Garbling table transfer receipt was acknowledged by the garbler.
-    /// NOTE: ignored
+    /// Per-slot acks are tracked in `Step::ReceivingGarblingTables.receipt_acked`;
+    /// the step only transitions to `SetupComplete` once every receipt has been
+    /// acked. Required for restore correctness — see `handle_action_result`.
     TableTransferReceiptAcked,
     /// Adaptor signatures were generated for deposit wires.
     DepositAdaptorsGenerated(DepositId, DepositAdaptors),

--- a/crates/cac/types/src/state_machine/evaluator/action.rs
+++ b/crates/cac/types/src/state_machine/evaluator/action.rs
@@ -77,6 +77,10 @@ pub enum ActionResult {
     /// Per-slot acks are tracked in `Step::ReceivingGarblingTables.receipt_acked`;
     /// the step only transitions to `SetupComplete` once every receipt has been
     /// acked. Required for restore correctness — see `handle_action_result`.
+    ///
+    /// Must be paired with `ActionId::SendTableTransferReceipt(commitment)`;
+    /// the handler uses the commitment to locate the slot in `eval_commitments`.
+    /// A mismatched pairing is treated as `InvalidInputData`.
     TableTransferReceiptAcked,
     /// Adaptor signatures were generated for deposit wires.
     DepositAdaptorsGenerated(DepositId, DepositAdaptors),

--- a/crates/cac/types/src/state_machine/evaluator/root_state.rs
+++ b/crates/cac/types/src/state_machine/evaluator/root_state.rs
@@ -65,8 +65,18 @@ crate::state_machine::define_step_phase! {
             eval_indices: EvaluationIndices,
             /// Expected commitments of garbling tables
             eval_commitments: EvalGarblingTableCommitments,
-            /// Track received garbling tables
+            /// Track received garbling tables.
             received: HeapArray<bool, N_EVAL_CIRCUITS>,
+            /// Track receipts whose `SendTableTransferReceipt` action has been
+            /// acked by the network layer. The step only transitions to
+            /// `SetupComplete` once every receipt has been acked — without
+            /// this gate, a crash between the eager step transition and the
+            /// ack would orphan in-flight `SendTableTransferReceipt` tracked
+            /// actions (restore for `SetupComplete` cannot re-emit them).
+            /// fasm's contract is that restore re-emits every tracked action
+            /// not yet completed at crash time, so the data needed to do so
+            /// must remain in the step until the action completes.
+            receipt_acked: HeapArray<bool, N_EVAL_CIRCUITS>,
         },
         /// Setup is completed, ready to be used for deposits.
         /// Accepts deposit inputs


### PR DESCRIPTION
## Description

The evaluator transitioned `Step::ReceivingGarblingTables → Step::SetupComplete` in the same handler that emitted the final `SendTableTransferReceipt` tracked action(s). Up to `N_EVAL_CIRCUITS` receipts could be in flight simultaneously when the transition fired. `restore()` for `SetupComplete` does not (and cannot) re-emit `SendTableTransferReceipt`, so a crash between the persisted step transition and `TrackedActionCompleted` delivery permanently orphaned the unacked receipts — leaving the garbler stalled in `TransferringGarblingTables` indefinitely.

fasm's contract is that `restore` re-emits every tracked action whose completion the framework has not yet processed; the framework replays nothing automatically. The data needed to do so must remain in the step until the ack lands.

### Fix

Add `receipt_acked: HeapArray<bool, N_EVAL_CIRCUITS>` to `ReceivingGarblingTables`. `handle_table_received` no longer transitions on `received.all()` alone. `TableTransferReceiptAcked` matches on `ActionId::SendTableTransferReceipt(commitment)`, locates the slot in `eval_commitments`, sets `receipt_acked[pos] = true`, and only transitions to `SetupComplete` when `received.all() && receipt_acked.all()`. `restore()` gates the receipt re-emit on `!receipt_acked[i]` (the previous code re-emitted for every `received[i]`, which was also over-eager — it re-sent already-acked receipts on every restart).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

Breaking: the `Step::ReceivingGarblingTables` variant adds a new `receipt_acked` field. Persisted evaluator states from before this change in that step will fail to deserialize (postcard `DeserializeUnexpectedEnd`). Pre-testnet, state reset is the recovery path; a versioned-storage upgrade binary is planned separately.

## Notes to Reviewers

This is a **liveness bug under honest crash**, not security — distinct from the #217 / #223 discussion which was about adversarial receipt behaviour. The system's safety story rests on "restart is safe", and every tracked action in flight must be reachable to `restore()` so the framework can drive it to completion.

Audit context: I walked every `emit + transition step` site in both state machines. This is the only gap of its kind — every other transition either emits no action at the transition or transitions into a step whose `restore` re-emits the just-emitted actions.

Tests added:

- `handle_table_received_does_not_advance_to_setup_complete` — invariant: receipt emitted, step stays `ReceivingGarblingTables`.
- `table_transfer_receipt_acked_advances_only_when_all_received_and_acked` — full ack sequence; `SetupComplete` fires on final ack.
- `duplicate_receipt_ack_is_idempotent` — restore-emitted receipts can produce a second ack; must not error.
- `late_receipt_ack_after_setup_complete_is_ignored` — late ack past the transition is a no-op.
- `restore_receiving_tables_re_emits_unacked_receipts_and_pending_receives` — mixed-state restore covers all three slot kinds.
- `restore_receiving_tables_emits_nothing_when_all_received_and_acked` — steady-state restore must emit nothing.
- `ack_with_unknown_commitment_is_invalid_input` — corrupted action id fails closed.

Existing `cac/protocol` e2e test (`test_e2e`) was adjusted: the step is now `ReceivingGarblingTables` (not `SetupComplete`) between `GarblingTableReceived` and the receipt acks.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

closes #256