### PR TITLE
test: don't hardcode reserved index in tests

### DIFF
--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -1209,7 +1209,7 @@ mod challenge_validation_tests {
             // bypassing `Index::new`. The Index API does not normally permit
             // 0 / out-of-range values, but a malicious peer can produce them
             // by hand-crafting wire bytes; the validator must catch that.
-            if raw == 0 {
+            if raw == Index::reserved().get() {
                 Index::reserved()
             } else {
                 Index::new(raw).unwrap_or_else(Index::reserved)
@@ -1222,7 +1222,7 @@ mod challenge_validation_tests {
     fn rejects_reserved_index() {
         // First entry is the reserved index (0).
         let mut indices: Vec<usize> = (1..=N_OPEN_CIRCUITS).collect();
-        indices[0] = 0;
+        indices[0] = Index::reserved().get();
         assert!(!is_valid_challenge(&make_challenge(&indices)));
     }
 

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -1205,14 +1205,10 @@ mod challenge_validation_tests {
     fn make_challenge(indices: &[usize]) -> ChallengeMsg {
         let challenge_indices: ChallengeIndices = HeapArray::new(|i| {
             let raw = indices[i];
-            // Allow constructing out-of-range entries for negative tests by
-            // bypassing `Index::new`. The Index API does not normally permit
-            // 0 / out-of-range values, but a malicious peer can produce them
-            // by hand-crafting wire bytes; the validator must catch that.
             if raw == Index::reserved().get() {
                 Index::reserved()
             } else {
-                Index::new(raw).unwrap_or_else(Index::reserved)
+                Index::new(raw).unwrap()
             }
         });
         ChallengeMsg { challenge_indices }


### PR DESCRIPTION
## Description

Recent work in #229 improves validation for challenge indexes. However, two of its added tests unnecessarily hardcode the reserved index. This PR moves to built-in functionality to dynamically pull the reserved index as a hedge against future changes to this value. It also removes the silent use of a default index value in tests, and fixes an errant comment.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

N/A

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Follows up on #229.
