### PR TITLE
Fix: verify opened input share indices

### DIFF
--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -910,9 +910,15 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
                         warn!(
                             circuit_index = %expected_index,
                             share_index = %share.index(),
-                            "evaluator opened input share index mismatch, rejecting chunk"
+                            "evaluator opened input share index mismatch, aborting"
                         );
-                        return Err(SMError::InvalidInputData);
+                        root_state.step = Step::Aborted {
+                            reason: format!(
+                                "invalid opened input share: chunk circuit_index {expected_index} carries share with index {}",
+                                share.index()
+                            ),
+                        };
+                        return Ok(());
                     }
                 }
             }

--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -897,6 +897,26 @@ async fn handle_recv_challenge_response_msg<S: StateMut>(
                 return Err(SMError::InvalidInputData);
             }
 
+            // Bind every embedded share index to the chunk's circuit_index.
+            // batch_verify_shares uses share.index() as the evaluation
+            // x-coordinate, so without this a garbler could substitute
+            // honest (j, P(j)) shares into a chunk claimed for circuit i and
+            // pass verification — defeating cut-and-choose soundness.
+            let expected_index = Index::new(response_msg_chunk.circuit_index as usize)
+                .expect("circuit_index validated against challenge set above");
+            for wire_shares in response_msg_chunk.shares.iter() {
+                for share in wire_shares.iter() {
+                    if share.index() != expected_index {
+                        warn!(
+                            circuit_index = %expected_index,
+                            share_index = %share.index(),
+                            "evaluator opened input share index mismatch, rejecting chunk"
+                        );
+                        return Err(SMError::InvalidInputData);
+                    }
+                }
+            }
+
             let chunk_idx = (response_msg_chunk.circuit_index as usize)
                 .checked_sub(1)
                 .unwrap();
@@ -1345,7 +1365,7 @@ fn sample_challenge_indices(base_seed: Seed) -> ChallengeIndices {
 }
 
 /// Verify reserved setup input shares and return failure reason or None.
-fn verify_reserved_setup_input_shares(
+pub(super) fn verify_reserved_setup_input_shares(
     reserved_setup_input_shares: &ReservedSetupInputShares,
     setup_inputs: &SetupInputs,
     setup_wire_zeroth_coefficients: &[WideLabelZerothPolynomialCoefficients],
@@ -1353,6 +1373,17 @@ fn verify_reserved_setup_input_shares(
     for wire in 0..N_SETUP_INPUT_WIRES {
         let val = setup_inputs[wire];
         let reserved_share = reserved_setup_input_shares[wire];
+        // The point check below only constrains the share's value,
+        // not its embedded index. Downstream consumers (Lagrange interpolation)
+        // treat share.index() as the evaluation x-coordinate, so a malicious
+        // garbler could submit (j, P(0)) shares that pass here and then
+        // corrupt interpolation. Bind the index to Index::reserved() (== 0).
+        if reserved_share.index() != Index::reserved() {
+            return Some(format!(
+                "reserved setup share for wire {wire} has index {}, expected reserved",
+                reserved_share.index()
+            ));
+        }
         if setup_wire_zeroth_coefficients[wire][val as usize] != reserved_share.commit().point() {
             return Some(format!(
                 "verify reserved setup shares failed for wire {wire}",

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -1097,15 +1097,22 @@ async fn opened_input_share_chunk_with_wrong_embedded_index_is_rejected() {
         &mut actions,
     )
     .await;
+    assert!(
+        result.is_ok(),
+        "wrong-index chunk should abort, not error: {result:?}"
+    );
+    assert!(actions.is_empty(), "abort path must not emit actions");
 
     let root = state.get_root_state().await.unwrap().unwrap();
-    let rejected = result.is_err() || matches!(root.step, Step::Aborted { .. });
-    assert!(
-        rejected,
-        "wrong-index chunk must be rejected; got result {result:?} and step {:?}",
-        root.step,
-    );
-    assert!(actions.is_empty(), "rejection path must not emit actions");
+    match root.step {
+        Step::Aborted { reason } => {
+            assert!(
+                reason.starts_with("invalid opened input share"),
+                "unexpected abort reason: {reason}"
+            );
+        }
+        other => panic!("expected Aborted, got: {other:?}"),
+    }
 
     assert_eq!(
         state

--- a/crates/cac/protocol/src/evaluator/tests.rs
+++ b/crates/cac/protocol/src/evaluator/tests.rs
@@ -5,15 +5,16 @@ use mosaic_cac_types::{
     ChallengeIndices, ChallengeResponseMsgChunk, ChallengeResponseMsgHeader, CommitMsgChunk,
     CommitMsgHeader, DepositId, EvalGarblingTableCommitments, EvaluationIndices,
     GarblingTableCommitment, HeapArray, Index, OpenedOutputShares, Polynomial,
+    ReservedSetupInputShares, SetupInputs, Share, WideLabelZerothPolynomialCoefficients,
     state_machine::evaluator::{
         Action, ActionId, ActionResult, EvaluatorState, Input, StateMut, StateRead, Step,
     },
 };
-use mosaic_common::constants::{N_EVAL_CIRCUITS, N_OPEN_CIRCUITS};
+use mosaic_common::constants::{N_EVAL_CIRCUITS, N_OPEN_CIRCUITS, N_SETUP_INPUT_WIRES};
 use mosaic_storage_inmemory::evaluator::StoredEvaluatorState;
 use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
-use super::stf::{handle_action_result, handle_event, restore};
+use super::stf::{handle_action_result, handle_event, restore, verify_reserved_setup_input_shares};
 use crate::evaluator::stf::get_remaining_challenge_response_chunks;
 
 #[tokio::test]
@@ -1054,4 +1055,142 @@ async fn corrupted_opened_output_share_aborts_without_persisting() {
     assert_eq!(state.get_opened_output_shares().await.unwrap(), None);
     assert_eq!(state.get_reserved_setup_input_shares().await.unwrap(), None);
     assert_eq!(state.get_opened_garbling_seeds().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn opened_input_share_chunk_with_wrong_embedded_index_is_rejected() {
+    let challenge_indices = ChallengeIndices::new(|i| Index::new(i + 1).unwrap());
+    let target_idx = challenge_indices[0]; // chunk claims to be for this circuit
+    let other_idx = challenge_indices[1]; // but every share has this embedded index
+
+    let mut state = StoredEvaluatorState::default();
+    state
+        .put_challenge_indices(&challenge_indices)
+        .await
+        .unwrap();
+    let remaining = get_remaining_challenge_response_chunks(&challenge_indices);
+    state
+        .put_root_state(&EvaluatorState {
+            config: None,
+            step: Step::WaitingForChallengeResponse {
+                header: false,
+                remaining_chunks: remaining,
+            },
+        })
+        .await
+        .unwrap();
+
+    // Shares that are honest evaluations at `other_idx` (so .index() == other_idx),
+    // packed into a chunk claiming `circuit_index = target_idx`.
+    let mut rng = ChaCha20Rng::seed_from_u64(42);
+    let polynomial = Polynomial::rand(&mut rng);
+    let share_at_other = polynomial.eval(other_idx);
+    let chunk = ChallengeResponseMsgChunk {
+        circuit_index: target_idx.get() as u16,
+        shares: HeapArray::from_elem(HeapArray::from_elem(share_at_other)),
+    };
+
+    let mut actions = Vec::new();
+    let result = handle_event(
+        &mut state,
+        Input::RecvChallengeResponseMsgChunk(chunk),
+        &mut actions,
+    )
+    .await;
+
+    let root = state.get_root_state().await.unwrap().unwrap();
+    let rejected = result.is_err() || matches!(root.step, Step::Aborted { .. });
+    assert!(
+        rejected,
+        "wrong-index chunk must be rejected; got result {result:?} and step {:?}",
+        root.step,
+    );
+    assert!(actions.is_empty(), "rejection path must not emit actions");
+
+    assert_eq!(
+        state
+            .get_opened_input_shares_for_circuit(target_idx.get() as u16)
+            .await
+            .unwrap(),
+        None,
+        "malicious chunk must not be persisted under the claimed circuit_index",
+    );
+}
+
+fn build_reserved_share_verification_inputs(
+    share_index: Index,
+) -> (
+    ReservedSetupInputShares,
+    SetupInputs,
+    Vec<WideLabelZerothPolynomialCoefficients>,
+) {
+    let mut rng = ChaCha20Rng::seed_from_u64(7);
+    let scalars: Vec<_> = (0..N_SETUP_INPUT_WIRES)
+        .map(|_| {
+            Polynomial::rand(&mut rng)
+                .eval(Index::new(1).unwrap())
+                .value()
+        })
+        .collect();
+
+    let setup_inputs: SetupInputs = std::array::from_fn(|i| (i as u8).wrapping_mul(3));
+
+    let shares = ReservedSetupInputShares::new(|wire| Share::new(share_index, scalars[wire]));
+
+    // Fill every slot of each row with g^{scalars[wire]} so the existing
+    // point-equality check passes regardless of which `val` setup_inputs picks.
+    let coefficients: Vec<WideLabelZerothPolynomialCoefficients> = scalars
+        .iter()
+        .map(|&scalar| {
+            let point = Share::new(Index::reserved(), scalar).commit().point();
+            HeapArray::from_elem(point)
+        })
+        .collect();
+
+    (shares, setup_inputs, coefficients)
+}
+
+#[test]
+fn verify_reserved_setup_input_shares_accepts_reserved_index() {
+    let (shares, setup_inputs, coefficients) =
+        build_reserved_share_verification_inputs(Index::reserved());
+
+    let result = verify_reserved_setup_input_shares(&shares, &setup_inputs, &coefficients);
+    assert!(
+        result.is_none(),
+        "honest reserved shares must verify, got: {result:?}"
+    );
+}
+
+#[test]
+fn verify_reserved_setup_input_shares_rejects_non_reserved_index() {
+    // Non-reserved index but the share's value still commits to the correct
+    // zeroth coefficient — i.e. the existing point check would accept it.
+    let attacker_index = Index::new(5).unwrap();
+    let (shares, setup_inputs, coefficients) =
+        build_reserved_share_verification_inputs(attacker_index);
+
+    let result = verify_reserved_setup_input_shares(&shares, &setup_inputs, &coefficients);
+    let reason = result.expect("non-reserved index must be rejected");
+    assert!(
+        reason.contains("expected reserved"),
+        "reason should mention reserved-index requirement, got: {reason}"
+    );
+}
+
+#[test]
+fn verify_reserved_setup_input_shares_rejects_first_offending_wire() {
+    // All wires honest except wire 0, which has a non-reserved index.
+    // The function must surface that specific wire in the failure reason.
+    let (mut shares, setup_inputs, coefficients) =
+        build_reserved_share_verification_inputs(Index::reserved());
+    let bad_value = shares[0].value();
+    shares[0] = Share::new(Index::new(2).unwrap(), bad_value);
+
+    let result = verify_reserved_setup_input_shares(&shares, &setup_inputs, &coefficients);
+    let reason = result.expect("non-reserved index must be rejected");
+    assert!(
+        reason.contains("wire 0"),
+        "reason should pinpoint the offending wire, got: {reason}"
+    );
 }


### PR DESCRIPTION
## Description

Addresses #233 by enforcing correct share indices for input shares as well (output shares addressed in #210). Adds corresponding tests that verify the fix. 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

Used Claude Code for writing tests. They failed before the change and pass now, as expected. 

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Fixes #233. 
