### PR TITLE
chore: move to `LazyLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,6 @@ dependencies = [
  "bitcoin-scriptexec",
  "k256",
  "mosaic-common",
- "once_cell",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ jsonrpsee-types = "*" # constrained by jsonrpsee dep
 k256 = "0.13.4"
 kanal = "0.1.1"
 monoio = "0.2.4"
-once_cell = "1.21.4"
 parking_lot = "0.12"
 postcard = { version = "1.1.3", features = ["alloc"] }
 proptest = "1.11"

--- a/crates/adaptor-sigs/Cargo.toml
+++ b/crates/adaptor-sigs/Cargo.toml
@@ -17,7 +17,6 @@ ark-ec.workspace = true
 ark-ff.workspace = true
 ark-secp256k1.workspace = true
 ark-serialize.workspace = true
-once_cell.workspace = true
 rand.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/adaptor-sigs/src/fixed_base.rs
+++ b/crates/adaptor-sigs/src/fixed_base.rs
@@ -1,16 +1,17 @@
 //! Global fixed-base precomputation for secp256k1's generator G.
 
+use std::sync::LazyLock;
+
 use ark_ec::{PrimeGroup, scalar_mul::BatchMulPreprocessing};
 use ark_secp256k1::{Fr as Scalar, Projective as Point};
 use mosaic_common::constants::{N_INPUT_WIRES, N_OPEN_CIRCUITS};
-use once_cell::sync::Lazy;
 
 const N_COEFFICIENTS: usize = N_OPEN_CIRCUITS + 1;
 const APPROX_MULS: usize = N_INPUT_WIRES * N_COEFFICIENTS * 256;
 
 /// Single global precomputation for G.
-static PRECOMP_G: Lazy<BatchMulPreprocessing<Point>> =
-    Lazy::new(|| BatchMulPreprocessing::new(Point::generator(), APPROX_MULS));
+static PRECOMP_G: LazyLock<BatchMulPreprocessing<Point>> =
+    LazyLock::new(|| BatchMulPreprocessing::new(Point::generator(), APPROX_MULS));
 
 /// Accessor for the global precomputation.
 #[inline]


### PR DESCRIPTION
## Description

Replaces the use of `Lazy` with `LazyLock` from the standard library, which removes `once_cell` as a direct dependency.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [x] Dependency update
- [ ] Security fix

## Notes to Reviewers

N/A

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

N/A
