### PR TITLE
fix: stop shipping reduced-circuits test binary in production Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,12 +32,9 @@ COPY .cargo .cargo
 COPY bin bin
 COPY crates crates
 
-# Build both release binaries so runtime can switch via env var.
+# Build the production release binary.
 RUN cargo build --release --bin mosaic \
-    && cp target/release/mosaic target/release/mosaic-default \
-    && cargo build --release --features=reduced-circuits --bin mosaic \
-    && mv target/release/mosaic target/release/mosaic-unsafe-test \
-    && strip --strip-debug target/release/mosaic-default target/release/mosaic-unsafe-test
+    && strip --strip-debug target/release/mosaic
 
 # ------------------------------------------------------------------------------
 # Stage 2: Minimal runtime image
@@ -65,8 +62,7 @@ RUN FDB_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "amd64") \
 #   FDB cluster file                   – path configured via storage.cluster_file in config.toml
 RUN mkdir -p /etc/mosaic && chown ubuntu:ubuntu /etc/mosaic
 
-COPY --from=builder /build/target/release/mosaic-default /usr/local/bin/mosaic
-COPY --from=builder /build/target/release/mosaic-unsafe-test /usr/local/bin/mosaic-unsafe-test
+COPY --from=builder /build/target/release/mosaic /usr/local/bin/mosaic
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,20 +8,6 @@
 # The config file's [circuit] section should reference:
 #   path = "/etc/mosaic/circuit.v5c"
 #
-# Test-mode binary (built with --features=reduced-circuits): for CI/test
-# environments only. This binary uses cut-and-choose parameters that are
-# explicitly documented as insecure (see crates/common/src/constants.rs)
-# and provides ~3 bits of challenge entropy versus the 40-bit production
-# target. To enable it you must set BOTH:
-#
-#     MOSAIC_UNSAFE_TEST=1
-#     MOSAIC_UNSAFE_TEST_I_UNDERSTAND_THIS_IS_NOT_PRODUCTION=1
-#
-# Setting only MOSAIC_UNSAFE_TEST=1 will refuse to start. The double-flag
-# is a deliberate footgun mitigation: it prevents accidental enablement
-# via a single environment-variable injection or a stray test config
-# being copied into a production deploy.
-#
 # Any extra arguments are forwarded to the mosaic binary.
 
 set -euo pipefail
@@ -34,48 +20,4 @@ if [ ! -f "$CONFIG_PATH" ]; then
     exit 1
 fi
 
-is_truthy() {
-    case "${1:-}" in
-        1|true|TRUE|True|yes|YES|Yes|on|ON|On) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-MOSAIC_BIN="/usr/local/bin/mosaic"
-
-if is_truthy "${MOSAIC_UNSAFE_TEST:-}"; then
-    if ! is_truthy "${MOSAIC_UNSAFE_TEST_I_UNDERSTAND_THIS_IS_NOT_PRODUCTION:-}"; then
-        cat >&2 <<'EOF'
-ERROR: MOSAIC_UNSAFE_TEST=1 is set, but
-       MOSAIC_UNSAFE_TEST_I_UNDERSTAND_THIS_IS_NOT_PRODUCTION is not.
-
-The reduced-circuits binary uses cut-and-choose parameters that are
-explicitly insecure (see crates/common/src/constants.rs) and must
-NEVER be deployed in production. To run it intentionally for testing,
-set both flags:
-
-    MOSAIC_UNSAFE_TEST=1
-    MOSAIC_UNSAFE_TEST_I_UNDERSTAND_THIS_IS_NOT_PRODUCTION=1
-
-Refusing to start.
-EOF
-        exit 1
-    fi
-
-    cat >&2 <<'EOF'
-================================================================================
-WARNING: Running mosaic-unsafe-test (reduced-circuits build).
-
-This binary uses test-only cut-and-choose parameters that provide ~3 bits
-of challenge entropy instead of the 40-bit production target. It is NOT
-SAFE for production use under any circumstances.
-
-If you see this message in a production environment, stop the container
-immediately and audit the deployment for environment-variable injection
-or test-config contamination.
-================================================================================
-EOF
-    MOSAIC_BIN="/usr/local/bin/mosaic-unsafe-test"
-fi
-
-exec "$MOSAIC_BIN" "$CONFIG_PATH" "$@"
+exec /usr/local/bin/mosaic "$CONFIG_PATH" "$@"


### PR DESCRIPTION
## Description

The production Docker image no longer ships or selects the reduced-circuits test binary. The Dockerfile previously built mosaic with the reduced-circuits feature alongside the production binary and the entrypoint chose between them via `MOSAIC_REDUCED_CIRCUITS`, so a single env var flipped a production deployment onto test circuits. The image now builds only the production binary and the entrypoint always execs it, keeping the existing config-file presence check.

Closes #212

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [x] Security fix

## Notes to Reviewers

The diff is removal-heavy on purpose: the reduced-circuits build stage and the entrypoint branch both go away, and the entrypoint keeps its config check then execs `/usr/local/bin/mosaic` unconditionally. `bash -n docker/entrypoint.sh` passes; anyone needing reduced circuits for local testing still has the cargo feature, it just no longer rides inside the production image.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works. (N/A: Docker packaging change; no test harness covers image contents. Verified with `bash -n docker/entrypoint.sh` and by walking the remaining build stages.)
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #212
