### PR TITLE
feat(rpc): load circuit metadata from v5c header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,6 +2321,7 @@ dependencies = [
  "mosaic-rpc-api",
  "mosaic-rpc-server",
  "mosaic-rpc-service",
+ "mosaic-rpc-types",
  "mosaic-sm-executor",
  "mosaic-sm-executor-api",
  "mosaic-storage-api",
@@ -2598,6 +2599,7 @@ name = "mosaic-rpc-types"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
+ "ckt-fmtv5-types",
  "hex",
  "jsonrpsee-types",
  "mosaic-cac-types",

--- a/bin/mosaic/Cargo.toml
+++ b/bin/mosaic/Cargo.toml
@@ -25,6 +25,7 @@ mosaic-net-svc.workspace = true
 mosaic-rpc-api.workspace = true
 mosaic-rpc-server.workspace = true
 mosaic-rpc-service.workspace = true
+mosaic-rpc-types.workspace = true
 mosaic-sm-executor.workspace = true
 mosaic-sm-executor-api.workspace = true
 mosaic-storage-api.workspace = true

--- a/bin/mosaic/src/main.rs
+++ b/bin/mosaic/src/main.rs
@@ -248,8 +248,11 @@ where
         storage,
         rng,
     );
-    let rpc_controller =
-        rpc::start_rpc_server(rpc_bind_addr, mosaic_api).context("failed to start RPC server")?;
+    let circuit_info =
+        mosaic_rpc_types::RpcCircuitInfoEntry::from_circuit_file(&config.circuit.path)
+            .context("failed to read circuit file header")?;
+    let rpc_controller = rpc::start_rpc_server(rpc_bind_addr, mosaic_api, circuit_info)
+        .context("failed to start RPC server")?;
 
     tracing::info!("all currently supported components started");
     Ok(RunningMosaic {

--- a/bin/mosaic/src/rpc.rs
+++ b/bin/mosaic/src/rpc.rs
@@ -10,6 +10,7 @@ use jsonrpsee::server::ServerHandle;
 use mosaic_rpc_api::MosaicRpcServer;
 use mosaic_rpc_server::RpcServerImpl;
 use mosaic_rpc_service::MosaicApi;
+use mosaic_rpc_types::RpcCircuitInfoEntry;
 
 /// Controller for a running RPC server.
 #[derive(Debug)]
@@ -46,8 +47,9 @@ impl RpcController {
 pub(crate) fn start_rpc_server(
     bind_addr: SocketAddr,
     service: impl MosaicApi,
+    circuit_info: RpcCircuitInfoEntry,
 ) -> Result<RpcController> {
-    let rpc_impl = RpcServerImpl::new(service);
+    let rpc_impl = RpcServerImpl::new(service, circuit_info);
 
     let (handle_tx, handle_rx) = std::sync::mpsc::sync_channel(1);
 

--- a/crates/rpc/server/src/server.rs
+++ b/crates/rpc/server/src/server.rs
@@ -20,12 +20,16 @@ use crate::conversions::{
 #[derive(Debug)]
 pub struct RpcServerImpl<Svc: MosaicApi> {
     service: Svc,
+    circuit_info: RpcCircuitInfoEntry,
 }
 
 impl<Svc: MosaicApi> RpcServerImpl<Svc> {
     /// Constructs a new instance with the given service implementation.
-    pub fn new(service: Svc) -> Self {
-        Self { service }
+    pub fn new(service: Svc, circuit_info: RpcCircuitInfoEntry) -> Self {
+        Self {
+            service,
+            circuit_info,
+        }
     }
 }
 
@@ -37,7 +41,7 @@ fn parse_sm_id(tsid: RpcTablesetId) -> RpcResult<StateMachineId> {
 #[async_trait]
 impl<Svc: MosaicApi> MosaicRpcServer for RpcServerImpl<Svc> {
     fn get_circuit_defs(&self) -> RpcResult<Vec<RpcCircuitInfoEntry>> {
-        Ok(vec![RpcCircuitInfoEntry::from_config()])
+        Ok(vec![self.circuit_info.clone()])
     }
 
     fn get_peer_id(&self) -> RpcResult<RpcPeerId> {

--- a/crates/rpc/types/Cargo.toml
+++ b/crates/rpc/types/Cargo.toml
@@ -12,6 +12,7 @@ keywords.workspace = true
 
 [dependencies]
 bitcoin = { workspace = true, features = ["serde"] }
+ckt-fmtv5-types.workspace = true
 mosaic-cac-types.workspace = true
 mosaic-common.workspace = true
 mosaic-net-svc-api.workspace = true

--- a/crates/rpc/types/src/circuit.rs
+++ b/crates/rpc/types/src/circuit.rs
@@ -1,3 +1,9 @@
+use std::{
+    io::{self, Read},
+    path::Path,
+};
+
+use ckt_fmtv5_types::v5::c::{HEADER_SIZE, HeaderV5c};
 use serde::{Deserialize, Serialize};
 
 use crate::RpcByte32;
@@ -14,20 +20,33 @@ pub struct RpcCircuitInfoEntry {
 }
 
 impl RpcCircuitInfoEntry {
-    /// Create circuit info from config.
-    pub fn from_config(/* TODO: mosaic config */) -> Self {
-        Self {
-            name: "default".into(),
-            commitment: [0; 32].into(),
+    /// Create circuit info by reading the v5c header from the circuit file at `path`.
+    pub fn from_circuit_file(path: &Path) -> io::Result<Self> {
+        let mut f = std::fs::File::open(path)?;
+        let mut header_bytes = [0u8; HEADER_SIZE];
+        f.read_exact(&mut header_bytes)?;
+        let header = HeaderV5c::from_bytes(&header_bytes)?;
+
+        let file_size = std::fs::metadata(path)?.len();
+
+        let name = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        Ok(Self {
+            name,
+            commitment: header.checksum.into(),
             info: RpcCircuitInfo {
-                total_size_bytes: 0,
-                total_gates: 0,
-                levels: 0,
-                max_width: 0,
-                num_input_wires: 0,
-                num_output_wires: 0,
+                total_size_bytes: file_size,
+                total_gates: header.total_gates(),
+                xor_gates: header.xor_gates,
+                and_gates: header.and_gates,
+                num_input_wires: header.primary_inputs,
+                num_output_wires: header.num_outputs,
             },
-        }
+        })
     }
 }
 
@@ -38,10 +57,16 @@ impl RpcCircuitInfoEntry {
 /// going to take to work with it.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RpcCircuitInfo {
-    total_size_bytes: u64,
-    total_gates: u64,
-    levels: u64,
-    max_width: u64,
-    num_input_wires: u64,
-    num_output_wires: u64,
+    /// total circuit file size in bytes
+    pub total_size_bytes: u64,
+    /// total number of gates (xor + and)
+    pub total_gates: u64,
+    /// number of XOR gates
+    pub xor_gates: u64,
+    /// number of AND gates
+    pub and_gates: u64,
+    /// number of primary input wires
+    pub num_input_wires: u64,
+    /// number of output wires
+    pub num_output_wires: u64,
 }


### PR DESCRIPTION
## Description
Loads circuit metadata from header of configured v5c circuit and serves on `mosaic_getCircuitDefs` rpc endpoint.

This is intended to be used by bridge to verify that mosaic is using the expected circuit corresponding to the counterproof VK that it is using.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers
The rpc endpoint already existed but used default values. This PR populates it with correct metadata.

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->

fixes #266