### PR TITLE
net/svc: add protocol-version + deployment-version handshake (#265)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,7 @@ Ensure all the following are checked:
 - [ ] My changes do not introduce new warnings.
 - [ ] I have added tests that prove my changes are effective or that my feature works.
 - [ ] New and existing tests pass with my changes.
+- [ ] If this PR touches the wire-visible protocol surface — message types in `crates/cac/types`, garbler/evaluator STF semantics peers depend on in `crates/cac/protocol`, or net-svc framing/priorities — I bumped `PROTOCOL_VERSION` in `crates/net/svc-api/src/handshake.rs`.
 
 ## Related Issues
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,7 @@ name = "mosaic-net-svc"
 version = "0.1.0"
 dependencies = [
  "ahash",
+ "ark-serialize",
  "blake3",
  "ed25519-dalek",
  "hashbrown 0.17.1",
@@ -2518,6 +2519,7 @@ dependencies = [
 name = "mosaic-net-svc-api"
 version = "0.1.0"
 dependencies = [
+ "ark-serialize",
  "ed25519-dalek",
  "hex",
  "kanal",
@@ -2553,6 +2555,7 @@ name = "mosaic-rpc-server"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
+ "hex",
  "jsonrpsee",
  "mosaic-cac-types",
  "mosaic-common",

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -54,10 +54,12 @@ impl MosaicConfig {
             .map(PeerEntry::to_peer_config)
             .collect::<Result<Vec<_>>>()?;
 
-        Ok(NetServiceConfig::new(signing_key, bind_addr, peers)
+        NetServiceConfig::new(signing_key, bind_addr, peers)
             .with_keep_alive_interval(Duration::from_secs(self.network.keep_alive_interval_secs))
             .with_idle_timeout(Duration::from_secs(self.network.idle_timeout_secs))
-            .with_reconnect_backoff(Duration::from_secs(self.network.reconnect_backoff_secs)))
+            .with_reconnect_backoff(Duration::from_secs(self.network.reconnect_backoff_secs))
+            .with_deployment_version(self.network.deployment_version.clone())
+            .with_context(|| "invalid network.deployment_version")
     }
 
     pub(crate) fn build_net_client_config(&self) -> NetClientConfig {
@@ -237,6 +239,13 @@ pub(crate) struct NetworkConfig {
     pub(crate) idle_timeout_secs: u64,
     #[serde(default = "default_reconnect_backoff_secs")]
     pub(crate) reconnect_backoff_secs: u64,
+    /// Deployment-cohort identifier exchanged in the version handshake.
+    /// `None` (the default) skips cohort coordination — suitable for
+    /// single-operator dev. Coordinated deployments must set this to the
+    /// same string on every operator (e.g. `"tn3"`); mismatched or
+    /// asymmetric values cause the handshake to fail at connect time.
+    #[serde(default)]
+    pub(crate) deployment_version: Option<String>,
     #[serde(default)]
     pub(crate) client: NetworkClientConfig,
     #[serde(default)]

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -60,6 +60,7 @@ impl MosaicConfig {
             .with_reconnect_backoff(Duration::from_secs(self.network.reconnect_backoff_secs))
             .with_deployment_version(self.network.deployment_version.clone())
             .with_context(|| "invalid network.deployment_version")
+            .map(|cfg| cfg.with_reduced_circuits(cfg!(feature = "reduced-circuits")))
     }
 
     pub(crate) fn build_net_client_config(&self) -> NetClientConfig {

--- a/bin/mosaic/src/main.rs
+++ b/bin/mosaic/src/main.rs
@@ -241,6 +241,7 @@ where
     let our_peer_id = net_service_config.our_peer_id();
     let protocol_version = net_service_config.protocol_version;
     let deployment_version = net_service_config.deployment_version.clone();
+    let reduced_circuits = net_service_config.reduced_circuits;
     drop(net_service_config);
     let other_peer_ids = config.known_peers()?;
     let rng = rand_chacha::ChaCha20Rng::from_entropy();
@@ -253,6 +254,7 @@ where
         rng,
         protocol_version,
         deployment_version,
+        reduced_circuits,
     );
     let circuit_info =
         mosaic_rpc_types::RpcCircuitInfoEntry::from_circuit_file(&config.circuit.path)

--- a/bin/mosaic/src/main.rs
+++ b/bin/mosaic/src/main.rs
@@ -237,7 +237,11 @@ where
         .context("failed to spawn sm executor thread")?;
 
     let rpc_bind_addr = config.rpc_bind_addr()?;
-    let our_peer_id = config.build_net_service_config()?.our_peer_id();
+    let net_service_config = config.build_net_service_config()?;
+    let our_peer_id = net_service_config.our_peer_id();
+    let protocol_version = net_service_config.protocol_version;
+    let deployment_version = net_service_config.deployment_version.clone();
+    drop(net_service_config);
     let other_peer_ids = config.known_peers()?;
     let rng = rand_chacha::ChaCha20Rng::from_entropy();
 
@@ -247,6 +251,8 @@ where
         sm_executor_handle.clone(),
         storage,
         rng,
+        protocol_version,
+        deployment_version,
     );
     let circuit_info =
         mosaic_rpc_types::RpcCircuitInfoEntry::from_circuit_file(&config.circuit.path)

--- a/crates/net/svc-api/Cargo.toml
+++ b/crates/net/svc-api/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
+ark-serialize = { workspace = true }
 ed25519-dalek = "2"
 hex = "0.4"
 kanal = "0.1.1"

--- a/crates/net/svc-api/src/config.rs
+++ b/crates/net/svc-api/src/config.rs
@@ -8,7 +8,10 @@ use std::net::SocketAddr;
 
 use ed25519_dalek::SigningKey;
 
-use crate::peer_id::{PeerId, peer_id_from_signing_key};
+use crate::{
+    handshake::{MAX_DEPLOYMENT_VERSION_LEN, PROTOCOL_VERSION},
+    peer_id::{PeerId, peer_id_from_signing_key},
+};
 
 /// Configuration for a known peer.
 #[derive(Debug, Clone)]
@@ -92,6 +95,16 @@ pub struct NetServiceConfig {
     pub reconnect_backoff: std::time::Duration,
     /// Per-peer protocol-stream rate limit. Defaults to [`PeerStreamRateLimit::default`].
     pub peer_stream_rate_limit: PeerStreamRateLimit,
+    /// Protocol version this node advertises during the version handshake.
+    /// Defaults to [`PROTOCOL_VERSION`]; overridable for testing the mismatch
+    /// path.
+    pub protocol_version: u32,
+    /// Operator-supplied deployment-cohort identifier exchanged during the
+    /// version handshake. `None` for single-operator / local dev; `Some` for
+    /// coordinated deployments where every operator must set the same value
+    /// (e.g. `"tn3"` for testnet 3). Mismatched or asymmetric → handshake
+    /// refused.
+    pub deployment_version: Option<String>,
 }
 
 impl NetServiceConfig {
@@ -114,6 +127,8 @@ impl NetServiceConfig {
             idle_timeout: Self::DEFAULT_IDLE_TIMEOUT,
             reconnect_backoff: Self::DEFAULT_RECONNECT_BACKOFF,
             peer_stream_rate_limit: PeerStreamRateLimit::default(),
+            protocol_version: PROTOCOL_VERSION,
+            deployment_version: None,
         }
     }
 
@@ -139,6 +154,35 @@ impl NetServiceConfig {
     pub fn with_reconnect_backoff(mut self, backoff: std::time::Duration) -> Self {
         self.reconnect_backoff = backoff;
         self
+    }
+
+    /// Override the protocol version this node advertises. Intended for tests
+    /// that exercise the mismatch path; production callers should leave the
+    /// default ([`PROTOCOL_VERSION`]) in place.
+    pub fn with_protocol_version(mut self, version: u32) -> Self {
+        self.protocol_version = version;
+        self
+    }
+
+    /// Set the deployment-cohort identifier. Empty strings are treated as
+    /// `None` (no cohort coordination). Strings exceeding
+    /// [`MAX_DEPLOYMENT_VERSION_LEN`] bytes are rejected.
+    pub fn with_deployment_version(
+        mut self,
+        version: Option<String>,
+    ) -> Result<Self, DeploymentVersionError> {
+        match version {
+            Some(s) if s.is_empty() => self.deployment_version = None,
+            Some(s) if s.len() > MAX_DEPLOYMENT_VERSION_LEN => {
+                return Err(DeploymentVersionError::TooLong {
+                    len: s.len(),
+                    max: MAX_DEPLOYMENT_VERSION_LEN,
+                });
+            }
+            Some(s) => self.deployment_version = Some(s),
+            None => self.deployment_version = None,
+        }
+        Ok(self)
     }
 
     /// Check if a peer is in the known peers list.
@@ -175,9 +219,30 @@ impl std::fmt::Debug for NetServiceConfig {
             .field("peers", &self.peers.len())
             .field("keep_alive_interval", &self.keep_alive_interval)
             .field("idle_timeout", &self.idle_timeout)
+            .field("protocol_version", &self.protocol_version)
+            .field("deployment_version", &self.deployment_version)
             .finish()
     }
 }
+
+/// Error returned when an invalid deployment-version string is supplied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeploymentVersionError {
+    /// String exceeded [`MAX_DEPLOYMENT_VERSION_LEN`] bytes.
+    TooLong { len: usize, max: usize },
+}
+
+impl std::fmt::Display for DeploymentVersionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooLong { len, max } => {
+                write!(f, "deployment version is {len} bytes, max is {max}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DeploymentVersionError {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/net/svc-api/src/config.rs
+++ b/crates/net/svc-api/src/config.rs
@@ -105,6 +105,12 @@ pub struct NetServiceConfig {
     /// (e.g. `"tn3"` for testnet 3). Mismatched or asymmetric → handshake
     /// refused.
     pub deployment_version: Option<String>,
+    /// Whether this node is configured to run reduced-circuits mode.
+    /// Hard-matched across peers: a node running reduced circuits cannot
+    /// interop with one running full circuits because the circuit shape
+    /// (wire counts, tableset commitments, etc.) diverges. Defaults to
+    /// `false`; the binary sets this from its own circuit configuration.
+    pub reduced_circuits: bool,
 }
 
 impl NetServiceConfig {
@@ -129,6 +135,7 @@ impl NetServiceConfig {
             peer_stream_rate_limit: PeerStreamRateLimit::default(),
             protocol_version: PROTOCOL_VERSION,
             deployment_version: None,
+            reduced_circuits: false,
         }
     }
 
@@ -185,6 +192,13 @@ impl NetServiceConfig {
         Ok(self)
     }
 
+    /// Set whether this node is running reduced-circuits mode. Hard-matched
+    /// against peers during the version handshake.
+    pub fn with_reduced_circuits(mut self, reduced: bool) -> Self {
+        self.reduced_circuits = reduced;
+        self
+    }
+
     /// Check if a peer is in the known peers list.
     pub fn has_peer(&self, peer_id: &PeerId) -> bool {
         self.peers.iter().any(|p| &p.peer_id == peer_id)
@@ -221,6 +235,7 @@ impl std::fmt::Debug for NetServiceConfig {
             .field("idle_timeout", &self.idle_timeout)
             .field("protocol_version", &self.protocol_version)
             .field("deployment_version", &self.deployment_version)
+            .field("reduced_circuits", &self.reduced_circuits)
             .finish()
     }
 }

--- a/crates/net/svc-api/src/handshake.rs
+++ b/crates/net/svc-api/src/handshake.rs
@@ -63,15 +63,21 @@ pub struct HandshakePayload {
     /// uncoordinated deployments; `Some` for coordinated cohorts where every
     /// operator must set the same value.
     pub deployment_version: Option<String>,
+    /// Whether this node is built / configured to run reduced-circuits mode.
+    /// Hard-matched: peers with different values cannot interop because the
+    /// circuit definitions (and therefore tableset shapes, wire counts, and
+    /// commitment material) diverge.
+    pub reduced_circuits: bool,
 }
 
 impl HandshakePayload {
     /// Construct the local payload for this node.
-    pub fn new(deployment_version: Option<String>) -> Self {
+    pub fn new(deployment_version: Option<String>, reduced_circuits: bool) -> Self {
         Self {
             magic: HANDSHAKE_MAGIC,
             protocol_version: PROTOCOL_VERSION,
             deployment_version,
+            reduced_circuits,
         }
     }
 }
@@ -98,12 +104,14 @@ impl CanonicalSerialize for HandshakePayload {
                 writer.write_all(s.as_bytes())?;
             }
         }
+        (self.reduced_circuits as u8).serialize_with_mode(&mut writer, compress)?;
         Ok(())
     }
 
     fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
-        let base =
-            self.magic.serialized_size(compress) + self.protocol_version.serialized_size(compress);
+        let base = self.magic.serialized_size(compress)
+            + self.protocol_version.serialized_size(compress)
+            + 0u8.serialized_size(compress); // reduced_circuits byte
         match &self.deployment_version {
             None => base + 0u8.serialized_size(compress),
             Some(s) => {
@@ -154,10 +162,17 @@ impl CanonicalDeserialize for HandshakePayload {
             }
             _ => return Err(ark_serialize::SerializationError::InvalidData),
         };
+        let reduced_byte = u8::deserialize_with_mode(&mut reader, compress, validate)?;
+        let reduced_circuits = match reduced_byte {
+            0 => false,
+            1 => true,
+            _ => return Err(ark_serialize::SerializationError::InvalidData),
+        };
         Ok(Self {
             magic,
             protocol_version,
             deployment_version,
+            reduced_circuits,
         })
     }
 }
@@ -176,6 +191,10 @@ pub enum HandshakeMismatch {
     DeploymentVersionMissingRemote { local: String },
     /// Remote has `deployment_version` set, local does not.
     DeploymentVersionMissingLocal { remote: String },
+    /// Reduced-circuits mode differed. One side is running full circuits and
+    /// the other reduced (or vice versa) — wire-incompatible because the
+    /// circuit shape diverges.
+    ReducedCircuitsMismatch { local: bool, remote: bool },
 }
 
 impl HandshakeMismatch {
@@ -191,6 +210,7 @@ impl HandshakeMismatch {
             Self::DeploymentVersionMissingLocal { .. } => {
                 "local missing deployment version (remote set)"
             }
+            Self::ReducedCircuitsMismatch { .. } => "reduced-circuits mode mismatch",
         }
     }
 }
@@ -211,6 +231,9 @@ impl std::fmt::Display for HandshakeMismatch {
             Self::DeploymentVersionMissingLocal { remote } => {
                 write!(f, "{}: remote={remote:?}", self.reason())
             }
+            Self::ReducedCircuitsMismatch { local, remote } => {
+                write!(f, "{}: local={local} remote={remote}", self.reason())
+            }
         }
     }
 }
@@ -220,9 +243,11 @@ impl std::error::Error for HandshakeMismatch {}
 /// Validate a received handshake payload against the local configuration.
 /// `local_deployment_version` is the deployment-version this node is
 /// configured with (or `None` for uncoordinated single-operator dev).
+/// `local_reduced_circuits` is whether this node is running reduced circuits.
 pub fn validate_handshake(
     local_protocol_version: u32,
     local_deployment_version: Option<&str>,
+    local_reduced_circuits: bool,
     remote: &HandshakePayload,
 ) -> Result<(), HandshakeMismatch> {
     if remote.magic != HANDSHAKE_MAGIC {
@@ -232,6 +257,12 @@ pub fn validate_handshake(
         return Err(HandshakeMismatch::ProtocolVersionMismatch {
             local: local_protocol_version,
             remote: remote.protocol_version,
+        });
+    }
+    if remote.reduced_circuits != local_reduced_circuits {
+        return Err(HandshakeMismatch::ReducedCircuitsMismatch {
+            local: local_reduced_circuits,
+            remote: remote.reduced_circuits,
         });
     }
     match (local_deployment_version, &remote.deployment_version) {
@@ -271,27 +302,31 @@ mod tests {
 
     #[test]
     fn roundtrip_no_deployment_version() {
-        let p = HandshakePayload::new(None);
-        assert_eq!(roundtrip(&p), p);
+        for rc in [false, true] {
+            let p = HandshakePayload::new(None, rc);
+            assert_eq!(roundtrip(&p), p);
+        }
     }
 
     #[test]
     fn roundtrip_with_deployment_version() {
-        let p = HandshakePayload::new(Some("tn3".to_string()));
-        assert_eq!(roundtrip(&p), p);
+        for rc in [false, true] {
+            let p = HandshakePayload::new(Some("tn3".to_string()), rc);
+            assert_eq!(roundtrip(&p), p);
+        }
     }
 
     #[test]
     fn roundtrip_with_max_length_deployment_version() {
         let s = "x".repeat(MAX_DEPLOYMENT_VERSION_LEN);
-        let p = HandshakePayload::new(Some(s));
+        let p = HandshakePayload::new(Some(s), true);
         assert_eq!(roundtrip(&p), p);
     }
 
     #[test]
     fn over_length_deployment_version_fails_to_serialize() {
         let s = "x".repeat(MAX_DEPLOYMENT_VERSION_LEN + 1);
-        let p = HandshakePayload::new(Some(s));
+        let p = HandshakePayload::new(Some(s), false);
         let mut buf = Vec::new();
         assert!(p.serialize_with_mode(&mut buf, Compress::No).is_err());
     }
@@ -306,6 +341,7 @@ mod tests {
         buf.push(1u8); // has_deployment
         buf.push((MAX_DEPLOYMENT_VERSION_LEN as u8) + 1); // over-cap length
         buf.extend(std::iter::repeat_n(b'x', MAX_DEPLOYMENT_VERSION_LEN + 1));
+        buf.push(0u8); // reduced_circuits
         let r =
             HandshakePayload::deserialize_with_mode(buf.as_slice(), Compress::No, Validate::Yes);
         assert!(r.is_err());
@@ -317,6 +353,20 @@ mod tests {
         buf.extend_from_slice(b"XXXX");
         buf.extend_from_slice(&1u32.to_le_bytes());
         buf.push(0u8);
+        buf.push(0u8); // reduced_circuits
+        let r =
+            HandshakePayload::deserialize_with_mode(buf.as_slice(), Compress::No, Validate::Yes);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn invalid_reduced_circuits_byte_fails_to_deserialize() {
+        // Anything other than 0/1 in the reduced_circuits position is invalid.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&HANDSHAKE_MAGIC);
+        buf.extend_from_slice(&PROTOCOL_VERSION.to_le_bytes());
+        buf.push(0u8); // no deployment
+        buf.push(2u8); // invalid reduced_circuits
         let r =
             HandshakePayload::deserialize_with_mode(buf.as_slice(), Compress::No, Validate::Yes);
         assert!(r.is_err());
@@ -324,21 +374,21 @@ mod tests {
 
     #[test]
     fn validate_matching_passes() {
-        let remote = HandshakePayload::new(Some("tn3".to_string()));
-        assert!(validate_handshake(PROTOCOL_VERSION, Some("tn3"), &remote).is_ok());
+        let remote = HandshakePayload::new(Some("tn3".to_string()), true);
+        assert!(validate_handshake(PROTOCOL_VERSION, Some("tn3"), true, &remote).is_ok());
     }
 
     #[test]
     fn validate_no_deployment_passes() {
-        let remote = HandshakePayload::new(None);
-        assert!(validate_handshake(PROTOCOL_VERSION, None, &remote).is_ok());
+        let remote = HandshakePayload::new(None, false);
+        assert!(validate_handshake(PROTOCOL_VERSION, None, false, &remote).is_ok());
     }
 
     #[test]
     fn validate_protocol_mismatch_rejects() {
-        let mut remote = HandshakePayload::new(None);
+        let mut remote = HandshakePayload::new(None, false);
         remote.protocol_version = PROTOCOL_VERSION.wrapping_add(1);
-        let err = validate_handshake(PROTOCOL_VERSION, None, &remote).unwrap_err();
+        let err = validate_handshake(PROTOCOL_VERSION, None, false, &remote).unwrap_err();
         assert!(matches!(
             err,
             HandshakeMismatch::ProtocolVersionMismatch { .. }
@@ -347,8 +397,8 @@ mod tests {
 
     #[test]
     fn validate_deployment_mismatch_rejects() {
-        let remote = HandshakePayload::new(Some("tn4".to_string()));
-        let err = validate_handshake(PROTOCOL_VERSION, Some("tn3"), &remote).unwrap_err();
+        let remote = HandshakePayload::new(Some("tn4".to_string()), false);
+        let err = validate_handshake(PROTOCOL_VERSION, Some("tn3"), false, &remote).unwrap_err();
         assert!(matches!(
             err,
             HandshakeMismatch::DeploymentVersionMismatch { .. }
@@ -357,15 +407,15 @@ mod tests {
 
     #[test]
     fn validate_deployment_asymmetry_rejects_both_directions() {
-        let local_set = HandshakePayload::new(None);
-        let err = validate_handshake(PROTOCOL_VERSION, Some("tn3"), &local_set).unwrap_err();
+        let local_set = HandshakePayload::new(None, false);
+        let err = validate_handshake(PROTOCOL_VERSION, Some("tn3"), false, &local_set).unwrap_err();
         assert!(matches!(
             err,
             HandshakeMismatch::DeploymentVersionMissingRemote { .. }
         ));
 
-        let remote_set = HandshakePayload::new(Some("tn3".to_string()));
-        let err = validate_handshake(PROTOCOL_VERSION, None, &remote_set).unwrap_err();
+        let remote_set = HandshakePayload::new(Some("tn3".to_string()), false);
+        let err = validate_handshake(PROTOCOL_VERSION, None, false, &remote_set).unwrap_err();
         assert!(matches!(
             err,
             HandshakeMismatch::DeploymentVersionMissingLocal { .. }
@@ -374,9 +424,32 @@ mod tests {
 
     #[test]
     fn validate_bad_magic_rejects() {
-        let mut remote = HandshakePayload::new(None);
+        let mut remote = HandshakePayload::new(None, false);
         remote.magic = [0u8; 4];
-        let err = validate_handshake(PROTOCOL_VERSION, None, &remote).unwrap_err();
+        let err = validate_handshake(PROTOCOL_VERSION, None, false, &remote).unwrap_err();
         assert!(matches!(err, HandshakeMismatch::MagicMismatch));
+    }
+
+    #[test]
+    fn validate_reduced_circuits_mismatch_rejects_both_directions() {
+        let remote_reduced = HandshakePayload::new(None, true);
+        let err = validate_handshake(PROTOCOL_VERSION, None, false, &remote_reduced).unwrap_err();
+        match err {
+            HandshakeMismatch::ReducedCircuitsMismatch { local, remote } => {
+                assert!(!local);
+                assert!(remote);
+            }
+            other => panic!("expected ReducedCircuitsMismatch, got {other:?}"),
+        }
+
+        let remote_full = HandshakePayload::new(None, false);
+        let err = validate_handshake(PROTOCOL_VERSION, None, true, &remote_full).unwrap_err();
+        match err {
+            HandshakeMismatch::ReducedCircuitsMismatch { local, remote } => {
+                assert!(local);
+                assert!(!remote);
+            }
+            other => panic!("expected ReducedCircuitsMismatch, got {other:?}"),
+        }
     }
 }

--- a/crates/net/svc-api/src/handshake.rs
+++ b/crates/net/svc-api/src/handshake.rs
@@ -46,7 +46,7 @@ pub const MAX_DEPLOYMENT_VERSION_LEN: usize = 64;
 /// Magic prefix identifying a mosaic version handshake payload. Lets the
 /// receiver fail fast on a stream that was opened against the wrong service or
 /// carrying an unrelated payload.
-pub const HANDSHAKE_MAGIC: [u8; 4] = *b"MSCV";
+pub const HANDSHAKE_MAGIC: [u8; 4] = *b"Zk2u";
 
 /// Payload exchanged on the version-handshake stream.
 ///

--- a/crates/net/svc-api/src/handshake.rs
+++ b/crates/net/svc-api/src/handshake.rs
@@ -1,0 +1,382 @@
+//! Version handshake exchanged as the first app-layer message after QUIC TLS
+//! authentication completes.
+//!
+//! Two fields are exchanged:
+//!
+//! - [`HandshakePayload::protocol_version`] — code-level compatibility marker. A
+//!   manually-maintained `u32` ([`PROTOCOL_VERSION`]) bumped whenever the wire-visible protocol
+//!   surface changes (message types in `cac/types` / `cac/protocol`, net-svc wire framing,
+//!   garbler/evaluator STF semantics peers depend on). Mismatch → refuse communication.
+//! - [`HandshakePayload::deployment_version`] — operator-supplied cohort identifier
+//!   (`Option<String>`). All-or-none: every operator in a coordinated deployment sets the same
+//!   string (e.g. `"tn3"`); single-operator dev / local testing leaves it unset. Asymmetric or
+//!   mismatched → refuse.
+//!
+//! The handshake runs on a dedicated bi-stream opened immediately after QUIC
+//! TLS completes and the peer-identity has been verified. No protocol streams
+//! are opened until the handshake succeeds on both sides.
+
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+/// Current protocol version.
+///
+/// **Bump this constant whenever a wire-visible protocol change ships.** The
+/// surface that needs tracking:
+///
+/// - Message types and serialization in `crates/cac/types`
+/// - Garbler/evaluator state machine semantics in `crates/cac/protocol` that change what peers send
+///   or expect
+/// - net-svc wire framing or stream priorities in `crates/net/svc`
+///
+/// We deliberately use a manual constant (not a git-hash or content-hash) so
+/// that protocol-irrelevant commits don't sever connectivity. The PR template
+/// includes a "touches wire-visible surface" checkbox to make this visible at
+/// review time.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Maximum number of bytes the receiver will read for a handshake payload.
+/// Sized comfortably above the largest legitimate payload (protocol version
+/// + optional ~64-byte deployment string + ark-serialize overhead).
+pub const MAX_HANDSHAKE_PAYLOAD_BYTES: usize = 256;
+
+/// Maximum length of the deployment-version string in bytes. Anything longer
+/// is rejected at deserialize time, before any peer-controlled allocation.
+pub const MAX_DEPLOYMENT_VERSION_LEN: usize = 64;
+
+/// Magic prefix identifying a mosaic version handshake payload. Lets the
+/// receiver fail fast on a stream that was opened against the wrong service or
+/// carrying an unrelated payload.
+pub const HANDSHAKE_MAGIC: [u8; 4] = *b"MSCV";
+
+/// Payload exchanged on the version-handshake stream.
+///
+/// Encoded with ark-serialize (consistent with the rest of the mosaic wire
+/// surface). The receiver MUST refuse to read more than
+/// [`MAX_HANDSHAKE_PAYLOAD_BYTES`] bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HandshakePayload {
+    /// See [`HANDSHAKE_MAGIC`]. Always set to that value on send.
+    pub magic: [u8; 4],
+    /// See [`PROTOCOL_VERSION`].
+    pub protocol_version: u32,
+    /// Optional operator-coordinated cohort identifier. `None` for
+    /// uncoordinated deployments; `Some` for coordinated cohorts where every
+    /// operator must set the same value.
+    pub deployment_version: Option<String>,
+}
+
+impl HandshakePayload {
+    /// Construct the local payload for this node.
+    pub fn new(deployment_version: Option<String>) -> Self {
+        Self {
+            magic: HANDSHAKE_MAGIC,
+            protocol_version: PROTOCOL_VERSION,
+            deployment_version,
+        }
+    }
+}
+
+// Manual ark-serialize impl. We deliberately don't derive because we want the
+// deployment-version length cap enforced at decode time, before allocation.
+impl CanonicalSerialize for HandshakePayload {
+    fn serialize_with_mode<W: ark_serialize::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        self.magic.serialize_with_mode(&mut writer, compress)?;
+        self.protocol_version
+            .serialize_with_mode(&mut writer, compress)?;
+        match &self.deployment_version {
+            None => 0u8.serialize_with_mode(&mut writer, compress)?,
+            Some(s) => {
+                if s.len() > MAX_DEPLOYMENT_VERSION_LEN {
+                    return Err(ark_serialize::SerializationError::InvalidData);
+                }
+                1u8.serialize_with_mode(&mut writer, compress)?;
+                (s.len() as u8).serialize_with_mode(&mut writer, compress)?;
+                writer.write_all(s.as_bytes())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        let base =
+            self.magic.serialized_size(compress) + self.protocol_version.serialized_size(compress);
+        match &self.deployment_version {
+            None => base + 0u8.serialized_size(compress),
+            Some(s) => {
+                base + 0u8.serialized_size(compress) + 0u8.serialized_size(compress) + s.len()
+            }
+        }
+    }
+}
+
+impl ark_serialize::Valid for HandshakePayload {
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        if self.magic != HANDSHAKE_MAGIC {
+            return Err(ark_serialize::SerializationError::InvalidData);
+        }
+        if let Some(s) = &self.deployment_version
+            && s.len() > MAX_DEPLOYMENT_VERSION_LEN
+        {
+            return Err(ark_serialize::SerializationError::InvalidData);
+        }
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for HandshakePayload {
+    fn deserialize_with_mode<R: ark_serialize::Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let magic = <[u8; 4]>::deserialize_with_mode(&mut reader, compress, validate)?;
+        if magic != HANDSHAKE_MAGIC {
+            return Err(ark_serialize::SerializationError::InvalidData);
+        }
+        let protocol_version = u32::deserialize_with_mode(&mut reader, compress, validate)?;
+        let has_deployment = u8::deserialize_with_mode(&mut reader, compress, validate)?;
+        let deployment_version = match has_deployment {
+            0 => None,
+            1 => {
+                let len = u8::deserialize_with_mode(&mut reader, compress, validate)? as usize;
+                if len > MAX_DEPLOYMENT_VERSION_LEN {
+                    return Err(ark_serialize::SerializationError::InvalidData);
+                }
+                let mut buf = vec![0u8; len];
+                reader.read_exact(&mut buf)?;
+                let s = String::from_utf8(buf)
+                    .map_err(|_| ark_serialize::SerializationError::InvalidData)?;
+                Some(s)
+            }
+            _ => return Err(ark_serialize::SerializationError::InvalidData),
+        };
+        Ok(Self {
+            magic,
+            protocol_version,
+            deployment_version,
+        })
+    }
+}
+
+/// Reason a handshake was rejected. Distinct from a transport error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HandshakeMismatch {
+    /// Magic prefix did not match — either a stream from an unrelated service
+    /// or a malformed handshake.
+    MagicMismatch,
+    /// Protocol versions differed. Operators are running incompatible builds.
+    ProtocolVersionMismatch { local: u32, remote: u32 },
+    /// Both peers set a `deployment_version` but they differ.
+    DeploymentVersionMismatch { local: String, remote: String },
+    /// Local has `deployment_version` set, remote does not.
+    DeploymentVersionMissingRemote { local: String },
+    /// Remote has `deployment_version` set, local does not.
+    DeploymentVersionMissingLocal { remote: String },
+}
+
+impl HandshakeMismatch {
+    /// Short, log-safe reason string.
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::MagicMismatch => "magic mismatch",
+            Self::ProtocolVersionMismatch { .. } => "protocol version mismatch",
+            Self::DeploymentVersionMismatch { .. } => "deployment version mismatch",
+            Self::DeploymentVersionMissingRemote { .. } => {
+                "remote missing deployment version (local set)"
+            }
+            Self::DeploymentVersionMissingLocal { .. } => {
+                "local missing deployment version (remote set)"
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for HandshakeMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MagicMismatch => write!(f, "{}", self.reason()),
+            Self::ProtocolVersionMismatch { local, remote } => {
+                write!(f, "{}: local={local} remote={remote}", self.reason())
+            }
+            Self::DeploymentVersionMismatch { local, remote } => {
+                write!(f, "{}: local={local:?} remote={remote:?}", self.reason())
+            }
+            Self::DeploymentVersionMissingRemote { local } => {
+                write!(f, "{}: local={local:?}", self.reason())
+            }
+            Self::DeploymentVersionMissingLocal { remote } => {
+                write!(f, "{}: remote={remote:?}", self.reason())
+            }
+        }
+    }
+}
+
+impl std::error::Error for HandshakeMismatch {}
+
+/// Validate a received handshake payload against the local configuration.
+/// `local_deployment_version` is the deployment-version this node is
+/// configured with (or `None` for uncoordinated single-operator dev).
+pub fn validate_handshake(
+    local_protocol_version: u32,
+    local_deployment_version: Option<&str>,
+    remote: &HandshakePayload,
+) -> Result<(), HandshakeMismatch> {
+    if remote.magic != HANDSHAKE_MAGIC {
+        return Err(HandshakeMismatch::MagicMismatch);
+    }
+    if remote.protocol_version != local_protocol_version {
+        return Err(HandshakeMismatch::ProtocolVersionMismatch {
+            local: local_protocol_version,
+            remote: remote.protocol_version,
+        });
+    }
+    match (local_deployment_version, &remote.deployment_version) {
+        (None, None) => Ok(()),
+        (Some(l), Some(r)) if l == r => Ok(()),
+        (Some(l), Some(r)) => Err(HandshakeMismatch::DeploymentVersionMismatch {
+            local: l.to_string(),
+            remote: r.clone(),
+        }),
+        (Some(l), None) => Err(HandshakeMismatch::DeploymentVersionMissingRemote {
+            local: l.to_string(),
+        }),
+        (None, Some(r)) => {
+            Err(HandshakeMismatch::DeploymentVersionMissingLocal { remote: r.clone() })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_serialize::{Compress, Validate};
+
+    use super::*;
+
+    fn roundtrip(payload: &HandshakePayload) -> HandshakePayload {
+        let mut buf = Vec::new();
+        payload
+            .serialize_with_mode(&mut buf, Compress::No)
+            .expect("serialize");
+        assert!(
+            buf.len() <= MAX_HANDSHAKE_PAYLOAD_BYTES,
+            "encoded payload exceeds MAX_HANDSHAKE_PAYLOAD_BYTES"
+        );
+        HandshakePayload::deserialize_with_mode(buf.as_slice(), Compress::No, Validate::Yes)
+            .expect("deserialize")
+    }
+
+    #[test]
+    fn roundtrip_no_deployment_version() {
+        let p = HandshakePayload::new(None);
+        assert_eq!(roundtrip(&p), p);
+    }
+
+    #[test]
+    fn roundtrip_with_deployment_version() {
+        let p = HandshakePayload::new(Some("tn3".to_string()));
+        assert_eq!(roundtrip(&p), p);
+    }
+
+    #[test]
+    fn roundtrip_with_max_length_deployment_version() {
+        let s = "x".repeat(MAX_DEPLOYMENT_VERSION_LEN);
+        let p = HandshakePayload::new(Some(s));
+        assert_eq!(roundtrip(&p), p);
+    }
+
+    #[test]
+    fn over_length_deployment_version_fails_to_serialize() {
+        let s = "x".repeat(MAX_DEPLOYMENT_VERSION_LEN + 1);
+        let p = HandshakePayload::new(Some(s));
+        let mut buf = Vec::new();
+        assert!(p.serialize_with_mode(&mut buf, Compress::No).is_err());
+    }
+
+    #[test]
+    fn over_length_deployment_version_fails_to_deserialize() {
+        // Hand-construct a payload with a deployment-version length byte that
+        // exceeds the cap. Receivers MUST reject before allocating the buffer.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&HANDSHAKE_MAGIC);
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.push(1u8); // has_deployment
+        buf.push((MAX_DEPLOYMENT_VERSION_LEN as u8) + 1); // over-cap length
+        buf.extend(std::iter::repeat_n(b'x', MAX_DEPLOYMENT_VERSION_LEN + 1));
+        let r =
+            HandshakePayload::deserialize_with_mode(buf.as_slice(), Compress::No, Validate::Yes);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn bad_magic_fails_to_deserialize() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"XXXX");
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.push(0u8);
+        let r =
+            HandshakePayload::deserialize_with_mode(buf.as_slice(), Compress::No, Validate::Yes);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn validate_matching_passes() {
+        let remote = HandshakePayload::new(Some("tn3".to_string()));
+        assert!(validate_handshake(PROTOCOL_VERSION, Some("tn3"), &remote).is_ok());
+    }
+
+    #[test]
+    fn validate_no_deployment_passes() {
+        let remote = HandshakePayload::new(None);
+        assert!(validate_handshake(PROTOCOL_VERSION, None, &remote).is_ok());
+    }
+
+    #[test]
+    fn validate_protocol_mismatch_rejects() {
+        let mut remote = HandshakePayload::new(None);
+        remote.protocol_version = PROTOCOL_VERSION.wrapping_add(1);
+        let err = validate_handshake(PROTOCOL_VERSION, None, &remote).unwrap_err();
+        assert!(matches!(
+            err,
+            HandshakeMismatch::ProtocolVersionMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn validate_deployment_mismatch_rejects() {
+        let remote = HandshakePayload::new(Some("tn4".to_string()));
+        let err = validate_handshake(PROTOCOL_VERSION, Some("tn3"), &remote).unwrap_err();
+        assert!(matches!(
+            err,
+            HandshakeMismatch::DeploymentVersionMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn validate_deployment_asymmetry_rejects_both_directions() {
+        let local_set = HandshakePayload::new(None);
+        let err = validate_handshake(PROTOCOL_VERSION, Some("tn3"), &local_set).unwrap_err();
+        assert!(matches!(
+            err,
+            HandshakeMismatch::DeploymentVersionMissingRemote { .. }
+        ));
+
+        let remote_set = HandshakePayload::new(Some("tn3".to_string()));
+        let err = validate_handshake(PROTOCOL_VERSION, None, &remote_set).unwrap_err();
+        assert!(matches!(
+            err,
+            HandshakeMismatch::DeploymentVersionMissingLocal { .. }
+        ));
+    }
+
+    #[test]
+    fn validate_bad_magic_rejects() {
+        let mut remote = HandshakePayload::new(None);
+        remote.magic = [0u8; 4];
+        let err = validate_handshake(PROTOCOL_VERSION, None, &remote).unwrap_err();
+        assert!(matches!(err, HandshakeMismatch::MagicMismatch));
+    }
+}

--- a/crates/net/svc-api/src/lib.rs
+++ b/crates/net/svc-api/src/lib.rs
@@ -23,6 +23,7 @@
 
 pub mod api;
 pub mod config;
+pub mod handshake;
 pub mod peer_id;
 
 // Re-export main types for convenience.
@@ -31,4 +32,8 @@ pub use api::{
     PayloadBuf, Stream, StreamClosed,
 };
 pub use config::{NetServiceConfig, PeerConfig, PeerStreamRateLimit};
+pub use handshake::{
+    HANDSHAKE_MAGIC, HandshakeMismatch, HandshakePayload, MAX_DEPLOYMENT_VERSION_LEN,
+    MAX_HANDSHAKE_PAYLOAD_BYTES, PROTOCOL_VERSION, validate_handshake,
+};
 pub use peer_id::{PeerId, peer_id_from_signing_key, peer_id_from_verifying_key};

--- a/crates/net/svc/Cargo.toml
+++ b/crates/net/svc/Cargo.toml
@@ -38,6 +38,7 @@ x509-parser = "0.18"
 
 # Wire format
 mosaic-net-wire = { path = "../wire" }
+ark-serialize = { workspace = true }
 
 # Utilities
 ahash = "0.8"

--- a/crates/net/svc/src/close_codes.rs
+++ b/crates/net/svc/src/close_codes.rs
@@ -14,6 +14,7 @@
 //! | 3    | Invalid peer ID in certificate (outbound)    |
 //! | 4    | Peer ID mismatch (connected to wrong peer)   |
 //! | 5    | Invalid overlap key metadata                 |
+//! | 6    | Version handshake failed (mismatch / timeout / decode error) |
 
 use quinn::VarInt;
 
@@ -51,3 +52,10 @@ pub const CLOSE_PEER_ID_MISMATCH: VarInt = VarInt::from_u32(4);
 /// The client did not present a parseable overlap-key server name, so the
 /// connection cannot participate in deterministic race resolution.
 pub const CLOSE_INVALID_OVERLAP_KEY: VarInt = VarInt::from_u32(5);
+
+/// Version handshake failed.
+///
+/// Either the protocol version, deployment version, or magic-prefix check did
+/// not match; or the handshake stream timed out / failed to decode. The
+/// concrete reason is logged at ERROR on the local side.
+pub const CLOSE_VERSION_HANDSHAKE_FAILED: VarInt = VarInt::from_u32(6);

--- a/crates/net/svc/src/svc/handlers.rs
+++ b/crates/net/svc/src/svc/handlers.rs
@@ -149,6 +149,7 @@ fn start_outbound_attempt(peer: PeerId, state: &mut ServiceState) {
         state.event_tx.clone(),
         state.config.protocol_version,
         state.config.deployment_version.clone(),
+        state.config.reduced_circuits,
     );
 }
 
@@ -545,6 +546,23 @@ fn handle_open_stream_request(
     if !state.config.has_peer(&peer) {
         tokio::spawn(async move {
             let _ = respond_to.send(Err(OpenStreamError::PeerNotFound)).await;
+        });
+        return;
+    }
+
+    // Peer is in the incompatible-peer cache (failed version handshake during
+    // this process lifetime). `start_outbound_attempt` will skip dialing, so
+    // queueing the request would just leave it pending until the caller's
+    // timeout / cancel fires. Reject immediately so the caller surfaces the
+    // failure right away.
+    if state.incompatible_peers.contains(&peer) {
+        tokio::spawn(async move {
+            let _ = respond_to
+                .send(Err(OpenStreamError::ConnectionFailed(
+                    "peer marked incompatible (version handshake failed); reconnect suppressed until restart or inbound handshake"
+                        .to_string(),
+                )))
+                .await;
         });
         return;
     }

--- a/crates/net/svc/src/svc/handlers.rs
+++ b/crates/net/svc/src/svc/handlers.rs
@@ -1408,7 +1408,7 @@ pub fn handle_event(event: ServiceEvent, state: &mut ServiceState) {
                 tracing::info!(
                     peer = %hex::encode(peer),
                     reason = %reason,
-                    "marking peer incompatible; future reconnect attempts suppressed until restart"
+                    "marking peer incompatible; future reconnect attempts suppressed until they reconnect or we restart"
                 );
             } else {
                 tracing::debug!(
@@ -1420,6 +1420,18 @@ pub fn handle_event(event: ServiceEvent, state: &mut ServiceState) {
             // suppression takes effect immediately rather than after one more
             // attempt.
             clear_reconnect(peer, state);
+        }
+
+        ServiceEvent::ClearPeerIncompatible { peer } => {
+            // Successful handshake — peer has been upgraded (or always was
+            // compatible). Drop them from the cache so outbound reconnect
+            // attempts resume normally if the connection later drops.
+            if state.incompatible_peers.remove(&peer) {
+                tracing::info!(
+                    peer = %hex::encode(peer),
+                    "peer reconnected with matching versions; clearing incompatible flag"
+                );
+            }
         }
 
         ServiceEvent::ConnectionLost {

--- a/crates/net/svc/src/svc/handlers.rs
+++ b/crates/net/svc/src/svc/handlers.rs
@@ -115,6 +115,16 @@ fn clear_reconnect(peer: PeerId, state: &mut ServiceState) {
 }
 
 fn start_outbound_attempt(peer: PeerId, state: &mut ServiceState) {
+    // Don't burn cycles reconnecting to a peer we know is incompatible.
+    // Cleared on process restart.
+    if state.incompatible_peers.contains(&peer) {
+        tracing::debug!(
+            peer = %hex::encode(peer),
+            "skipping outbound attempt: peer marked incompatible (version handshake failed)"
+        );
+        return;
+    }
+
     let addr = match state.config.get_peer_addr(&peer) {
         Some(addr) => addr,
         None => return,
@@ -137,6 +147,8 @@ fn start_outbound_attempt(peer: PeerId, state: &mut ServiceState) {
         attempt,
         addr,
         state.event_tx.clone(),
+        state.config.protocol_version,
+        state.config.deployment_version.clone(),
     );
 }
 
@@ -1385,6 +1397,29 @@ pub fn handle_event(event: ServiceEvent, state: &mut ServiceState) {
                 "outbound connection failed"
             );
             on_outbound_failed(peer, attempt_id, error, state);
+        }
+
+        ServiceEvent::MarkPeerIncompatible { peer, reason } => {
+            // First insertion logs at INFO; the ERROR-level log was already
+            // emitted by the spawn task at the point of failure. Repeated
+            // signals (e.g. multiple in-flight attempts converging) become
+            // a no-op at DEBUG.
+            if state.incompatible_peers.insert(peer) {
+                tracing::info!(
+                    peer = %hex::encode(peer),
+                    reason = %reason,
+                    "marking peer incompatible; future reconnect attempts suppressed until restart"
+                );
+            } else {
+                tracing::debug!(
+                    peer = %hex::encode(peer),
+                    "duplicate MarkPeerIncompatible signal; already tracked"
+                );
+            }
+            // Clear any pending reconnect schedule for this peer so the
+            // suppression takes effect immediately rather than after one more
+            // attempt.
+            clear_reconnect(peer, state);
         }
 
         ServiceEvent::ConnectionLost {

--- a/crates/net/svc/src/svc/mod.rs
+++ b/crates/net/svc/src/svc/mod.rs
@@ -24,6 +24,7 @@ mod peer_rate_limit;
 mod state;
 mod stream;
 mod tasks;
+mod version_handshake;
 
 use std::{
     collections::HashSet,
@@ -317,6 +318,7 @@ async fn run_service_async(
         next_connection_generation: 1,
         resolved_outbound_attempt_by_peer: HashMap::new(),
         peer_rate_limiter,
+        incompatible_peers: ahash::HashSet::default(),
     };
 
     // Schedule initial connections to all peers.
@@ -397,6 +399,8 @@ async fn run_service_async(
         peer_by_port,
         peer_by_ip,
         event_tx.clone(),
+        config.protocol_version,
+        config.deployment_version.clone(),
     );
 
     // Main event loop - NEVER blocks on I/O, only receives and dispatches

--- a/crates/net/svc/src/svc/mod.rs
+++ b/crates/net/svc/src/svc/mod.rs
@@ -401,6 +401,7 @@ async fn run_service_async(
         event_tx.clone(),
         config.protocol_version,
         config.deployment_version.clone(),
+        config.reduced_circuits,
     );
 
     // Main event loop - NEVER blocks on I/O, only receives and dispatches

--- a/crates/net/svc/src/svc/state.rs
+++ b/crates/net/svc/src/svc/state.rs
@@ -206,6 +206,13 @@ pub struct ServiceState {
 
     /// Per-peer protocol-stream admission rate limiter.
     pub peer_rate_limiter: super::peer_rate_limit::PeerStreamRateLimiter,
+
+    /// Peers that have failed the version handshake during this process
+    /// lifetime. Outbound reconnect attempts skip peers in this set so we
+    /// don't burn CPU and log lines re-handshaking a known-incompatible peer.
+    /// Cleared on process restart — if either side is upgraded, the next
+    /// startup gets a clean attempt.
+    pub incompatible_peers: HashSet<PeerId>,
 }
 
 impl ServiceState {
@@ -296,6 +303,14 @@ pub enum ServiceEvent {
         peer: PeerId,
         attempt_id: u64,
         error: String,
+    },
+    /// A peer failed the version handshake; mark it incompatible for the rest
+    /// of this process lifetime so reconnect attempts don't churn against it.
+    MarkPeerIncompatible {
+        peer: PeerId,
+        /// One-line reason from `HandshakeError::reason()`. Logged on first
+        /// entry only, to avoid log spam from reconnect loops.
+        reason: String,
     },
     /// A connection was lost.
     ConnectionLost {

--- a/crates/net/svc/src/svc/state.rs
+++ b/crates/net/svc/src/svc/state.rs
@@ -210,8 +210,14 @@ pub struct ServiceState {
     /// Peers that have failed the version handshake during this process
     /// lifetime. Outbound reconnect attempts skip peers in this set so we
     /// don't burn CPU and log lines re-handshaking a known-incompatible peer.
-    /// Cleared on process restart — if either side is upgraded, the next
-    /// startup gets a clean attempt.
+    ///
+    /// Entries are cleared on:
+    /// - Process restart (cache is in-memory only), OR
+    /// - A successful version handshake with that peer (typically because they upgraded and either
+    ///   dialed us inbound or our outbound succeeded on a path that wasn't suppressed).
+    ///
+    /// Inbound connections always run the handshake regardless of this set
+    /// — an upgraded peer dialing us is always free to reconnect.
     pub incompatible_peers: HashSet<PeerId>,
 }
 
@@ -305,13 +311,20 @@ pub enum ServiceEvent {
         error: String,
     },
     /// A peer failed the version handshake; mark it incompatible for the rest
-    /// of this process lifetime so reconnect attempts don't churn against it.
+    /// of this process lifetime (or until cleared by a successful subsequent
+    /// handshake, see `ClearPeerIncompatible`) so reconnect attempts don't
+    /// churn against it.
     MarkPeerIncompatible {
         peer: PeerId,
         /// One-line reason from `HandshakeError::reason()`. Logged on first
         /// entry only, to avoid log spam from reconnect loops.
         reason: String,
     },
+    /// A peer that was previously marked incompatible just completed a
+    /// successful version handshake (typically because they restarted with
+    /// matching versions and dialed us). Removes them from the cache so our
+    /// outbound reconnect logic stops suppressing attempts to them too.
+    ClearPeerIncompatible { peer: PeerId },
     /// A connection was lost.
     ConnectionLost {
         peer: PeerId,

--- a/crates/net/svc/src/svc/tasks.rs
+++ b/crates/net/svc/src/svc/tasks.rs
@@ -418,7 +418,10 @@ fn spawn_incoming_connection_handler(incoming: quinn::Incoming, ctx: IncomingHan
             // Version handshake: refuse before exposing protocol streams.
             // On mismatch we mark this peer incompatible via the service event
             // loop so future outbound reconnect attempts to it are suppressed
-            // until process restart.
+            // (until process restart, or until they dial us with matching
+            // versions). On success we proactively clear them from the
+            // cache so an upgraded peer who reconnects to us also unblocks
+            // our outbound reconnect logic.
             if let Err(err) =
                 run_inbound_handshake(&connection, protocol_version, deployment_version.as_deref())
                     .await
@@ -438,6 +441,7 @@ fn spawn_incoming_connection_handler(incoming: quinn::Incoming, ctx: IncomingHan
                 );
                 return;
             }
+            let _ = event_tx.send(ServiceEvent::ClearPeerIncompatible { peer: peer_id });
 
             let peer_guess = predicted_peer.unwrap_or(peer_id);
             if event_tx
@@ -527,7 +531,8 @@ pub fn spawn_outbound_connection(
                     return;
                 }
 
-                // Version handshake before we expose protocol streams.
+                // Version handshake before we expose protocol streams. See
+                // the inbound counterpart for the cache-clear rationale.
                 if let Err(err) = run_outbound_handshake(
                     &connection,
                     protocol_version,
@@ -549,6 +554,7 @@ pub fn spawn_outbound_connection(
                     );
                     return;
                 }
+                let _ = event_tx.send(ServiceEvent::ClearPeerIncompatible { peer });
 
                 tracing::debug!(peer = %hex::encode(peer), "outbound handshake completed");
                 if let Err(error) = event_tx.send(ServiceEvent::OutboundConnectionReady {

--- a/crates/net/svc/src/svc/tasks.rs
+++ b/crates/net/svc/src/svc/tasks.rs
@@ -204,6 +204,7 @@ struct IncomingHandshakeCtx {
     reject_tracker: Arc<InboundRejectTracker>,
     protocol_version: u32,
     deployment_version: Option<String>,
+    reduced_circuits: bool,
     _handshake_permit: tokio::sync::OwnedSemaphorePermit,
 }
 
@@ -238,6 +239,7 @@ pub fn spawn_accept_loop(
     event_tx: UnboundedSender<ServiceEvent>,
     protocol_version: u32,
     deployment_version: Option<String>,
+    reduced_circuits: bool,
 ) {
     tokio::spawn(
         async move {
@@ -310,6 +312,7 @@ pub fn spawn_accept_loop(
                         reject_tracker: reject_tracker.clone(),
                         protocol_version,
                         deployment_version: deployment_version.clone(),
+                        reduced_circuits,
                         _handshake_permit: permit,
                     },
                 );
@@ -339,6 +342,7 @@ fn spawn_incoming_connection_handler(incoming: quinn::Incoming, ctx: IncomingHan
                 reject_tracker,
                 protocol_version,
                 deployment_version,
+                reduced_circuits,
                 _handshake_permit,
             } = ctx;
 
@@ -422,9 +426,13 @@ fn spawn_incoming_connection_handler(incoming: quinn::Incoming, ctx: IncomingHan
             // versions). On success we proactively clear them from the
             // cache so an upgraded peer who reconnects to us also unblocks
             // our outbound reconnect logic.
-            if let Err(err) =
-                run_inbound_handshake(&connection, protocol_version, deployment_version.as_deref())
-                    .await
+            if let Err(err) = run_inbound_handshake(
+                &connection,
+                protocol_version,
+                deployment_version.as_deref(),
+                reduced_circuits,
+            )
+            .await
             {
                 handle_version_handshake_failure(
                     "incoming",
@@ -488,6 +496,7 @@ pub fn spawn_outbound_connection(
     event_tx: UnboundedSender<ServiceEvent>,
     protocol_version: u32,
     deployment_version: Option<String>,
+    reduced_circuits: bool,
 ) {
     tokio::spawn(async move {
         tracing::debug!(peer = %hex::encode(peer), addr = %addr, "attempting outbound connection");
@@ -537,6 +546,7 @@ pub fn spawn_outbound_connection(
                     &connection,
                     protocol_version,
                     deployment_version.as_deref(),
+                    reduced_circuits,
                 )
                 .await
                 {

--- a/crates/net/svc/src/svc/tasks.rs
+++ b/crates/net/svc/src/svc/tasks.rs
@@ -31,12 +31,13 @@ use super::{
         OutboundAttempt, OverlapKey, PROTOCOL_FIRST_PAYLOAD_TIMEOUT, ServiceEvent,
     },
     stream,
+    version_handshake::{HandshakeError, run_inbound_handshake, run_outbound_handshake},
 };
 use crate::{
     api::{InboundProtocolStream, OpenStreamError, Stream},
     close_codes::{
         CLOSE_INVALID_OVERLAP_KEY, CLOSE_INVALID_PEER_ID_INCOMING, CLOSE_INVALID_PEER_ID_OUTBOUND,
-        CLOSE_PEER_ID_MISMATCH, CLOSE_UNKNOWN_PEER,
+        CLOSE_PEER_ID_MISMATCH, CLOSE_UNKNOWN_PEER, CLOSE_VERSION_HANDSHAKE_FAILED,
     },
     svc::state::{STREAM_HEADER_WRITE_TIMEOUT, STREAM_OPEN_TIMEOUT},
     tls::PeerId,
@@ -62,6 +63,39 @@ const INBOUND_REJECT_MAX_TRACKED_IPS: usize = 8192;
 const OVERLAP_SERVER_NAME_PREFIX: &str = "ovk-";
 /// Suffix used for overlap-key metadata encoded in TLS server_name.
 const OVERLAP_SERVER_NAME_SUFFIX: &str = ".mosaic";
+
+/// Common path for both inbound and outbound version-handshake failure.
+///
+/// - Logs at ERROR with peer, direction, and reason.
+/// - Closes the QUIC connection with [`CLOSE_VERSION_HANDSHAKE_FAILED`].
+/// - Sends [`ServiceEvent::MarkPeerIncompatible`] so the service loop suppresses future reconnect
+///   attempts to this peer.
+/// - Optionally emits the per-direction reject/failed event so the existing bookkeeping
+///   (reject_tracker, candidate cleanup) runs.
+fn handle_version_handshake_failure(
+    direction: &'static str,
+    peer: PeerId,
+    err: &HandshakeError,
+    connection: &quinn::Connection,
+    event_tx: &UnboundedSender<ServiceEvent>,
+    direction_specific: Option<ServiceEvent>,
+) {
+    let reason = err.reason();
+    tracing::error!(
+        peer = %hex::encode(peer),
+        direction,
+        reason = %reason,
+        "version handshake failed; peer is incompatible until restart"
+    );
+    connection.close(CLOSE_VERSION_HANDSHAKE_FAILED, reason.as_bytes());
+    let _ = event_tx.send(ServiceEvent::MarkPeerIncompatible {
+        peer,
+        reason: reason.clone(),
+    });
+    if let Some(evt) = direction_specific {
+        let _ = event_tx.send(evt);
+    }
+}
 
 fn overlap_server_name(overlap_key: OverlapKey) -> String {
     format!(
@@ -168,6 +202,8 @@ struct IncomingHandshakeCtx {
     allowed_peers: Arc<HashSet<PeerId>>,
     event_tx: UnboundedSender<ServiceEvent>,
     reject_tracker: Arc<InboundRejectTracker>,
+    protocol_version: u32,
+    deployment_version: Option<String>,
     _handshake_permit: tokio::sync::OwnedSemaphorePermit,
 }
 
@@ -192,6 +228,7 @@ pub(super) fn normalize_socket_addr(addr: SocketAddr) -> SocketAddr {
 ///
 /// Each accepted connection is handed to a separate handshake task with an
 /// `accepted_at` timestamp captured at accept time.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_accept_loop(
     endpoint: Endpoint,
     allowed_peers: Arc<HashSet<PeerId>>,
@@ -199,6 +236,8 @@ pub fn spawn_accept_loop(
     peer_by_port: Arc<HashMap<u16, PeerId>>,
     peer_by_ip: Arc<HashMap<IpAddr, PeerId>>,
     event_tx: UnboundedSender<ServiceEvent>,
+    protocol_version: u32,
+    deployment_version: Option<String>,
 ) {
     tokio::spawn(
         async move {
@@ -269,6 +308,8 @@ pub fn spawn_accept_loop(
                         allowed_peers: allowed_peers.clone(),
                         event_tx: event_tx.clone(),
                         reject_tracker: reject_tracker.clone(),
+                        protocol_version,
+                        deployment_version: deployment_version.clone(),
                         _handshake_permit: permit,
                     },
                 );
@@ -296,6 +337,8 @@ fn spawn_incoming_connection_handler(incoming: quinn::Incoming, ctx: IncomingHan
                 allowed_peers,
                 event_tx,
                 reject_tracker,
+                protocol_version,
+                deployment_version,
                 _handshake_permit,
             } = ctx;
 
@@ -372,6 +415,30 @@ fn spawn_incoming_connection_handler(incoming: quinn::Incoming, ctx: IncomingHan
                 }
             };
 
+            // Version handshake: refuse before exposing protocol streams.
+            // On mismatch we mark this peer incompatible via the service event
+            // loop so future outbound reconnect attempts to it are suppressed
+            // until process restart.
+            if let Err(err) =
+                run_inbound_handshake(&connection, protocol_version, deployment_version.as_deref())
+                    .await
+            {
+                handle_version_handshake_failure(
+                    "incoming",
+                    peer_id,
+                    &err,
+                    &connection,
+                    &event_tx,
+                    Some(ServiceEvent::IncomingConnectionRejected {
+                        peer_guess: predicted_peer,
+                        peer_auth_opt: Some(peer_id),
+                        candidate_id,
+                        reason: format!("version handshake failed: {}", err.reason()),
+                    }),
+                );
+                return;
+            }
+
             let peer_guess = predicted_peer.unwrap_or(peer_id);
             if event_tx
                 .send(ServiceEvent::IncomingConnectionAccepted {
@@ -407,6 +474,7 @@ fn spawn_incoming_connection_handler(incoming: quinn::Incoming, ctx: IncomingHan
 ///
 /// This attempts to connect to a peer with a timeout and sends the result
 /// back via the event channel.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_outbound_connection(
     endpoint: Endpoint,
     client_config: quinn::ClientConfig,
@@ -414,6 +482,8 @@ pub fn spawn_outbound_connection(
     attempt: OutboundAttempt,
     addr: std::net::SocketAddr,
     event_tx: UnboundedSender<ServiceEvent>,
+    protocol_version: u32,
+    deployment_version: Option<String>,
 ) {
     tokio::spawn(async move {
         tracing::debug!(peer = %hex::encode(peer), addr = %addr, "attempting outbound connection");
@@ -454,6 +524,29 @@ pub fn spawn_outbound_connection(
                         attempt_id: attempt.attempt_id,
                         error: "peer id mismatch".to_string(),
                     });
+                    return;
+                }
+
+                // Version handshake before we expose protocol streams.
+                if let Err(err) = run_outbound_handshake(
+                    &connection,
+                    protocol_version,
+                    deployment_version.as_deref(),
+                )
+                .await
+                {
+                    handle_version_handshake_failure(
+                        "outbound",
+                        peer,
+                        &err,
+                        &connection,
+                        &event_tx,
+                        Some(ServiceEvent::OutboundConnectionFailed {
+                            peer,
+                            attempt_id: attempt.attempt_id,
+                            error: format!("version handshake failed: {}", err.reason()),
+                        }),
+                    );
                     return;
                 }
 

--- a/crates/net/svc/src/svc/version_handshake.rs
+++ b/crates/net/svc/src/svc/version_handshake.rs
@@ -1,0 +1,181 @@
+//! Version-handshake exchange over a QUIC bi-stream.
+//!
+//! See [`mosaic_net_svc_api::handshake`] for the payload shape and validation
+//! rules. This module owns the on-the-wire framing and the timeout/timing
+//! around the exchange itself.
+
+use std::time::Duration;
+
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
+use mosaic_net_svc_api::handshake::{
+    HandshakeMismatch, HandshakePayload, MAX_HANDSHAKE_PAYLOAD_BYTES, validate_handshake,
+};
+use quinn::Connection;
+
+/// Maximum time the handshake exchange may take, end-to-end (stream open +
+/// send + receive). Generous to absorb scheduling jitter; this is local LAN
+/// traffic for a tiny payload.
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Result of an attempted handshake exchange.
+#[derive(Debug)]
+pub enum HandshakeError {
+    /// The remote payload was a valid `HandshakePayload` but did not match
+    /// our local config (protocol-version, deployment-version, magic).
+    Mismatch(HandshakeMismatch),
+    /// Timed out waiting for the stream to open / payload to arrive.
+    Timeout,
+    /// Stream open / write / read transport error.
+    Transport(String),
+    /// Remote claimed a payload size larger than [`MAX_HANDSHAKE_PAYLOAD_BYTES`].
+    PayloadTooLarge { len: usize },
+    /// `ark-serialize` could not decode the payload bytes.
+    Decode(String),
+}
+
+impl HandshakeError {
+    /// Short, log-safe reason string.
+    pub fn reason(&self) -> String {
+        match self {
+            Self::Mismatch(m) => m.reason().to_string(),
+            Self::Timeout => "handshake timed out".to_string(),
+            Self::Transport(e) => format!("transport error: {e}"),
+            Self::PayloadTooLarge { len } => format!("payload too large: {len} bytes"),
+            Self::Decode(e) => format!("decode error: {e}"),
+        }
+    }
+}
+
+impl std::fmt::Display for HandshakeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mismatch(m) => write!(f, "{m}"),
+            other => write!(f, "{}", other.reason()),
+        }
+    }
+}
+
+impl std::error::Error for HandshakeError {}
+
+/// Outbound side: open a bi-stream, send our payload, read the peer's payload,
+/// validate. Returns the validated remote payload on success.
+pub async fn run_outbound_handshake(
+    connection: &Connection,
+    local_protocol_version: u32,
+    local_deployment_version: Option<&str>,
+) -> Result<HandshakePayload, HandshakeError> {
+    let local = HandshakePayload {
+        magic: mosaic_net_svc_api::handshake::HANDSHAKE_MAGIC,
+        protocol_version: local_protocol_version,
+        deployment_version: local_deployment_version.map(str::to_string),
+    };
+
+    let stream_result = tokio::time::timeout(HANDSHAKE_TIMEOUT, connection.open_bi()).await;
+    let (send, recv) = match stream_result {
+        Ok(Ok((send, recv))) => (send, recv),
+        Ok(Err(e)) => return Err(HandshakeError::Transport(e.to_string())),
+        Err(_) => return Err(HandshakeError::Timeout),
+    };
+
+    exchange(
+        send,
+        recv,
+        &local,
+        local_protocol_version,
+        local_deployment_version,
+    )
+    .await
+}
+
+/// Inbound side: accept a bi-stream, read the peer's payload, send our payload,
+/// validate. Returns the validated remote payload on success.
+pub async fn run_inbound_handshake(
+    connection: &Connection,
+    local_protocol_version: u32,
+    local_deployment_version: Option<&str>,
+) -> Result<HandshakePayload, HandshakeError> {
+    let local = HandshakePayload {
+        magic: mosaic_net_svc_api::handshake::HANDSHAKE_MAGIC,
+        protocol_version: local_protocol_version,
+        deployment_version: local_deployment_version.map(str::to_string),
+    };
+
+    let stream_result = tokio::time::timeout(HANDSHAKE_TIMEOUT, connection.accept_bi()).await;
+    let (send, recv) = match stream_result {
+        Ok(Ok((send, recv))) => (send, recv),
+        Ok(Err(e)) => return Err(HandshakeError::Transport(e.to_string())),
+        Err(_) => return Err(HandshakeError::Timeout),
+    };
+
+    exchange(
+        send,
+        recv,
+        &local,
+        local_protocol_version,
+        local_deployment_version,
+    )
+    .await
+}
+
+/// Symmetric exchange: write our payload, read theirs, validate. Both halves
+/// run concurrently so a slow peer on one direction doesn't extend wall-clock
+/// past the timeout.
+async fn exchange(
+    mut send: quinn::SendStream,
+    mut recv: quinn::RecvStream,
+    local: &HandshakePayload,
+    local_protocol_version: u32,
+    local_deployment_version: Option<&str>,
+) -> Result<HandshakePayload, HandshakeError> {
+    let mut bytes = Vec::new();
+    local
+        .serialize_with_mode(&mut bytes, Compress::No)
+        .map_err(|e| HandshakeError::Decode(e.to_string()))?;
+    if bytes.len() > MAX_HANDSHAKE_PAYLOAD_BYTES {
+        return Err(HandshakeError::PayloadTooLarge { len: bytes.len() });
+    }
+    let len = bytes.len() as u32;
+
+    let send_fut = async {
+        send.write_all(&len.to_le_bytes())
+            .await
+            .map_err(|e| HandshakeError::Transport(format!("write len: {e}")))?;
+        send.write_all(&bytes)
+            .await
+            .map_err(|e| HandshakeError::Transport(format!("write payload: {e}")))?;
+        send.finish()
+            .map_err(|e| HandshakeError::Transport(format!("finish: {e}")))?;
+        Ok::<(), HandshakeError>(())
+    };
+
+    let recv_fut = async {
+        let mut len_buf = [0u8; 4];
+        recv.read_exact(&mut len_buf)
+            .await
+            .map_err(|e| HandshakeError::Transport(format!("read len: {e}")))?;
+        let remote_len = u32::from_le_bytes(len_buf) as usize;
+        if remote_len > MAX_HANDSHAKE_PAYLOAD_BYTES {
+            return Err(HandshakeError::PayloadTooLarge { len: remote_len });
+        }
+        let mut buf = vec![0u8; remote_len];
+        recv.read_exact(&mut buf)
+            .await
+            .map_err(|e| HandshakeError::Transport(format!("read payload: {e}")))?;
+        HandshakePayload::deserialize_with_mode(buf.as_slice(), Compress::No, Validate::Yes)
+            .map_err(|e| HandshakeError::Decode(e.to_string()))
+    };
+
+    let join = tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
+        tokio::try_join!(send_fut, recv_fut)
+    })
+    .await;
+    let (_, remote) = match join {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => return Err(e),
+        Err(_) => return Err(HandshakeError::Timeout),
+    };
+
+    validate_handshake(local_protocol_version, local_deployment_version, &remote)
+        .map_err(HandshakeError::Mismatch)?;
+    Ok(remote)
+}

--- a/crates/net/svc/src/svc/version_handshake.rs
+++ b/crates/net/svc/src/svc/version_handshake.rs
@@ -63,11 +63,13 @@ pub async fn run_outbound_handshake(
     connection: &Connection,
     local_protocol_version: u32,
     local_deployment_version: Option<&str>,
+    local_reduced_circuits: bool,
 ) -> Result<HandshakePayload, HandshakeError> {
     let local = HandshakePayload {
         magic: mosaic_net_svc_api::handshake::HANDSHAKE_MAGIC,
         protocol_version: local_protocol_version,
         deployment_version: local_deployment_version.map(str::to_string),
+        reduced_circuits: local_reduced_circuits,
     };
 
     let stream_result = tokio::time::timeout(HANDSHAKE_TIMEOUT, connection.open_bi()).await;
@@ -83,6 +85,7 @@ pub async fn run_outbound_handshake(
         &local,
         local_protocol_version,
         local_deployment_version,
+        local_reduced_circuits,
     )
     .await
 }
@@ -93,11 +96,13 @@ pub async fn run_inbound_handshake(
     connection: &Connection,
     local_protocol_version: u32,
     local_deployment_version: Option<&str>,
+    local_reduced_circuits: bool,
 ) -> Result<HandshakePayload, HandshakeError> {
     let local = HandshakePayload {
         magic: mosaic_net_svc_api::handshake::HANDSHAKE_MAGIC,
         protocol_version: local_protocol_version,
         deployment_version: local_deployment_version.map(str::to_string),
+        reduced_circuits: local_reduced_circuits,
     };
 
     let stream_result = tokio::time::timeout(HANDSHAKE_TIMEOUT, connection.accept_bi()).await;
@@ -113,6 +118,7 @@ pub async fn run_inbound_handshake(
         &local,
         local_protocol_version,
         local_deployment_version,
+        local_reduced_circuits,
     )
     .await
 }
@@ -120,12 +126,14 @@ pub async fn run_inbound_handshake(
 /// Symmetric exchange: write our payload, read theirs, validate. Both halves
 /// run concurrently so a slow peer on one direction doesn't extend wall-clock
 /// past the timeout.
+#[allow(clippy::too_many_arguments)]
 async fn exchange(
     mut send: quinn::SendStream,
     mut recv: quinn::RecvStream,
     local: &HandshakePayload,
     local_protocol_version: u32,
     local_deployment_version: Option<&str>,
+    local_reduced_circuits: bool,
 ) -> Result<HandshakePayload, HandshakeError> {
     let mut bytes = Vec::new();
     local
@@ -175,7 +183,12 @@ async fn exchange(
         Err(_) => return Err(HandshakeError::Timeout),
     };
 
-    validate_handshake(local_protocol_version, local_deployment_version, &remote)
-        .map_err(HandshakeError::Mismatch)?;
+    validate_handshake(
+        local_protocol_version,
+        local_deployment_version,
+        local_reduced_circuits,
+        &remote,
+    )
+    .map_err(HandshakeError::Mismatch)?;
     Ok(remote)
 }

--- a/crates/net/svc/tests/integration.rs
+++ b/crates/net/svc/tests/integration.rs
@@ -1199,3 +1199,131 @@ fn version_handshake_no_deployment_either_side_allows_stream_open() {
     peer_a.shutdown();
     peer_b.shutdown();
 }
+
+#[test]
+fn version_handshake_incompatible_cache_clears_on_upgraded_reconnect() {
+    // Scenario: A and B start with mismatched protocol versions. A's
+    // outbound to B fails the handshake; A adds B to incompatible_peers.
+    // B is then "upgraded" (restarted with matching protocol version on the
+    // same signing key and the same port). B dials A — inbound handshake
+    // succeeds — and the cache clears, so subsequent traffic flows normally.
+    init_tracing();
+
+    for attempt in 0..50 {
+        let port_a = next_port();
+        let port_b = next_port();
+
+        let key_a = test_key_from_tag(next_key_tag());
+        let key_b = test_key_from_tag(next_key_tag());
+
+        let peer_id_a = peer_id_from_signing_key(&key_a);
+        let peer_id_b = peer_id_from_signing_key(&key_b);
+
+        let addr_a = test_addr(port_a);
+        let addr_b = test_addr(port_b);
+
+        let local_pv = mosaic_net_svc_api::handshake::PROTOCOL_VERSION;
+
+        let config_a = NetServiceConfig::new(
+            key_a.clone(),
+            addr_a,
+            vec![PeerConfig::new(peer_id_b, addr_b)],
+        )
+        .with_reconnect_backoff(Duration::from_millis(50))
+        .with_protocol_version(local_pv);
+
+        let config_b_v1 = NetServiceConfig::new(
+            key_b.clone(),
+            addr_b,
+            vec![PeerConfig::new(peer_id_a, addr_a)],
+        )
+        .with_reconnect_backoff(Duration::from_millis(50))
+        .with_protocol_version(local_pv.wrapping_add(1)); // mismatched
+
+        let (handle_a, ctrl_a) = match NetService::new(config_a) {
+            Ok(r) => r,
+            Err(_) if attempt < 49 => continue,
+            Err(e) => panic!("create A: {}", e),
+        };
+        let (_handle_b_v1, ctrl_b_v1) = match NetService::new(config_b_v1) {
+            Ok(r) => r,
+            Err(_) if attempt < 49 => {
+                let _ = shutdown_controller_with_timeout(ctrl_a, Duration::from_secs(2));
+                continue;
+            }
+            Err(e) => panic!("create B v1: {}", e),
+        };
+
+        let peer_a = TestPeer {
+            handle: handle_a,
+            controller: ctrl_a,
+            peer_id: peer_id_a,
+        };
+
+        run_async(async {
+            // Phase 1 — confirm the mismatch path: A→B fails to open a stream.
+            let result = tokio::time::timeout(
+                MISMATCH_OBSERVATION_WINDOW,
+                peer_a.handle.open_protocol_stream(peer_id_b, 0),
+            )
+            .await;
+            assert!(
+                !matches!(result, Ok(Ok(_))),
+                "stream-open should be blocked by initial version mismatch"
+            );
+        });
+
+        // Phase 2 — "upgrade" B: shut it down and bring it back up on the
+        // same key + port with the matching protocol version.
+        let _ = shutdown_controller_with_timeout(ctrl_b_v1, Duration::from_secs(2));
+
+        // QUIC/UDP socket sometimes needs a moment to release the port after
+        // shutdown; retry the rebind a few times to absorb scheduling jitter.
+        let build_config_b_v2 = || {
+            NetServiceConfig::new(
+                key_b.clone(),
+                addr_b,
+                vec![PeerConfig::new(peer_id_a, addr_a)],
+            )
+            .with_reconnect_backoff(Duration::from_millis(50))
+            .with_protocol_version(local_pv) // matching
+        };
+        let mut handle_ctrl = None;
+        for _ in 0..40 {
+            match NetService::new(build_config_b_v2()) {
+                Ok(hc) => {
+                    handle_ctrl = Some(hc);
+                    break;
+                }
+                Err(_) => std::thread::sleep(Duration::from_millis(50)),
+            }
+        }
+        let (handle_b_v2, ctrl_b_v2) = handle_ctrl.expect("rebind B v2 on the same port");
+        let peer_b = TestPeer {
+            handle: handle_b_v2,
+            controller: ctrl_b_v2,
+            peer_id: peer_id_b,
+        };
+
+        run_async(async {
+            // After B reconnects with matching versions, a stream should
+            // open in either direction. Going B→A here exercises the
+            // inbound-handshake-clears-cache path explicitly (A had B
+            // marked incompatible at this point).
+            let (_outbound, inbound) =
+                open_stream_pair_eventually(&peer_b, &peer_a, b"recovered").await;
+            assert_eq!(inbound.payload(), Some(&b"recovered"[..]));
+
+            // And after the cache is cleared, A→B works too (i.e. A's
+            // outbound logic is no longer suppressed).
+            let (_outbound, inbound) =
+                open_stream_pair_eventually(&peer_a, &peer_b, b"a-can-dial-too").await;
+            assert_eq!(inbound.payload(), Some(&b"a-can-dial-too"[..]));
+        });
+
+        peer_a.shutdown();
+        peer_b.shutdown();
+        return;
+    }
+    unreachable!()
+}

--- a/crates/net/svc/tests/integration.rs
+++ b/crates/net/svc/tests/integration.rs
@@ -1009,6 +1009,25 @@ fn create_peer_pair_with_versions(
     b_protocol_version: u32,
     b_deployment_version: Option<String>,
 ) -> (TestPeer, TestPeer) {
+    create_peer_pair_with_versions_full(
+        a_protocol_version,
+        a_deployment_version,
+        false,
+        b_protocol_version,
+        b_deployment_version,
+        false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn create_peer_pair_with_versions_full(
+    a_protocol_version: u32,
+    a_deployment_version: Option<String>,
+    a_reduced_circuits: bool,
+    b_protocol_version: u32,
+    b_deployment_version: Option<String>,
+    b_reduced_circuits: bool,
+) -> (TestPeer, TestPeer) {
     init_tracing();
     for attempt in 0..50 {
         let port_a = next_port();
@@ -1028,14 +1047,16 @@ fn create_peer_pair_with_versions(
                 .with_reconnect_backoff(Duration::from_millis(50))
                 .with_protocol_version(a_protocol_version)
                 .with_deployment_version(a_deployment_version.clone())
-                .expect("valid deployment version");
+                .expect("valid deployment version")
+                .with_reduced_circuits(a_reduced_circuits);
 
         let config_b =
             NetServiceConfig::new(key_b, addr_b, vec![PeerConfig::new(peer_id_a, addr_a)])
                 .with_reconnect_backoff(Duration::from_millis(50))
                 .with_protocol_version(b_protocol_version)
                 .with_deployment_version(b_deployment_version.clone())
-                .expect("valid deployment version");
+                .expect("valid deployment version")
+                .with_reduced_circuits(b_reduced_circuits);
 
         let (handle_a, ctrl_a) = match NetService::new(config_a) {
             Ok(r) => r,
@@ -1173,6 +1194,59 @@ fn version_handshake_deployment_asymmetry_blocks_stream_open() {
                 panic!("expected stream-open to be blocked by deployment-version asymmetry")
             }
         }
+    });
+
+    peer_a.shutdown();
+    peer_b.shutdown();
+}
+
+#[test]
+fn version_handshake_reduced_circuits_mismatch_blocks_stream_open() {
+    // A runs full circuits, B runs reduced circuits. Hard incompatibility:
+    // the circuit shapes diverge, so no protocol streams may open.
+    let (peer_a, peer_b) = create_peer_pair_with_versions_full(
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        None,
+        false,
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        None,
+        true,
+    );
+
+    run_async(async {
+        let result = tokio::time::timeout(
+            MISMATCH_OBSERVATION_WINDOW,
+            peer_a.handle.open_protocol_stream(peer_b.peer_id, 0),
+        )
+        .await;
+        match result {
+            Err(_) | Ok(Err(_)) => {}
+            Ok(Ok(_)) => {
+                panic!("expected stream-open to be blocked by reduced-circuits mismatch")
+            }
+        }
+    });
+
+    peer_a.shutdown();
+    peer_b.shutdown();
+}
+
+#[test]
+fn version_handshake_reduced_circuits_both_sides_allows_stream_open() {
+    // Both sides run reduced circuits — handshake succeeds.
+    let (peer_a, peer_b) = create_peer_pair_with_versions_full(
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        None,
+        true,
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        None,
+        true,
+    );
+
+    run_async(async {
+        let (_outbound, inbound) =
+            open_stream_pair_eventually(&peer_a, &peer_b, b"reduced-both").await;
+        assert_eq!(inbound.payload(), Some(&b"reduced-both"[..]));
     });
 
     peer_a.shutdown();

--- a/crates/net/svc/tests/integration.rs
+++ b/crates/net/svc/tests/integration.rs
@@ -991,3 +991,211 @@ fn test_large_payload() {
     peer_a.shutdown();
     peer_b.shutdown();
 }
+
+// ============================================================================
+// Version handshake (issue #265)
+// ============================================================================
+//
+// These tests exercise the post-TLS / pre-protocol version handshake. They
+// use the same dual-NetService scaffolding as the rest of the file but vary
+// `protocol_version` and `deployment_version` on each side.
+
+/// Set up a peer pair with explicit version-handshake parameters per side.
+/// Mirrors `create_peer_pair` but returns the controllers and peer ids so
+/// callers can drive the handshake.
+fn create_peer_pair_with_versions(
+    a_protocol_version: u32,
+    a_deployment_version: Option<String>,
+    b_protocol_version: u32,
+    b_deployment_version: Option<String>,
+) -> (TestPeer, TestPeer) {
+    init_tracing();
+    for attempt in 0..50 {
+        let port_a = next_port();
+        let port_b = next_port();
+
+        let key_a = test_key_from_tag(next_key_tag());
+        let key_b = test_key_from_tag(next_key_tag());
+
+        let peer_id_a = peer_id_from_signing_key(&key_a);
+        let peer_id_b = peer_id_from_signing_key(&key_b);
+
+        let addr_a = test_addr(port_a);
+        let addr_b = test_addr(port_b);
+
+        let config_a =
+            NetServiceConfig::new(key_a, addr_a, vec![PeerConfig::new(peer_id_b, addr_b)])
+                .with_reconnect_backoff(Duration::from_millis(50))
+                .with_protocol_version(a_protocol_version)
+                .with_deployment_version(a_deployment_version.clone())
+                .expect("valid deployment version");
+
+        let config_b =
+            NetServiceConfig::new(key_b, addr_b, vec![PeerConfig::new(peer_id_a, addr_a)])
+                .with_reconnect_backoff(Duration::from_millis(50))
+                .with_protocol_version(b_protocol_version)
+                .with_deployment_version(b_deployment_version.clone())
+                .expect("valid deployment version");
+
+        let (handle_a, ctrl_a) = match NetService::new(config_a) {
+            Ok(r) => r,
+            Err(_) if attempt < 49 => continue,
+            Err(e) => panic!("create net service A: {}", e),
+        };
+        let (handle_b, ctrl_b) = match NetService::new(config_b) {
+            Ok(r) => r,
+            Err(_) if attempt < 49 => {
+                let _ = shutdown_controller_with_timeout(ctrl_a, Duration::from_secs(2));
+                continue;
+            }
+            Err(e) => panic!("create net service B: {}", e),
+        };
+
+        return (
+            TestPeer {
+                handle: handle_a,
+                controller: ctrl_a,
+                peer_id: peer_id_a,
+            },
+            TestPeer {
+                handle: handle_b,
+                controller: ctrl_b,
+                peer_id: peer_id_b,
+            },
+        );
+    }
+    unreachable!()
+}
+
+/// Tight per-operation timeout used by the mismatch tests so a "no connection
+/// will ever succeed" outcome surfaces in seconds rather than the full
+/// `CI_TIMEOUT`.
+const MISMATCH_OBSERVATION_WINDOW: Duration = Duration::from_secs(3);
+
+#[test]
+fn version_handshake_matching_versions_allows_stream_open() {
+    let (peer_a, peer_b) = create_peer_pair_with_versions(
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        Some("tn3".to_string()),
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        Some("tn3".to_string()),
+    );
+
+    run_async(async {
+        let (_outbound, inbound) =
+            open_stream_pair_eventually(&peer_a, &peer_b, b"hello-versioned").await;
+        assert_eq!(inbound.payload(), Some(&b"hello-versioned"[..]));
+    });
+
+    peer_a.shutdown();
+    peer_b.shutdown();
+}
+
+#[test]
+fn version_handshake_protocol_mismatch_blocks_stream_open() {
+    // A advertises v=1, B advertises v=2. No protocol streams should ever
+    // open in either direction.
+    let (peer_a, peer_b) = create_peer_pair_with_versions(
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        None,
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION.wrapping_add(1),
+        None,
+    );
+
+    run_async(async {
+        let result = tokio::time::timeout(
+            MISMATCH_OBSERVATION_WINDOW,
+            peer_a.handle.open_protocol_stream(peer_b.peer_id, 0),
+        )
+        .await;
+        // We either get a timeout (no connection ever established) or an Err
+        // (incompatible-peer suppression took effect). Both confirm the
+        // handshake gate.
+        match result {
+            Err(_elapsed) => {}      // timeout: no stream opened
+            Ok(Err(_open_err)) => {} // open rejected
+            Ok(Ok(_)) => panic!("expected stream-open to be blocked by protocol-version mismatch"),
+        }
+    });
+
+    peer_a.shutdown();
+    peer_b.shutdown();
+}
+
+#[test]
+fn version_handshake_deployment_mismatch_blocks_stream_open() {
+    let (peer_a, peer_b) = create_peer_pair_with_versions(
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        Some("tn3".to_string()),
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        Some("tn4".to_string()),
+    );
+
+    run_async(async {
+        let result = tokio::time::timeout(
+            MISMATCH_OBSERVATION_WINDOW,
+            peer_a.handle.open_protocol_stream(peer_b.peer_id, 0),
+        )
+        .await;
+        match result {
+            Err(_) | Ok(Err(_)) => {}
+            Ok(Ok(_)) => {
+                panic!("expected stream-open to be blocked by deployment-version mismatch")
+            }
+        }
+    });
+
+    peer_a.shutdown();
+    peer_b.shutdown();
+}
+
+#[test]
+fn version_handshake_deployment_asymmetry_blocks_stream_open() {
+    // One side has a deployment version, the other doesn't. Per spec this is
+    // a refusal — otherwise an unconfigured node could silently bypass
+    // cohort coordination.
+    let (peer_a, peer_b) = create_peer_pair_with_versions(
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        Some("tn3".to_string()),
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        None,
+    );
+
+    run_async(async {
+        let result = tokio::time::timeout(
+            MISMATCH_OBSERVATION_WINDOW,
+            peer_a.handle.open_protocol_stream(peer_b.peer_id, 0),
+        )
+        .await;
+        match result {
+            Err(_) | Ok(Err(_)) => {}
+            Ok(Ok(_)) => {
+                panic!("expected stream-open to be blocked by deployment-version asymmetry")
+            }
+        }
+    });
+
+    peer_a.shutdown();
+    peer_b.shutdown();
+}
+
+#[test]
+fn version_handshake_no_deployment_either_side_allows_stream_open() {
+    // Single-operator / local-dev path: neither side sets a deployment
+    // version; protocol versions match. Handshake succeeds.
+    let (peer_a, peer_b) = create_peer_pair_with_versions(
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        None,
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        None,
+    );
+
+    run_async(async {
+        let (_outbound, inbound) =
+            open_stream_pair_eventually(&peer_a, &peer_b, b"no-deployment").await;
+        assert_eq!(inbound.payload(), Some(&b"no-deployment"[..]));
+    });
+
+    peer_a.shutdown();
+    peer_b.shutdown();
+}

--- a/crates/rpc/api/src/traits.rs
+++ b/crates/rpc/api/src/traits.rs
@@ -27,6 +27,13 @@ pub trait MosaicRpc {
     #[method(name = "getRpcPeerId")]
     fn get_peer_id(&self) -> RpcResult<RpcPeerId>;
 
+    /// Identity / version information about this node — the protocol version
+    /// and deployment-cohort string exchanged in the peer version handshake.
+    /// Operators use this to verify build and cohort compatibility between
+    /// peers without log-diving.
+    #[method(name = "nodeInfo")]
+    fn node_info(&self) -> RpcResult<RpcNodeInfo>;
+
     /// Helper to get deterministic [`RpcTablesetId`].
     #[method(name = "getRpcTablesetId")]
     fn get_tableset_id(

--- a/crates/rpc/server/Cargo.toml
+++ b/crates/rpc/server/Cargo.toml
@@ -19,6 +19,7 @@ mosaic-rpc-service.workspace = true
 mosaic-rpc-types.workspace = true
 
 bitcoin.workspace = true
+hex = "0.4"
 jsonrpsee = { workspace = true, features = ["server-core"] }
 
 [lints]

--- a/crates/rpc/server/src/conversions.rs
+++ b/crates/rpc/server/src/conversions.rs
@@ -2,7 +2,9 @@
 
 use mosaic_cac_types::state_machine::Role;
 use mosaic_rpc_service::ServiceError;
-use mosaic_rpc_types::{CacRole, DepositStatus, RpcDepositId, RpcError, RpcTablesetStatus};
+use mosaic_rpc_types::{
+    CacRole, DepositStatus, RpcDepositId, RpcError, RpcNodeInfo, RpcTablesetStatus,
+};
 
 /// Converts [`CacRole`] to the domain [`Role`].
 pub(crate) fn cac_role_to_domain(role: CacRole) -> Role {
@@ -54,6 +56,15 @@ pub(crate) fn tableset_status_to_rpc(
         mosaic_rpc_service::TablesetStatus::Aborted { reason } => {
             RpcTablesetStatus::Aborted { reason }
         }
+    }
+}
+
+/// Converts a service [`mosaic_rpc_service::NodeInfo`] to wire [`RpcNodeInfo`].
+pub(crate) fn node_info_to_rpc(info: mosaic_rpc_service::NodeInfo) -> RpcNodeInfo {
+    RpcNodeInfo {
+        peer_id_hex: hex::encode(info.peer_id),
+        protocol_version: info.protocol_version,
+        deployment_version: info.deployment_version,
     }
 }
 

--- a/crates/rpc/server/src/conversions.rs
+++ b/crates/rpc/server/src/conversions.rs
@@ -65,6 +65,7 @@ pub(crate) fn node_info_to_rpc(info: mosaic_rpc_service::NodeInfo) -> RpcNodeInf
         peer_id_hex: hex::encode(info.peer_id),
         protocol_version: info.protocol_version,
         deployment_version: info.deployment_version,
+        reduced_circuits: info.reduced_circuits,
     }
 }
 

--- a/crates/rpc/server/src/server.rs
+++ b/crates/rpc/server/src/server.rs
@@ -10,7 +10,8 @@ use mosaic_rpc_service::{
 use mosaic_rpc_types::*;
 
 use crate::conversions::{
-    cac_role_to_domain, deposit_status_to_rpc, service_err, tableset_status_to_rpc,
+    cac_role_to_domain, deposit_status_to_rpc, node_info_to_rpc, service_err,
+    tableset_status_to_rpc,
 };
 
 /// Mosaic RPC server impl.
@@ -46,6 +47,10 @@ impl<Svc: MosaicApi> MosaicRpcServer for RpcServerImpl<Svc> {
 
     fn get_peer_id(&self) -> RpcResult<RpcPeerId> {
         Ok(RpcPeerId::new(*self.service.get_peer_id().as_bytes()))
+    }
+
+    fn node_info(&self) -> RpcResult<RpcNodeInfo> {
+        Ok(node_info_to_rpc(self.service.node_info()))
     }
 
     fn get_tableset_id(

--- a/crates/rpc/service/src/default.rs
+++ b/crates/rpc/service/src/default.rs
@@ -27,7 +27,8 @@ use tracing::error;
 
 use crate::{
     DepositStatus, DepositWithStatus, EvaluatorDepositInit, EvaluatorWithdrawalData,
-    GarblerDepositInit, MosaicApi, ServiceError, ServiceResult, SetupConfig, TablesetStatus,
+    GarblerDepositInit, MosaicApi, NodeInfo, ServiceError, ServiceResult, SetupConfig,
+    TablesetStatus,
     crypto_conversions::{
         into_schnorr_signature, try_from_schnorr_signature, try_from_x_only_pubkey,
         try_into_x_only_pubkey,
@@ -46,6 +47,12 @@ pub struct DefaultMosaicApi<S: StorageProvider, R: CryptoRng + Rng + Send> {
     executor_handle: SmExecutorHandle,
     storage: S,
     rng: Mutex<R>,
+    /// Protocol version advertised in the peer version handshake. Exposed via
+    /// [`MosaicApi::node_info`] for operator diagnostics.
+    protocol_version: u32,
+    /// Deployment-cohort identifier advertised in the peer version handshake.
+    /// Exposed via [`MosaicApi::node_info`] for operator diagnostics.
+    deployment_version: Option<String>,
 }
 
 impl<S: StorageProvider, R: CryptoRng + Rng + Send> DefaultMosaicApi<S, R> {
@@ -56,6 +63,8 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send> DefaultMosaicApi<S, R> {
         executor_handle: SmExecutorHandle,
         storage: S,
         rng: R,
+        protocol_version: u32,
+        deployment_version: Option<String>,
     ) -> Self {
         Self {
             own_peer_id,
@@ -63,6 +72,8 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send> DefaultMosaicApi<S, R> {
             executor_handle,
             storage,
             rng: Mutex::new(rng),
+            protocol_version,
+            deployment_version,
         }
     }
 
@@ -96,6 +107,14 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send> DefaultMosaicApi<S, R> {
 impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for DefaultMosaicApi<S, R> {
     fn get_peer_id(&self) -> PeerId {
         self.own_peer_id
+    }
+
+    fn node_info(&self) -> NodeInfo {
+        NodeInfo {
+            peer_id: self.own_peer_id,
+            protocol_version: self.protocol_version,
+            deployment_version: self.deployment_version.clone(),
+        }
     }
 
     fn get_tableset_id(&self, role: Role, peer_id: &PeerId, _instance: &Byte32) -> StateMachineId {

--- a/crates/rpc/service/src/default.rs
+++ b/crates/rpc/service/src/default.rs
@@ -53,10 +53,14 @@ pub struct DefaultMosaicApi<S: StorageProvider, R: CryptoRng + Rng + Send> {
     /// Deployment-cohort identifier advertised in the peer version handshake.
     /// Exposed via [`MosaicApi::node_info`] for operator diagnostics.
     deployment_version: Option<String>,
+    /// Whether this node is running reduced-circuits mode. Hard-matched in the
+    /// peer version handshake. Exposed via [`MosaicApi::node_info`].
+    reduced_circuits: bool,
 }
 
 impl<S: StorageProvider, R: CryptoRng + Rng + Send> DefaultMosaicApi<S, R> {
     /// Creates a new instance.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         own_peer_id: PeerId,
         other_peer_ids: Vec<PeerId>,
@@ -65,6 +69,7 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send> DefaultMosaicApi<S, R> {
         rng: R,
         protocol_version: u32,
         deployment_version: Option<String>,
+        reduced_circuits: bool,
     ) -> Self {
         Self {
             own_peer_id,
@@ -74,6 +79,7 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send> DefaultMosaicApi<S, R> {
             rng: Mutex::new(rng),
             protocol_version,
             deployment_version,
+            reduced_circuits,
         }
     }
 
@@ -114,6 +120,7 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for Defa
             peer_id: self.own_peer_id,
             protocol_version: self.protocol_version,
             deployment_version: self.deployment_version.clone(),
+            reduced_circuits: self.reduced_circuits,
         }
     }
 

--- a/crates/rpc/service/src/tests.rs
+++ b/crates/rpc/service/src/tests.rs
@@ -61,6 +61,7 @@ impl TestHarness {
             rng,
             mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
             None,
+            false,
         );
         Self {
             api,
@@ -1454,6 +1455,7 @@ async fn dispatch_returns_executor_error_when_channel_closed() {
         rng,
         mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
         None,
+        false,
     );
 
     // Setup garbler at SetupComplete with a ready deposit

--- a/crates/rpc/service/src/tests.rs
+++ b/crates/rpc/service/src/tests.rs
@@ -59,6 +59,8 @@ impl TestHarness {
             executor_handle,
             storage.clone(),
             rng,
+            mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+            None,
         );
         Self {
             api,
@@ -1450,6 +1452,8 @@ async fn dispatch_returns_executor_error_when_channel_closed() {
         executor_handle,
         storage.clone(),
         rng,
+        mosaic_net_svc_api::handshake::PROTOCOL_VERSION,
+        None,
     );
 
     // Setup garbler at SetupComplete with a ready deposit

--- a/crates/rpc/service/src/traits.rs
+++ b/crates/rpc/service/src/traits.rs
@@ -11,7 +11,7 @@ use mosaic_net_svc_api::PeerId;
 
 use crate::{
     DepositStatus, DepositWithStatus, EvaluatorDepositInit, EvaluatorWithdrawalData,
-    GarblerDepositInit, ServiceResult, SetupConfig, TablesetStatus,
+    GarblerDepositInit, NodeInfo, ServiceResult, SetupConfig, TablesetStatus,
 };
 
 /// Main programmatic interface for controlling Mosaic.
@@ -22,6 +22,11 @@ use crate::{
 pub trait MosaicApi: Send + Sync + 'static {
     /// Returns this node's peer ID.
     fn get_peer_id(&self) -> PeerId;
+
+    /// Returns identity / version information about this node. Operators
+    /// use this to verify build compatibility and deployment-cohort
+    /// alignment with their peers without log-diving.
+    fn node_info(&self) -> NodeInfo;
 
     /// Computes the deterministic tableset (state machine) ID for a given
     /// role, peer, and instance.

--- a/crates/rpc/service/src/types.rs
+++ b/crates/rpc/service/src/types.rs
@@ -25,6 +25,9 @@ pub struct NodeInfo {
     pub protocol_version: u32,
     /// Deployment-cohort identifier exchanged in the peer version handshake.
     pub deployment_version: Option<String>,
+    /// Whether this node is running reduced-circuits mode. Hard-matched in the
+    /// version handshake.
+    pub reduced_circuits: bool,
 }
 
 /// Status of a tableset (state machine).

--- a/crates/rpc/service/src/types.rs
+++ b/crates/rpc/service/src/types.rs
@@ -15,6 +15,18 @@ use mosaic_cac_types::{
 use mosaic_common::Byte32;
 use mosaic_net_svc_api::PeerId;
 
+/// Identity / version information about a running mosaic node. Returned by
+/// [`crate::MosaicApi::node_info`] for operator diagnostics.
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    /// This node's peer id.
+    pub peer_id: PeerId,
+    /// Protocol version exchanged in the peer version handshake.
+    pub protocol_version: u32,
+    /// Deployment-cohort identifier exchanged in the peer version handshake.
+    pub deployment_version: Option<String>,
+}
+
 /// Status of a tableset (state machine).
 #[derive(Debug, Clone)]
 pub enum TablesetStatus {

--- a/crates/rpc/types/src/lib.rs
+++ b/crates/rpc/types/src/lib.rs
@@ -5,11 +5,13 @@ use serde as _; // needed because of the way the macros work
 mod bytearrays;
 mod circuit;
 mod deposit;
+mod node;
 mod response;
 mod tableset;
 
 pub use bytearrays::*;
 pub use circuit::*;
 pub use deposit::*;
+pub use node::*;
 pub use response::*;
 pub use tableset::*;

--- a/crates/rpc/types/src/node.rs
+++ b/crates/rpc/types/src/node.rs
@@ -1,0 +1,22 @@
+//! Node-level status types returned by the admin RPC.
+
+use serde::{Deserialize, Serialize};
+
+/// Identity / version information about a running mosaic node.
+///
+/// Returned by the `mosaic_nodeInfo` RPC. Operators can use this to verify
+/// that two nodes are on compatible builds and the same deployment cohort
+/// without diving into logs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RpcNodeInfo {
+    /// Hex-encoded Ed25519 peer id of this node.
+    pub peer_id_hex: String,
+    /// Protocol version this node advertises in the peer-to-peer
+    /// version handshake. Same value on both peers is a prerequisite for any
+    /// communication to succeed.
+    pub protocol_version: u32,
+    /// Deployment-cohort identifier exchanged in the handshake. `None` for
+    /// uncoordinated dev nodes; `Some` for coordinated deployments where every
+    /// operator must set the same value (e.g. `"tn3"`).
+    pub deployment_version: Option<String>,
+}

--- a/crates/rpc/types/src/node.rs
+++ b/crates/rpc/types/src/node.rs
@@ -19,4 +19,7 @@ pub struct RpcNodeInfo {
     /// uncoordinated dev nodes; `Some` for coordinated deployments where every
     /// operator must set the same value (e.g. `"tn3"`).
     pub deployment_version: Option<String>,
+    /// Whether this node is running reduced-circuits mode. Hard-matched in the
+    /// version handshake — peers running mismatched modes cannot interop.
+    pub reduced_circuits: bool,
 }

--- a/docs/network.md
+++ b/docs/network.md
@@ -84,10 +84,15 @@ Two fields are checked:
   on every node.
 
 **On mismatch:** the connection is closed with `CLOSE_VERSION_HANDSHAKE_FAILED`
-(code 6), the local peer is marked incompatible for the rest of the process
-lifetime, and the reason is logged at ERROR once per peer. Subsequent reconnect
-attempts to that peer are suppressed — restart the process if the peer is
-upgraded out of the incompatible state.
+(code 6), the peer is added to an in-memory `incompatible_peers` cache, and
+the reason is logged at ERROR once per peer. Outbound reconnect attempts to
+peers in the cache are suppressed to avoid log spam.
+
+**Recovery:** inbound connections always run the handshake regardless of
+cache state — an upgraded peer is free to dial us. A successful handshake
+(inbound or outbound) clears the entry, so once they reconnect with matching
+versions our outbound reconnect logic resumes normally too. The cache is
+also fully cleared on process restart.
 
 **Operator surface:** the `mosaic_nodeInfo` RPC returns the current
 `protocol_version` and `deployment_version` so two operators can compare

--- a/docs/network.md
+++ b/docs/network.md
@@ -70,7 +70,7 @@ After QUIC TLS authentication and the overlap-key check, both sides exchange a
 short version-handshake payload on a dedicated bi-stream. **No protocol streams
 are exposed until the handshake succeeds on both sides.**
 
-Two fields are checked:
+Three fields are checked:
 
 - **`protocol_version`** — a manually-maintained `u32` constant
   (`PROTOCOL_VERSION` in `crates/net/svc-api/src/handshake.rs`). Bumped any
@@ -82,6 +82,12 @@ Two fields are checked:
   in a coordinated deployment must set the same value. Mismatched or
   asymmetric → refuse. Single-operator dev / local testing leaves it unset
   on every node.
+- **`reduced_circuits`** — a `bool` derived at build time from the
+  `reduced-circuits` Cargo feature. A node built with reduced circuits
+  cannot interop with one built without: the circuit shape (wire counts,
+  tableset commitments, garbling tables) diverges, so even an otherwise
+  compatible protocol exchange will produce nonsense. Hard-matched; any
+  mismatch refuses the connection.
 
 **On mismatch:** the connection is closed with `CLOSE_VERSION_HANDSHAKE_FAILED`
 (code 6), the peer is added to an in-memory `incompatible_peers` cache, and
@@ -95,5 +101,5 @@ versions our outbound reconnect logic resumes normally too. The cache is
 also fully cleared on process restart.
 
 **Operator surface:** the `mosaic_nodeInfo` RPC returns the current
-`protocol_version` and `deployment_version` so two operators can compare
-configurations without log-diving.
+`protocol_version`, `deployment_version`, and `reduced_circuits` so two
+operators can compare configurations without log-diving.

--- a/docs/network.md
+++ b/docs/network.md
@@ -63,3 +63,32 @@ This layering means net-svc could theoretically be reused for other protocols.
 - Disconnections trigger automatic reconnection with backoff
 - Keep-alives prevent idle timeouts
 - On simultaneous connect (both sides dial), lower peer_id wins deterministically
+
+## Version Handshake
+
+After QUIC TLS authentication and the overlap-key check, both sides exchange a
+short version-handshake payload on a dedicated bi-stream. **No protocol streams
+are exposed until the handshake succeeds on both sides.**
+
+Two fields are checked:
+
+- **`protocol_version`** — a manually-maintained `u32` constant
+  (`PROTOCOL_VERSION` in `crates/net/svc-api/src/handshake.rs`). Bumped any
+  time the wire-visible surface changes — message types in `cac/types`,
+  garbler/evaluator STF semantics peers depend on, net-svc framing. Mismatch
+  → refuse communication.
+- **`deployment_version`** — operator-supplied cohort identifier via TOML
+  config (`network.deployment_version = "tn3"`). All-or-none: every operator
+  in a coordinated deployment must set the same value. Mismatched or
+  asymmetric → refuse. Single-operator dev / local testing leaves it unset
+  on every node.
+
+**On mismatch:** the connection is closed with `CLOSE_VERSION_HANDSHAKE_FAILED`
+(code 6), the local peer is marked incompatible for the rest of the process
+lifetime, and the reason is logged at ERROR once per peer. Subsequent reconnect
+attempts to that peer are suppressed — restart the process if the peer is
+upgraded out of the incompatible state.
+
+**Operator surface:** the `mosaic_nodeInfo` RPC returns the current
+`protocol_version` and `deployment_version` so two operators can compare
+configurations without log-diving.


### PR DESCRIPTION
## Description

Closes #265.

Adds a post-TLS / pre-protocol-stream version handshake on a dedicated bi-stream. Three fields are checked symmetrically:

- **`protocol_version: u32`** — constant in `crates/net/svc-api/src/handshake.rs`. Bump when wire-visible code changes (cac/types message shapes, cac/protocol STF semantics peers depend on, net-svc framing). Mismatch refuses the connection.
- **`deployment_version: Option<String>`** — operator-supplied via TOML config (`network.deployment_version = "tn3"`). All-or-none: every operator in a cohort must set the same value. Asymmetric or mismatched values refuse the connection; single-operator dev leaves it unset on every node.
- **`reduced_circuits: bool`** — derived at build time from the `reduced-circuits` Cargo feature. Hard-matched: nodes with mismatched circuit shapes can't interop even if the wire protocol is otherwise compatible, so the handshake refuses any mismatch.

### Failure handling

- QUIC connection closed with `CLOSE_VERSION_HANDSHAKE_FAILED` (code 6).
- Peer added to an in-memory `incompatible_peers` set in `ServiceState`. Outbound reconnect attempts to peers in the set are suppressed so we don't burn cycles re-handshaking a known-incompatible peer. The cache clears on process restart and on a successful inbound handshake — if either side is upgraded, the next handshake succeeds and the gate clears.
- `open_protocol_stream` against a peer in `incompatible_peers` fails immediately with `ConnectionFailed` instead of being queued (codex P2 finding).
- Logged at ERROR on first detection, DEBUG thereafter.

### Operator surface

- `mosaic_nodeInfo` RPC returns all three fields so two operators can compare configurations without log-diving.
- TOML config gains `network.deployment_version` (defaults to unset). `reduced_circuits` follows the Cargo feature.

### PR template

Added a checkbox under the existing checklist for bumping `PROTOCOL_VERSION` when touching wire-visible code. Review-time discipline for now; can swap to a content-hash strategy later without breaking compat.

### Type of Change

- [x] New feature/Enhancement
- [x] New or updated tests
- [ ] Breaking change

Not breaking for storage / RPC / protocol — only adds bytes to the handshake exchange. Two peers on this code with default config behave as before. A peer on this code talking to older code (no handshake stream) times out and is marked incompatible — that's intended for cluster upgrades.

## Notes to Reviewers

- **Position in the stack:** handshake slots in `crates/net/svc/src/svc/tasks.rs` between `extract_peer_id` (TLS cert) and `*ConnectionReady` (event back to service loop). Nothing is exposed to higher layers until it succeeds.
- **Wire shape:** ark-serialize, matching the rest of the mosaic wire surface. Receiver is hard-capped at `MAX_HANDSHAKE_PAYLOAD_BYTES = 256` bytes before any peer-controlled allocation.
- **`incompatible_peers` cleared on restart:** intentional. Upgrade either side, restart the upgraded node, gate clears. In-memory only.
- **Tests:** integration tests in `crates/net/svc/tests/integration.rs` cover matching, protocol mismatch, deployment mismatch, deployment asymmetry, reduced_circuits mismatch, reduced_circuits both-sides, and uncoordinated (None/None). Unit tests in `crates/net/svc-api/src/handshake.rs` cover wire encoding edges (max-length, over-length, bad magic, invalid boolean byte) and the validation truth table. Workspace tests pass on `--release`.
- **Out of scope** (per issue, follow-up):
  - Negotiation / backwards-compat
  - Automatic ban / backoff timers
  - A `--retry-incompatible-after <duration>` knob

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] If this PR touches the wire-visible protocol surface … I bumped `PROTOCOL_VERSION` in `crates/net/svc-api/src/handshake.rs`. *(N/A — this PR adds the constant; nothing else in this diff changes wire shape.)*

## Related Issues

closes #265