### PR TITLE
feat(job-scheduler): Add memory-heavy job pool for VerifyOpenedInputShares

### DIFF
--- a/bin/mosaic/config/config.a.toml
+++ b/bin/mosaic/config/config.a.toml
@@ -55,8 +55,8 @@ threads = 2
 concurrency_per_worker = 8
 
 [job_scheduler.memory_heavy]
-threads = 1
-concurrency_per_worker = 2
+threads = 2
+concurrency_per_worker = 1
 
 [job_scheduler.garbling]
 worker_threads = 2

--- a/bin/mosaic/config/config.a.toml
+++ b/bin/mosaic/config/config.a.toml
@@ -54,6 +54,10 @@ concurrency_per_worker = 32
 threads = 2
 concurrency_per_worker = 8
 
+[job_scheduler.memory_heavy]
+threads = 1
+concurrency_per_worker = 2
+
 [job_scheduler.garbling]
 worker_threads = 2
 max_concurrent = 2

--- a/bin/mosaic/config/config.b.toml
+++ b/bin/mosaic/config/config.b.toml
@@ -55,8 +55,8 @@ threads = 2
 concurrency_per_worker = 8
 
 [job_scheduler.memory_heavy]
-threads = 1
-concurrency_per_worker = 2
+threads = 2
+concurrency_per_worker = 1
 
 [job_scheduler.garbling]
 worker_threads = 2

--- a/bin/mosaic/config/config.b.toml
+++ b/bin/mosaic/config/config.b.toml
@@ -54,6 +54,10 @@ concurrency_per_worker = 32
 threads = 2
 concurrency_per_worker = 8
 
+[job_scheduler.memory_heavy]
+threads = 1
+concurrency_per_worker = 2
+
 [job_scheduler.garbling]
 worker_threads = 2
 max_concurrent = 2

--- a/bin/mosaic/config/config.c.toml
+++ b/bin/mosaic/config/config.c.toml
@@ -55,8 +55,8 @@ threads = 2
 concurrency_per_worker = 8
 
 [job_scheduler.memory_heavy]
-threads = 1
-concurrency_per_worker = 2
+threads = 2
+concurrency_per_worker = 1
 
 [job_scheduler.garbling]
 worker_threads = 2

--- a/bin/mosaic/config/config.c.toml
+++ b/bin/mosaic/config/config.c.toml
@@ -54,6 +54,10 @@ concurrency_per_worker = 32
 threads = 2
 concurrency_per_worker = 8
 
+[job_scheduler.memory_heavy]
+threads = 1
+concurrency_per_worker = 2
+
 [job_scheduler.garbling]
 worker_threads = 2
 max_concurrent = 2

--- a/bin/mosaic/config/config.d.toml
+++ b/bin/mosaic/config/config.d.toml
@@ -55,8 +55,8 @@ threads = 2
 concurrency_per_worker = 8
 
 [job_scheduler.memory_heavy]
-threads = 1
-concurrency_per_worker = 2
+threads = 2
+concurrency_per_worker = 1
 
 [job_scheduler.garbling]
 worker_threads = 2

--- a/bin/mosaic/config/config.d.toml
+++ b/bin/mosaic/config/config.d.toml
@@ -54,6 +54,10 @@ concurrency_per_worker = 32
 threads = 2
 concurrency_per_worker = 8
 
+[job_scheduler.memory_heavy]
+threads = 1
+concurrency_per_worker = 2
+
 [job_scheduler.garbling]
 worker_threads = 2
 max_concurrent = 2

--- a/bin/mosaic/config/config.e.toml
+++ b/bin/mosaic/config/config.e.toml
@@ -55,8 +55,8 @@ threads = 2
 concurrency_per_worker = 8
 
 [job_scheduler.memory_heavy]
-threads = 1
-concurrency_per_worker = 2
+threads = 2
+concurrency_per_worker = 1
 
 [job_scheduler.garbling]
 worker_threads = 2

--- a/bin/mosaic/config/config.e.toml
+++ b/bin/mosaic/config/config.e.toml
@@ -54,6 +54,10 @@ concurrency_per_worker = 32
 threads = 2
 concurrency_per_worker = 8
 
+[job_scheduler.memory_heavy]
+threads = 1
+concurrency_per_worker = 2
+
 [job_scheduler.garbling]
 worker_threads = 2
 max_concurrent = 2

--- a/bin/mosaic/config/config.example.toml
+++ b/bin/mosaic/config/config.example.toml
@@ -41,8 +41,8 @@ threads = 2
 concurrency_per_worker = 8
 
 [job_scheduler.memory_heavy]
-threads = 1
-concurrency_per_worker = 2
+threads = 2
+concurrency_per_worker = 1
 
 [job_scheduler.garbling]
 worker_threads = 4

--- a/bin/mosaic/config/config.example.toml
+++ b/bin/mosaic/config/config.example.toml
@@ -40,6 +40,10 @@ concurrency_per_worker = 32
 threads = 2
 concurrency_per_worker = 8
 
+[job_scheduler.memory_heavy]
+threads = 1
+concurrency_per_worker = 2
+
 [job_scheduler.garbling]
 worker_threads = 4
 max_concurrent = 8

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -86,6 +86,11 @@ impl MosaicConfig {
                 concurrency_per_worker: self.job_scheduler.heavy.concurrency_per_worker,
                 priority_queue: true,
             },
+            memory_heavy: PoolConfig {
+                threads: self.job_scheduler.memory_heavy.threads,
+                concurrency_per_worker: self.job_scheduler.memory_heavy.concurrency_per_worker,
+                priority_queue: true,
+            },
             garbling: GarblingConfig {
                 worker_threads: self.job_scheduler.garbling.worker_threads,
                 max_concurrent: self.job_scheduler.garbling.max_concurrent,
@@ -133,7 +138,10 @@ impl MosaicConfig {
             bail!("job_scheduler.garbling.worker_threads must be greater than zero");
         }
 
-        if self.job_scheduler.light.threads == 0 || self.job_scheduler.heavy.threads == 0 {
+        if self.job_scheduler.light.threads == 0
+            || self.job_scheduler.heavy.threads == 0
+            || self.job_scheduler.memory_heavy.threads == 0
+        {
             bail!("job scheduler thread counts must be greater than zero");
         }
 
@@ -348,6 +356,8 @@ pub(crate) struct JobSchedulerSection {
     pub(crate) light: PoolSection,
     #[serde(default = "default_heavy_pool_section")]
     pub(crate) heavy: PoolSection,
+    #[serde(default = "default_memory_heavy_pool_section")]
+    pub(crate) memory_heavy: PoolSection,
     #[serde(default)]
     pub(crate) garbling: GarblingSection,
     #[serde(default = "default_submission_queue_size")]
@@ -378,6 +388,13 @@ fn default_heavy_pool_section() -> PoolSection {
     PoolSection {
         threads: 2,
         concurrency_per_worker: 8,
+    }
+}
+
+fn default_memory_heavy_pool_section() -> PoolSection {
+    PoolSection {
+        threads: 1,
+        concurrency_per_worker: 2,
     }
 }
 

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -145,6 +145,13 @@ impl MosaicConfig {
             bail!("job scheduler thread counts must be greater than zero");
         }
 
+        if self.job_scheduler.light.concurrency_per_worker == 0
+            || self.job_scheduler.heavy.concurrency_per_worker == 0
+            || self.job_scheduler.memory_heavy.concurrency_per_worker == 0
+        {
+            bail!("job scheduler concurrency_per_worker must be greater than zero");
+        }
+
         if !self.circuit.path.is_file() {
             bail!(
                 "circuit.path does not point to an existing file: {}",

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -400,8 +400,8 @@ fn default_heavy_pool_section() -> PoolSection {
 
 fn default_memory_heavy_pool_section() -> PoolSection {
     PoolSection {
-        threads: 1,
-        concurrency_per_worker: 2,
+        threads: 2,
+        concurrency_per_worker: 1,
     }
 }
 

--- a/crates/job/scheduler/src/lib.rs
+++ b/crates/job/scheduler/src/lib.rs
@@ -1,10 +1,12 @@
 //! Job scheduler implementation for Mosaic.
 //!
 //! This crate contains the execution infrastructure for actions emitted by
-//! Garbler and Evaluator state machines. It provides three specialized pools:
+//! Garbler and Evaluator state machines. It provides four specialized pools:
 //!
 //! - **Light pool**: FIFO queue for I/O-bound tasks (sends, acks)
 //! - **Heavy pool**: Priority queue for CPU-bound tasks (verification, crypto)
+//! - **Memory-heavy pool**: Priority queue with low concurrency for tasks with high peak memory
+//!   (e.g. batch share verification)
 //! - **Garbling coordinator**: Barrier-synchronized circuit reads for garbling
 //!
 //! The scheduler is generic over `ExecuteGarblerJob` + `ExecuteEvaluatorJob`, which decouples

--- a/crates/job/scheduler/src/scheduler.rs
+++ b/crates/job/scheduler/src/scheduler.rs
@@ -64,8 +64,8 @@ impl Default for JobSchedulerConfig {
                 priority_queue: true,
             },
             memory_heavy: PoolConfig {
-                threads: 1,
-                concurrency_per_worker: 2,
+                threads: 2,
+                concurrency_per_worker: 1,
                 priority_queue: true,
             },
             garbling: GarblingConfig::default(),

--- a/crates/job/scheduler/src/scheduler.rs
+++ b/crates/job/scheduler/src/scheduler.rs
@@ -32,6 +32,9 @@ pub struct JobSchedulerConfig {
     pub light: PoolConfig,
     /// Heavy pool: CPU-bound non-garbling tasks.
     pub heavy: PoolConfig,
+    /// Memory-heavy pool: tasks with large peak memory (e.g. batch share
+    /// verification). Low concurrency to cap aggregate memory usage.
+    pub memory_heavy: PoolConfig,
     /// Garbling coordinator: coordinated topology reads + garbling.
     pub garbling: GarblingConfig,
     /// Capacity of the submission channel.
@@ -60,6 +63,11 @@ impl Default for JobSchedulerConfig {
                 concurrency_per_worker: 8,
                 priority_queue: true,
             },
+            memory_heavy: PoolConfig {
+                threads: 1,
+                concurrency_per_worker: 2,
+                priority_queue: true,
+            },
             garbling: GarblingConfig::default(),
             submission_queue_size: 256,
             completion_queue_size: 256,
@@ -69,9 +77,10 @@ impl Default for JobSchedulerConfig {
 
 /// The job scheduler — executes actions emitted by state machines.
 ///
-/// Owns three execution pools:
+/// Owns four execution pools:
 /// - **Light pool**: FIFO queue, single thread, high concurrency (network I/O)
 /// - **Heavy pool**: Priority queue, multiple threads (crypto, verification)
+/// - **Memory-heavy pool**: Priority queue, low concurrency (large peak memory tasks)
 /// - **Garbling coordinator**: Barrier-synchronized topology reads + garbling
 ///
 /// Constructed by the main binary. The SM Scheduler interacts with it
@@ -79,6 +88,7 @@ impl Default for JobSchedulerConfig {
 pub struct JobScheduler<D: ExecuteGarblerJob + ExecuteEvaluatorJob> {
     light: Option<JobThreadPool<D>>,
     heavy: Option<JobThreadPool<D>>,
+    memory_heavy: Option<JobThreadPool<D>>,
     garbling: Option<GarblingCoordinator>,
     /// Receives batch submissions from the SM Scheduler.
     submission_rx: kanal::AsyncReceiver<JobBatch>,
@@ -179,6 +189,12 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
             completion_tx.clone(),
             fault_tx.clone(),
         );
+        let memory_heavy = JobThreadPool::new(
+            config.memory_heavy,
+            Arc::clone(&executor),
+            completion_tx.clone(),
+            fault_tx.clone(),
+        );
         let garbling = GarblingCoordinator::new(config.garbling, factory, completion_tx, fault_tx);
 
         let handle = JobSchedulerHandle::new(submit_tx, completion_rx);
@@ -186,6 +202,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
         let scheduler = Self {
             light: Some(light),
             heavy: Some(heavy),
+            memory_heavy: Some(memory_heavy),
             garbling: Some(garbling),
             submission_rx,
             fault_rx,
@@ -328,6 +345,12 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                                                     .expect("heavy pool must exist while scheduler is running")
                                                     .submit(priority, worker_job);
                                             }
+                                            ActionCategory::MemoryHeavy => {
+                                                self.memory_heavy
+                                                    .as_ref()
+                                                    .expect("memory_heavy pool must exist while scheduler is running")
+                                                    .submit(priority, worker_job);
+                                            }
                                             _ => unreachable!(),
                                         }
                                     }
@@ -362,6 +385,12 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                                                 self.heavy
                                                     .as_ref()
                                                     .expect("heavy pool must exist while scheduler is running")
+                                                    .submit(priority, worker_job);
+                                            }
+                                            ActionCategory::MemoryHeavy => {
+                                                self.memory_heavy
+                                                    .as_ref()
+                                                    .expect("memory_heavy pool must exist while scheduler is running")
                                                     .submit(priority, worker_job);
                                             }
                                             _ => unreachable!(),
@@ -473,6 +502,9 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
         if let Some(heavy) = self.heavy.take() {
             heavy.shutdown();
         }
+        if let Some(memory_heavy) = self.memory_heavy.take() {
+            memory_heavy.shutdown();
+        }
         if let Some(mut garbling) = self.garbling.take() {
             garbling.shutdown();
         }
@@ -491,6 +523,9 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> Drop for JobScheduler<D> {
         if let Some(heavy) = self.heavy.as_ref() {
             heavy.close_queue();
         }
+        if let Some(memory_heavy) = self.memory_heavy.as_ref() {
+            memory_heavy.close_queue();
+        }
         if let Some(garbling) = self.garbling.as_mut() {
             garbling.shutdown();
         }
@@ -505,6 +540,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> Drop for JobScheduler<D> {
 enum ActionCategory {
     Light,
     Heavy,
+    MemoryHeavy,
     Garbling,
 }
 
@@ -577,10 +613,13 @@ impl Classify for EvaluatorAction {
                 ActionCategory::Garbling
             }
 
+            // Memory-heavy (large peak memory — batch share verification)
+            Self::VerifyOpenedInputShares => ActionCategory::MemoryHeavy,
+
             // Heavy (everything else)
-            Self::VerifyOpenedInputShares
-            | Self::GenerateDepositAdaptors(_)
-            | Self::GenerateWithdrawalAdaptorsChunk(..) => ActionCategory::Heavy,
+            Self::GenerateDepositAdaptors(_) | Self::GenerateWithdrawalAdaptorsChunk(..) => {
+                ActionCategory::Heavy
+            }
         }
     }
 

--- a/docker/vol/mosaic-1/config.toml
+++ b/docker/vol/mosaic-1/config.toml
@@ -40,6 +40,10 @@ concurrency_per_worker = 32
 threads = 2
 concurrency_per_worker = 8
 
+[job_scheduler.memory_heavy]
+threads = 1
+concurrency_per_worker = 2
+
 [job_scheduler.garbling]
 worker_threads = 2
 max_concurrent = 2

--- a/docker/vol/mosaic-1/config.toml
+++ b/docker/vol/mosaic-1/config.toml
@@ -41,8 +41,8 @@ threads = 2
 concurrency_per_worker = 8
 
 [job_scheduler.memory_heavy]
-threads = 1
-concurrency_per_worker = 2
+threads = 2
+concurrency_per_worker = 1
 
 [job_scheduler.garbling]
 worker_threads = 2

--- a/docker/vol/mosaic-2/config.toml
+++ b/docker/vol/mosaic-2/config.toml
@@ -40,6 +40,10 @@ concurrency_per_worker = 32
 threads = 2
 concurrency_per_worker = 8
 
+[job_scheduler.memory_heavy]
+threads = 1
+concurrency_per_worker = 2
+
 [job_scheduler.garbling]
 worker_threads = 2
 max_concurrent = 2

--- a/docker/vol/mosaic-2/config.toml
+++ b/docker/vol/mosaic-2/config.toml
@@ -41,8 +41,8 @@ threads = 2
 concurrency_per_worker = 8
 
 [job_scheduler.memory_heavy]
-threads = 1
-concurrency_per_worker = 2
+threads = 2
+concurrency_per_worker = 1
 
 [job_scheduler.garbling]
 worker_threads = 2

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,8 @@ Bridge Core communicates with Mosaic via private RPC.
 | SM Scheduler | monoio pool | Runs Garbler/Evaluator state machines (1 pair per peer) |
 | JobScheduler | monoio | Routes actions to pools, manages requeue |
 | Job Light Pool | monoio (1 thread) | Network I/O (sends, acks, bulk receives) |
-| Job Heavy Pool | monoio (2 threads) | CPU-bound crypto (verification, polynomial ops, adaptors) |
+| Job Heavy Pool | monoio (2 threads) | CPU-bound crypto (polynomial ops, adaptors) |
+| Job Memory-Heavy Pool | monoio (1 thread) | High peak memory tasks (batch share verification) |
 | Garbling Coordinator | monoio (1+N threads) | Coordinated circuit reads + garbling/evaluation |
 | net-svc | tokio (isolated) | P2P QUIC between Mosaic instances |
 | S3TableStore | tokio (isolated) | Garbling table persistence via object_store |
@@ -42,7 +43,7 @@ Key insight: Jobs handle all outgoing traffic. Incoming protocol messages go to 
 - `crates/cac/types/` — Protocol message types, SM inputs/actions, StateRead/StateMut traits
 - `crates/job/api/` — Executor traits (`ExecuteGarblerJob`, `ExecuteEvaluatorJob`), `CircuitSession`, `SessionFactory`, submission/completion types
 - `crates/job/executors/` — `MosaicExecutor`, all 18 handler implementations, `GarblingSession`, `PolynomialCache`, circuit session types
-- `crates/job/scheduler/` — `JobScheduler`, light/heavy pools, multi-threaded garbling coordinator, action classification, priority queue
+- `crates/job/scheduler/` — `JobScheduler`, light/heavy/memory-heavy pools, multi-threaded garbling coordinator, action classification, priority queue
 - `crates/storage/api/` — `StorageProvider`, `StorageProviderMut`, `TableStore` traits
 - `crates/storage/inmemory/` — In-memory `StateRead`/`StateMut` impl (testing)
 - `crates/storage/s3/` — S3-backed `TableStore` via `object_store` + tokio bridge

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ Bridge Core communicates with Mosaic via private RPC.
 | JobScheduler | monoio | Routes actions to pools, manages requeue |
 | Job Light Pool | monoio (1 thread) | Network I/O (sends, acks, bulk receives) |
 | Job Heavy Pool | monoio (2 threads) | CPU-bound crypto (polynomial ops, adaptors) |
-| Job Memory-Heavy Pool | monoio (1 thread) | High peak memory tasks (batch share verification) |
+| Job Memory-Heavy Pool | monoio (2 threads) | High peak memory tasks (batch share verification) |
 | Garbling Coordinator | monoio (1+N threads) | Coordinated circuit reads + garbling/evaluation |
 | net-svc | tokio (isolated) | P2P QUIC between Mosaic instances |
 | S3TableStore | tokio (isolated) | Garbling table persistence via object_store |

--- a/docs/jobscheduler.md
+++ b/docs/jobscheduler.md
@@ -15,7 +15,7 @@ crates/job/
 
 **job-executors** provides `MosaicExecutor<SP, TS>`, the concrete implementation of both executor traits. Contains all 17 handler implementations, the `GarblingSession` core, `PolynomialCache`, and three `CircuitSession` types (commitment, transfer, evaluation). Generic over `StorageProvider` and `TableStore`.
 
-**job-scheduler** contains the scheduling infrastructure: light pool, heavy pool, multi-threaded garbling coordinator, action classification, priority queue, and worker retry logic. Generic over the executor traits — has no compile-time dependency on `job-executors`.
+**job-scheduler** contains the scheduling infrastructure: light pool, heavy pool, memory-heavy pool, multi-threaded garbling coordinator, action classification, priority queue, and worker retry logic. Generic over the executor traits — has no compile-time dependency on `job-executors`.
 
 ```
    ┌──────────────┐
@@ -41,18 +41,18 @@ crates/job/
 ## Architecture
 
 ```
-┌──────────────────────────────────────────────────────────────────────────┐
-│                   JobScheduler (monoio thread)                           │
-│                                                                          │
-│  dispatch_batch: classify action → route to pool or coordinator          │
-├──────────────────┬───────────────────┬───────────────────────────────────┤
-│  Light Pool      │   Heavy Pool      │   Garbling Coordinator            │
-│                  │                   │                                   │
-│  Pull model      │  Pull model       │  Push model                      │
-│  FIFO queue      │  Priority queue   │  Multi-threaded barrier sync     │
-│  1 monoio worker │  2 monoio workers │  1 main thread + N worker threads│
-│  32 concurrency  │  8 concurrency    │  SessionFactory + retry          │
-└──────────────────┴───────────────────┴───────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────────────────────┐
+│                            JobScheduler (monoio thread)                                      │
+│                                                                                              │
+│  dispatch_batch: classify action → route to pool or coordinator                              │
+├──────────────────┬───────────────────┬────────────────────┬─────────────────────────────────-┤
+│  Light Pool      │   Heavy Pool      │  Memory-Heavy Pool │   Garbling Coordinator           │
+│                  │                   │                    │                                  │
+│  Pull model      │  Pull model       │  Pull model        │  Push model                      │
+│  FIFO queue      │  Priority queue   │  Priority queue    │  Multi-threaded barrier sync     │
+│  1 monoio worker │  2 monoio workers │  1 monoio worker   │  1 main thread + N worker threads│
+│  32 concurrency  │  8 concurrency    │  2 concurrency     │  SessionFactory + retry          │
+└──────────────────┴───────────────────┴────────────────────┴──────────────────────────────────┘
 ```
 
 The scheduler thread runs its own monoio runtime. Each pool worker thread runs its own monoio runtime with bounded concurrency via a permit pool (kanal channel-based). Workers pull jobs from a shared queue as `!Send` local tasks.
@@ -64,10 +64,11 @@ The garbling coordinator runs on a dedicated main thread that reads the circuit 
 | Category | Time | Pool | Examples |
 |----------|------|------|----------|
 | Light | Milliseconds | FIFO, 1 thread | SendCommitMsgChunk, SendChallengeMsg, ReceiveGarblingTable |
-| Heavy | Seconds–minutes | Priority, 2 threads | VerifyOpenedInputShares, DepositVerifyAdaptors |
+| Heavy | Seconds–minutes | Priority, 2 threads | DepositVerifyAdaptors, GeneratePolynomialCommitments |
+| Memory-Heavy | Seconds–minutes | Priority, 1 thread, 2 concurrency | VerifyOpenedInputShares |
 | Garbling | Minutes | Coordinator, N threads | GenerateTableCommitment, TransferGarblingTable, EvaluateGarblingTable |
 
-Light actions are I/O-bound (outbound protocol sends via net-client, inbound bulk receives). Heavy actions are CPU-bound. Garbling actions are CPU-bound and require coordinated sequential reads of a ~130 GB circuit file.
+Light actions are I/O-bound (outbound protocol sends via net-client, inbound bulk receives). Heavy actions are CPU-bound. Memory-heavy actions have high peak memory (~4.5 GB per call) and are isolated in a low-concurrency pool to cap aggregate memory usage. Garbling actions are CPU-bound and require coordinated sequential reads of a ~130 GB circuit file.
 
 ## All 19 Actions
 
@@ -91,7 +92,7 @@ Light actions are I/O-bound (outbound protocol sends via net-client, inbound bul
 | # | Action | Category | Priority | Handler |
 |---|--------|----------|----------|---------|
 | E1 | `SendChallengeMsg(ChallengeMsg)` | Light | Normal | Net send + retry |
-| E2 | `VerifyOpenedInputShares` | Heavy | Normal | Verify 7.7M shares against polynomial commitments |
+| E2 | `VerifyOpenedInputShares` | Memory-Heavy | Normal | Verify 7.7M shares against polynomial commitments |
 | E3 | `GenerateTableCommitment(Index, GarblingSeed)` | Garbling | Normal | CommitmentSession — re-garble to verify commitment |
 | E4 | `ReceiveGarblingTable(GarblingTableCommitment)` | Light | Normal | Register bulk expectation, send transfer request, receive stream, hash verify, store to TableStore |
 | E5 | `GenerateDepositAdaptors(DepositId)` | Heavy | High | Generate adaptors from zeroth-coefficient commitments |
@@ -258,6 +259,12 @@ Handles CPU-intensive non-garbling work. Workers pull from a priority queue with
 
 Workers drain Critical → High → Normal. Withdrawal disputes are never blocked by background setup.
 
+## Memory-Heavy Pool
+
+Handles tasks with high peak memory. Currently only `VerifyOpenedInputShares` (E2), which allocates ~4.5 GB per call for batch share verification via a 7.3M-point multi-scalar multiplication. Low concurrency (default: 2) caps aggregate memory at ~9 GB regardless of peer count, while the heavy pool's slots remain fully available for other crypto work.
+
+Workers pull from a priority queue (same as heavy pool). The pool uses the same `JobThreadPool` infrastructure — the only difference is the concurrency configuration.
+
 ## Garbling Coordinator
 
 The coordinator solves the **shared reader problem**: garbling reads a ~130 GB circuit file. With independent readers at different offsets, disk thrashing destroys throughput. Sequential reads are dramatically faster.
@@ -267,14 +274,14 @@ The coordinator solves the **shared reader problem**: garbling reads a ~130 GB c
 ### Architecture
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
+┌───────────────────────────────────────────────────────────────────┐
 │               Main thread (coordinator_loop)                      │
-│                                                                    │
+│                                                                   │
 │  1. Collect PendingCircuitJobs (channel + retry list)             │
 │  2. Create sessions via SessionFactory (retry StorageUnavailable) │
 │  3. Distribute sessions round-robin across workers                │
 │  4. Read circuit file sequentially                                │
-│                                                                    │
+│                                                                   │
 │  For each chunk:                                                  │
 │    ReaderV5c → convert → Arc<OwnedChunk>                          │
 │        │                                                          │
@@ -282,13 +289,13 @@ The coordinator solves the **shared reader problem**: garbling reads a ~130 GB c
 │        ├── send to Worker 1 ──► process sessions ──► ChunkReport  │
 │        ├── send to Worker 2 ──► process sessions ──► ChunkReport  │
 │        └── send to Worker 3 ──► process sessions ──► ChunkReport  │
-│                                                                    │
+│                                                                   │
 │    Barrier: wait for all ChunkReports                             │
 │    Collect evicted jobs → retry list                              │
-│                                                                    │
+│                                                                   │
 │  5. Send FinishPass → workers call session.finish()               │
 │  6. Workers send completions directly to SM                       │
-└──────────────────────────────────────────────────────────────────┘
+└───────────────────────────────────────────────────────────────────┘
 ```
 
 ### Session Distribution
@@ -369,7 +376,7 @@ This prevents busy-spinning on transient failures (unresponsive peer, full polyn
 
 `JobScheduler` implements `Drop`. On drop, it:
 
-1. Closes the light and heavy pool queues (workers drain remaining jobs and exit)
+1. Closes the light, heavy, and memory-heavy pool queues (workers drain remaining jobs and exit)
 2. Shuts down the garbling coordinator (closes channel, joins coordinator thread, which in turn shuts down worker threads)
 
 The explicit `shutdown(&mut self)` method does the same but can be called manually for deterministic teardown. All operations are idempotent — calling `shutdown()` then dropping is safe.
@@ -384,6 +391,10 @@ Bursts of send operations queue up and execute as earlier tasks complete. All ar
 
 Setup generates many Normal-priority actions. They queue and process as workers become available. If a Critical withdrawal action arrives mid-setup, it jumps the queue immediately.
 
+### Memory-Heavy Pool
+
+Low concurrency (default: 2) ensures that at most two batch share verifications run simultaneously, capping peak memory from this path at ~9 GB. Additional requests queue without consuming slots in other pools.
+
 ### Garbling Coordinator
 
 Multiple peers need garbling tables simultaneously. Sessions are distributed across workers and process their chunks concurrently. A per-session timeout evicts slow consumers (e.g. G8 streaming to a congested peer) without blocking other sessions. Evicted sessions are automatically retried on the next pass.
@@ -394,7 +405,7 @@ The async submission channel prevents the garbling coordinator from blocking the
 
 | Resource | Protection |
 |----------|------------|
-| Memory | `max_concurrent` caps sessions (~1 GB each); bounded queues; chunk-at-a-time processing |
+| Memory | `max_concurrent` caps garbling sessions (~1 GB each); memory-heavy pool caps batch verification (~4.5 GB each); bounded queues; chunk-at-a-time processing |
 | CPU | Concurrency limits per worker; separate pools prevent interference |
 | Disk I/O | Single sequential circuit reader per pass; shared via Arc |
 | Network | Async I/O yields during waits; per-session timeout evicts slow streams |
@@ -406,6 +417,7 @@ The async submission channel prevents the garbling coordinator from blocking the
 pub struct JobSchedulerConfig {
     pub light: PoolConfig,            // default: 1 thread, 32 concurrency, FIFO
     pub heavy: PoolConfig,            // default: 2 threads, 8 concurrency, priority
+    pub memory_heavy: PoolConfig,     // default: 1 thread, 2 concurrency, priority
     pub garbling: GarblingConfig,     // default: 4 workers, 8 max sessions
     pub submission_queue_size: usize, // default: 256
     pub completion_queue_size: usize, // default: 256

--- a/docs/jobscheduler.md
+++ b/docs/jobscheduler.md
@@ -50,8 +50,8 @@ crates/job/
 │                  │                   │                    │                                  │
 │  Pull model      │  Pull model       │  Pull model        │  Push model                      │
 │  FIFO queue      │  Priority queue   │  Priority queue    │  Multi-threaded barrier sync     │
-│  1 monoio worker │  2 monoio workers │  1 monoio worker   │  1 main thread + N worker threads│
-│  32 concurrency  │  8 concurrency    │  2 concurrency     │  SessionFactory + retry          │
+│  1 monoio worker │  2 monoio workers │  2 monoio workers  │  1 main thread + N worker threads│
+│  32 concurrency  │  8 concurrency    │  1 concurrency     │  SessionFactory + retry          │
 └──────────────────┴───────────────────┴────────────────────┴──────────────────────────────────┘
 ```
 
@@ -65,7 +65,7 @@ The garbling coordinator runs on a dedicated main thread that reads the circuit 
 |----------|------|------|----------|
 | Light | Milliseconds | FIFO, 1 thread | SendCommitMsgChunk, SendChallengeMsg, ReceiveGarblingTable |
 | Heavy | Seconds–minutes | Priority, 2 threads | DepositVerifyAdaptors, GeneratePolynomialCommitments |
-| Memory-Heavy | Seconds–minutes | Priority, 1 thread, 2 concurrency | VerifyOpenedInputShares |
+| Memory-Heavy | Seconds–minutes | Priority, 2 threads, 1 concurrency each | VerifyOpenedInputShares |
 | Garbling | Minutes | Coordinator, N threads | GenerateTableCommitment, TransferGarblingTable, EvaluateGarblingTable |
 
 Light actions are I/O-bound (outbound protocol sends via net-client, inbound bulk receives). Heavy actions are CPU-bound. Memory-heavy actions have high peak memory (~4.5 GB per call) and are isolated in a low-concurrency pool to cap aggregate memory usage. Garbling actions are CPU-bound and require coordinated sequential reads of a ~130 GB circuit file.
@@ -393,7 +393,7 @@ Setup generates many Normal-priority actions. They queue and process as workers 
 
 ### Memory-Heavy Pool
 
-Low concurrency (default: 2) ensures that at most two batch share verifications run simultaneously, capping peak memory from this path at ~9 GB. Additional requests queue without consuming slots in other pools.
+Two dedicated threads (default: 1 concurrency each) ensure that at most two batch share verifications run simultaneously, capping peak memory from this path at ~9 GB. Additional requests queue without consuming slots in other pools.
 
 ### Garbling Coordinator
 
@@ -417,7 +417,7 @@ The async submission channel prevents the garbling coordinator from blocking the
 pub struct JobSchedulerConfig {
     pub light: PoolConfig,            // default: 1 thread, 32 concurrency, FIFO
     pub heavy: PoolConfig,            // default: 2 threads, 8 concurrency, priority
-    pub memory_heavy: PoolConfig,     // default: 1 thread, 2 concurrency, priority
+    pub memory_heavy: PoolConfig,     // default: 2 threads, 1 concurrency, priority
     pub garbling: GarblingConfig,     // default: 4 workers, 8 max sessions
     pub submission_queue_size: usize, // default: 256
     pub completion_queue_size: usize, // default: 256


### PR DESCRIPTION
## Description

VerifyOpenedInputShares allocates ~4.5 GB per call (batch MSM over 7.3M points). Under the previous design it shared the heavy pool (16 concurrent slots), so multiple peers completing the challenge phase simultaneously could spike memory to tens of gigabytes.

Introduce a dedicated memory-heavy pool (default: 1 thread, 2 concurrency) that caps peak memory from this path at ~9 GB regardless of peer count (configurable), while keeping all 16 heavy pool slots free for other crypto work.

Note 1) After #230, VerifyOpenedInputShares memory usage should drop to ~1 GB per call. 
Note 2) VerifyOpenedInputShares operation memory usage scales linearly with number of circuits, so this (4.5 GB allocation) is not seen when running in reduced circuits mode in tests.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
