### PR TITLE
job/executors: heartbeat progress logs for garbling phases

### DIFF
--- a/crates/job/executors/src/circuit_sessions.rs
+++ b/crates/job/executors/src/circuit_sessions.rs
@@ -44,7 +44,20 @@ use mosaic_net_client::BulkSender;
 use mosaic_storage_api::table_store::TableReader;
 use mosaic_vs3::{Index, Scalar, Share};
 
-use crate::garbling::{GarblingSession, GarblingSetup, compute_commitment, hash_garbling_params};
+use crate::{
+    garbling::{GarblingSession, GarblingSetup, compute_commitment, hash_garbling_params},
+    progress::{HEARTBEAT_PERIOD, HeartbeatTracker, ProgressUnit},
+};
+
+/// Short-id helper used to label progress logs. Renders the first 4 bytes
+/// of a digest as `0x........`. Truncates gracefully if shorter.
+fn short_id(digest: &[u8]) -> String {
+    let mut s = String::from("0x");
+    for b in digest.iter().take(4) {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
 
 // ════════════════════════════════════════════════════════════════════════════
 // Gate parsing helpers for OwnedBlock
@@ -198,6 +211,10 @@ pub struct CommitmentSession {
     is_garbler: bool,
     /// Reusable buffer for ciphertext bytes per chunk.
     ct_buffer: Vec<u8>,
+    /// Heartbeat progress tracker for operator visibility.
+    heartbeat: HeartbeatTracker,
+    /// Cumulative gates processed so far (matches `HeaderV5c::total_gates`).
+    gates_processed: u64,
 }
 
 impl std::fmt::Debug for CommitmentSession {
@@ -218,8 +235,21 @@ impl CommitmentSession {
         output_wire_ids: Vec<u32>,
         index: Index,
         is_garbler: bool,
+        total_gates: u64,
     ) -> Self {
         let translate_hash = blake3::hash(&setup.translation_bytes);
+        let label = if is_garbler {
+            "garbling.commit"
+        } else {
+            "garbling.verify"
+        };
+        let heartbeat = HeartbeatTracker::new(
+            label,
+            format!("ckt{index}"),
+            Some(total_gates),
+            ProgressUnit::Blocks,
+            HEARTBEAT_PERIOD,
+        );
 
         Self {
             setup,
@@ -229,6 +259,8 @@ impl CommitmentSession {
             index,
             is_garbler,
             ct_buffer: Vec::new(),
+            heartbeat,
+            gates_processed: 0,
         }
     }
 }
@@ -248,12 +280,15 @@ impl CircuitSession for CommitmentSession {
                     &mut self.ct_buffer,
                 );
                 self.ct_hasher.update(&self.ct_buffer);
+                self.gates_processed = self.gates_processed.saturating_add(block.num_gates as u64);
             }
+            self.heartbeat.maybe_log(self.gates_processed);
             Ok(())
         })
     }
 
-    fn finish(self: Box<Self>) -> Pin<Box<dyn Future<Output = HandlerOutcome> + Send>> {
+    fn finish(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = HandlerOutcome> + Send>> {
+        self.heartbeat.done(self.gates_processed);
         Box::pin(async move {
             let ct_hash = self.ct_hasher.finalize();
 
@@ -329,6 +364,10 @@ pub struct TransferSession {
     output_wire_ids: Vec<u32>,
     /// Reusable buffer for ciphertext bytes per block.
     ct_buffer: Vec<u8>,
+    /// Heartbeat progress tracker for operator visibility.
+    heartbeat: HeartbeatTracker,
+    /// Cumulative bytes written to the bulk stream so far.
+    bytes_sent: u64,
 }
 
 impl std::fmt::Debug for TransferSession {
@@ -350,7 +389,17 @@ impl TransferSession {
         seed: GarblingSeed,
         commitment: GarblingTableCommitment,
         output_wire_ids: Vec<u32>,
+        total_and_gates: u64,
     ) -> Self {
+        // Each AND gate emits 16 ciphertext bytes on the wire.
+        let total_bytes = total_and_gates.saturating_mul(16);
+        let heartbeat = HeartbeatTracker::new(
+            "table.upload",
+            short_id(commitment.as_ref()),
+            Some(total_bytes),
+            ProgressUnit::Bytes,
+            HEARTBEAT_PERIOD,
+        );
         Self {
             session,
             stream,
@@ -358,6 +407,8 @@ impl TransferSession {
             commitment,
             output_wire_ids,
             ct_buffer: Vec::new(),
+            heartbeat,
+            bytes_sent: 0,
         }
     }
 }
@@ -376,18 +427,26 @@ impl CircuitSession for TransferSession {
                 self.ct_buffer.clear();
                 process_owned_block_garble(&mut self.session.instance, block, &mut self.ct_buffer);
                 if !self.ct_buffer.is_empty() {
+                    let n = self.ct_buffer.len() as u64;
                     let out = std::mem::take(&mut self.ct_buffer);
                     self.ct_buffer =
                         self.stream.write(out).await.map_err(|e| {
                             CircuitError::ChunkFailed(format!("stream write: {e:?}"))
                         })?;
+                    self.bytes_sent = self.bytes_sent.saturating_add(n);
                 }
             }
+            self.heartbeat.maybe_log(self.bytes_sent);
             Ok(())
         })
     }
 
-    fn finish(self: Box<Self>) -> Pin<Box<dyn Future<Output = HandlerOutcome> + Send>> {
+    fn finish(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = HandlerOutcome> + Send>> {
+        // NB: the summary log fires here, before the returned future runs and
+        // the stream is FIN'd on drop. For multi-minute uploads the gap is
+        // negligible, but the log marks "session work done" rather than
+        // "bytes-on-wire FIN".
+        self.heartbeat.done(self.bytes_sent);
         Box::pin(async move {
             // Finalize the garbling session to properly release the ~1 GB
             // working space. We discard the output — the commitment was
@@ -443,6 +502,10 @@ pub struct EvaluationSession {
     /// to a share value. Stored as raw bytes ([u8; 32]) since Byte32 may
     /// not be Copy.
     output_label_ct: [u8; 32],
+    /// Heartbeat progress tracker for operator visibility.
+    heartbeat: HeartbeatTracker,
+    /// Cumulative gates evaluated so far (matches `HeaderV5c::total_gates`).
+    gates_processed: u64,
 }
 
 impl std::fmt::Debug for EvaluationSession {
@@ -465,7 +528,15 @@ impl EvaluationSession {
         commitment: GarblingTableCommitment,
         output_wire_ids: Vec<u32>,
         output_label_ct: [u8; 32],
+        total_gates: u64,
     ) -> Self {
+        let heartbeat = HeartbeatTracker::new(
+            "table.eval",
+            short_id(commitment.as_ref()),
+            Some(total_gates),
+            ProgressUnit::Blocks,
+            HEARTBEAT_PERIOD,
+        );
         Self {
             instance,
             ct_reader,
@@ -473,6 +544,8 @@ impl EvaluationSession {
             commitment,
             output_wire_ids,
             output_label_ct,
+            heartbeat,
+            gates_processed: 0,
         }
     }
 }
@@ -511,14 +584,17 @@ impl CircuitSession for EvaluationSession {
             let mut ct_offset = 0;
             for block in &chunk.blocks {
                 process_owned_block_eval(&mut self.instance, block, &ct_data, &mut ct_offset);
+                self.gates_processed = self.gates_processed.saturating_add(block.num_gates as u64);
             }
             debug_assert_eq!(ct_offset, ct_bytes_needed);
+            self.heartbeat.maybe_log(self.gates_processed);
 
             Ok(())
         })
     }
 
-    fn finish(self: Box<Self>) -> Pin<Box<dyn Future<Output = HandlerOutcome> + Send>> {
+    fn finish(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = HandlerOutcome> + Send>> {
+        self.heartbeat.done(self.gates_processed);
         Box::pin(async move {
             // Extract output labels and values from the evaluation instance.
             let wire_ids: Vec<u64> = self.output_wire_ids.iter().map(|&w| w as u64).collect();

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -862,5 +862,6 @@ pub(crate) async fn setup_evaluation_session<SP: StorageProvider, TS: TableStore
         commitment,
         outputs,
         output_label_ct_bytes,
+        header.total_gates(),
     ))
 }

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -627,6 +627,7 @@ pub(crate) async fn setup_transfer_session<SP: StorageProvider, TS: TableStore>(
         seed,
         commitment,
         outputs,
+        header.and_gates,
     ))
 }
 

--- a/crates/job/executors/src/lib.rs
+++ b/crates/job/executors/src/lib.rs
@@ -21,6 +21,7 @@ pub mod evaluator;
 pub mod garbler;
 pub mod garbling;
 pub mod polynomial_cache;
+pub mod progress;
 
 use ckt_fmtv5_types::v5::c::ReaderV5c;
 use mosaic_cac_types::state_machine::{evaluator::StateRead as _, garbler::StateRead as _};
@@ -201,7 +202,11 @@ impl<SP: StorageProvider, TS: TableStore> ExecuteGarblerJob for MosaicExecutor<S
 
             Ok(circuit_sessions::GarblerCircuitSession::Commitment(
                 Box::new(circuit_sessions::CommitmentSession::new(
-                    setup, outputs, index, true,
+                    setup,
+                    outputs,
+                    index,
+                    true,
+                    header.total_gates(),
                 )),
             ))
         }
@@ -322,7 +327,11 @@ impl<SP: StorageProvider, TS: TableStore> ExecuteEvaluatorJob for MosaicExecutor
 
             Ok(circuit_sessions::EvaluatorCircuitSession::Commitment(
                 Box::new(circuit_sessions::CommitmentSession::new(
-                    setup, outputs, index, false,
+                    setup,
+                    outputs,
+                    index,
+                    false,
+                    header.total_gates(),
                 )),
             ))
         }

--- a/crates/job/executors/src/progress.rs
+++ b/crates/job/executors/src/progress.rs
@@ -1,0 +1,274 @@
+//! Heartbeat progress logging for long-running garbling phases.
+//!
+//! Long phases like table upload (G8) and table evaluation (E8) can each
+//! take minutes. Without periodic logs, operators can't tell whether a node
+//! is making progress or wedged.
+//!
+//! [`HeartbeatTracker`] emits one `INFO` line per [`HEARTBEAT_PERIOD`]
+//! interval at the call site's choosing — no spawned timer, no shared
+//! state. Call sites tick `maybe_log` per chunk/block; the tracker prints
+//! only when enough time has elapsed since the last print.
+//!
+//! Logs are emitted on the `mosaic_progress` tracing target — operators can
+//! grep that string to surface only progress lines, or filter via
+//! `RUST_LOG=mosaic_progress=info`.
+
+use std::time::{Duration, Instant};
+
+/// Default interval between heartbeat log emissions.
+pub const HEARTBEAT_PERIOD: Duration = Duration::from_secs(30);
+
+/// The thing being counted on the wire — bytes get rate + eta formatting;
+/// blocks get percent + elapsed only.
+#[derive(Copy, Clone, Debug)]
+pub enum ProgressUnit {
+    /// Counter is bytes — output includes throughput (`inst`, `avg`) and ETA.
+    Bytes,
+    /// Counter is opaque units (typically blocks) — output is percent + elapsed only.
+    Blocks,
+}
+
+/// Tracks progress through a long-running phase and emits periodic INFO
+/// heartbeat logs.
+///
+/// Created at the start of a phase; `maybe_log` is called per chunk with
+/// the cumulative-progress count. `done` emits a final summary line.
+#[derive(Debug)]
+pub struct HeartbeatTracker {
+    label: &'static str,
+    short_id: String,
+    total: Option<u64>,
+    unit: ProgressUnit,
+    started_at: Instant,
+    last_log_at: Instant,
+    last_log_progress: u64,
+    period: Duration,
+}
+
+impl HeartbeatTracker {
+    /// Create a new tracker.
+    ///
+    /// `label` is the phase name printed in the log (e.g. `"table.upload"`).
+    /// `short_id` is a stable identifier the caller chose for this work item
+    /// (e.g. a commitment short-hash, or a circuit index).
+    /// `total` is the expected final count if known; `None` suppresses
+    /// percent/ETA in the output. `period` is the minimum interval between
+    /// emissions; pass [`HEARTBEAT_PERIOD`] for the default.
+    pub fn new(
+        label: &'static str,
+        short_id: String,
+        total: Option<u64>,
+        unit: ProgressUnit,
+        period: Duration,
+    ) -> Self {
+        let now = Instant::now();
+        Self {
+            label,
+            short_id,
+            total,
+            unit,
+            started_at: now,
+            last_log_at: now,
+            last_log_progress: 0,
+            period,
+        }
+    }
+
+    /// If [`HEARTBEAT_PERIOD`] has elapsed since the last log (or since
+    /// construction), emit an INFO heartbeat. Cheap on the not-yet-time path.
+    pub fn maybe_log(&mut self, current: u64) {
+        let now = Instant::now();
+        if now.duration_since(self.last_log_at) < self.period {
+            return;
+        }
+        self.emit(current, now, /* final = */ false);
+        self.last_log_at = now;
+        self.last_log_progress = current;
+    }
+
+    /// Emit a final summary line. Always logs regardless of last_log_at.
+    pub fn done(&mut self, current: u64) {
+        let now = Instant::now();
+        self.emit(current, now, /* final = */ true);
+    }
+
+    fn emit(&mut self, current: u64, now: Instant, is_final: bool) {
+        let elapsed = now.duration_since(self.started_at);
+        let interval = now.duration_since(self.last_log_at);
+        let delta = current.saturating_sub(self.last_log_progress);
+
+        let avg_rate = (current as f64) / elapsed.as_secs_f64().max(1e-3);
+        let inst_rate = (delta as f64) / interval.as_secs_f64().max(1e-3);
+
+        let pct = self
+            .total
+            .filter(|t| *t > 0)
+            .map(|t| (current as f64) * 100.0 / (t as f64));
+
+        let event_label = if is_final { "summary" } else { "progress" };
+
+        match self.unit {
+            ProgressUnit::Bytes => {
+                let done_str = match self.total {
+                    Some(t) => format!("{}/{}", fmt_bytes(current), fmt_bytes(t)),
+                    None => fmt_bytes(current),
+                };
+                let pct_str = pct.map(|p| format!(" pct={p:.1}%")).unwrap_or_default();
+                let eta_str = match (self.total, inst_rate) {
+                    (Some(t), r) if r > 0.0 && t > current => {
+                        let remaining = (t - current) as f64 / r;
+                        format!(" eta={}", fmt_duration(Duration::from_secs_f64(remaining)))
+                    }
+                    _ => String::new(),
+                };
+                tracing::info!(
+                    target: "mosaic_progress",
+                    phase = self.label,
+                    id = %self.short_id,
+                    "{} {} id={} done={}{} inst={}/s avg={}/s elapsed={}{}",
+                    self.label,
+                    event_label,
+                    self.short_id,
+                    done_str,
+                    pct_str,
+                    fmt_rate(inst_rate),
+                    fmt_rate(avg_rate),
+                    fmt_duration(elapsed),
+                    eta_str,
+                );
+            }
+            ProgressUnit::Blocks => {
+                let pct_str = match pct {
+                    Some(p) => format!(" pct=~{p:.0}%"),
+                    None => String::new(),
+                };
+                tracing::info!(
+                    target: "mosaic_progress",
+                    phase = self.label,
+                    id = %self.short_id,
+                    "{} {} id={}{} elapsed={}",
+                    self.label,
+                    event_label,
+                    self.short_id,
+                    pct_str,
+                    fmt_duration(elapsed),
+                );
+            }
+        }
+    }
+}
+
+fn fmt_bytes(n: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = 1024.0 * KIB;
+    const GIB: f64 = 1024.0 * MIB;
+    const TIB: f64 = 1024.0 * GIB;
+    let v = n as f64;
+    if v >= TIB {
+        format!("{:.1}TiB", v / TIB)
+    } else if v >= GIB {
+        format!("{:.1}GiB", v / GIB)
+    } else if v >= MIB {
+        format!("{:.1}MiB", v / MIB)
+    } else if v >= KIB {
+        format!("{:.1}KiB", v / KIB)
+    } else {
+        format!("{n}B")
+    }
+}
+
+fn fmt_rate(bytes_per_sec: f64) -> String {
+    const KB: f64 = 1_000.0;
+    const MB: f64 = 1_000_000.0;
+    const GB: f64 = 1_000_000_000.0;
+    if bytes_per_sec >= GB {
+        format!("{:.1}GB", bytes_per_sec / GB)
+    } else if bytes_per_sec >= MB {
+        format!("{:.0}MB", bytes_per_sec / MB)
+    } else if bytes_per_sec >= KB {
+        format!("{:.0}KB", bytes_per_sec / KB)
+    } else {
+        format!("{:.0}B", bytes_per_sec)
+    }
+}
+
+fn fmt_duration(d: Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    if h > 0 {
+        format!("{h}h{m:02}m")
+    } else if m > 0 {
+        format!("{m}m{s:02}s")
+    } else {
+        format!("{s}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fmt_bytes_units() {
+        assert_eq!(fmt_bytes(500), "500B");
+        assert_eq!(fmt_bytes(2048), "2.0KiB");
+        assert_eq!(fmt_bytes(2 * 1024 * 1024), "2.0MiB");
+        assert_eq!(
+            fmt_bytes(3 * 1024 * 1024 * 1024 + 500 * 1024 * 1024),
+            "3.5GiB"
+        );
+    }
+
+    #[test]
+    fn fmt_rate_units() {
+        assert_eq!(fmt_rate(500.0), "500B");
+        assert_eq!(fmt_rate(50_000.0), "50KB");
+        assert_eq!(fmt_rate(51_000_000.0), "51MB");
+    }
+
+    #[test]
+    fn fmt_duration_units() {
+        assert_eq!(fmt_duration(Duration::from_secs(5)), "5s");
+        assert_eq!(fmt_duration(Duration::from_secs(125)), "2m05s");
+        assert_eq!(fmt_duration(Duration::from_secs(3_600 + 600 + 45)), "1h10m");
+    }
+
+    #[test]
+    fn maybe_log_respects_period() {
+        // Tracker with a 60s period; immediate maybe_log shouldn't emit
+        // (period not elapsed), so last_log_at stays unchanged.
+        let mut t = HeartbeatTracker::new(
+            "test",
+            "0x01".to_string(),
+            Some(1_000),
+            ProgressUnit::Bytes,
+            Duration::from_secs(60),
+        );
+        let last_before = t.last_log_at;
+        t.maybe_log(100);
+        assert_eq!(t.last_log_at, last_before);
+        assert_eq!(t.last_log_progress, 0);
+    }
+
+    #[test]
+    fn maybe_log_emits_after_period_elapsed() {
+        // Sub-millisecond period + a short sleep guarantees we cross it.
+        let mut t = HeartbeatTracker::new(
+            "test",
+            "0x01".to_string(),
+            Some(1_000),
+            ProgressUnit::Bytes,
+            Duration::from_micros(100),
+        );
+        let last_before = t.last_log_at;
+        std::thread::sleep(Duration::from_millis(2));
+        t.maybe_log(250);
+        assert!(
+            t.last_log_at > last_before,
+            "last_log_at should advance after the period elapses"
+        );
+        assert_eq!(t.last_log_progress, 250);
+    }
+}


### PR DESCRIPTION
## Summary

Adds periodic INFO heartbeat logs during long-running garbling phases (table upload G8, table eval E8, commitment generate G3/E3) so operators can tell at a glance whether a node is making progress or wedged.

## Approach

- New `HeartbeatTracker` helper in `crates/job/executors/src/progress.rs` with `Bytes` / `Blocks` units and a 30s default period.
- No spawned timer — sessions tick `maybe_log` per chunk, the tracker checks elapsed time and only emits when the period has passed. Cheap on the not-yet-time path.
- Wired into three `CircuitSession` impls:
  - **`TransferSession`** (G8) → `table.upload` (bytes, total = `header.and_gates × 16`)
  - **`CommitmentSession`** (G3 / E3) → `garbling.commit` / `garbling.verify` (gates, total = `header.total_gates()`)
  - **`EvaluationSession`** (E8) → `table.eval` (gates, total = `header.total_gates()`)

## Log format

Emitted on tracing target `mosaic_progress`. Operators filter via `RUST_LOG=mosaic_progress=info` or grep `mosaic_progress` in their log pipeline.

```
table.upload progress id=0xabcdef01 done=<X>/<Y> pct=<Z>% inst=<>/s avg=<>/s elapsed=<> eta=<>
table.eval progress id=0xabcdef01 pct=~<Z>% elapsed=<>
garbling.commit progress id=ckt<N> pct=~<Z>% elapsed=<>
```

`id` is the first 4 bytes of the commitment hash for table phases, or the circuit index for commitment-generate phases. Bytes show throughput + ETA when total is known; block-counted phases show percent + elapsed only (no rate / ETA — gate processing isn't byte-paced).

## Test plan

- [x] Unit tests on the helper: byte/duration/rate formatting, period gating, emit-after-period-elapsed.
- [x] `cargo test --release -p mosaic-job-executors` — 15 / 15 pass.
- [x] `cargo +nightly fmt --all`, `cargo clippy -p mosaic-job-executors --all-targets -- -D warnings` — clean.
- [ ] Manual e2e: observe heartbeats during a real garbling phase, confirm cadence and totals.

## Draft

Open as a draft for review of cadence (30s) + log format + `id=` field choices before promoting.

## Out of scope

- Heartbeat for the evaluator-side bulk receive (E4) — separate pool action surface.
- Metrics export — same data points should later feed a Prometheus surface.
- Configurable period — hardcoded const for v1.