### PR TITLE
net/svc,bin/mosaic: resolve peer DNS lazily, don't crash on NXDOMAIN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -3496,7 +3496,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3553,7 +3553,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4076,7 +4076,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4672,7 +4672,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,6 +2493,7 @@ dependencies = [
  "ark-serialize",
  "blake3",
  "ed25519-dalek",
+ "futures",
  "hex",
  "kanal",
  "mosaic-net-svc-api",

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -284,10 +284,13 @@ impl PeerEntry {
     }
 
     pub(crate) fn to_peer_config(&self) -> Result<PeerConfig> {
-        Ok(PeerConfig::new(
-            self.peer_id()?,
-            parse_socket_addr(&self.addr)?,
-        ))
+        // Address is validated as `host:port` shape but **not** resolved here
+        // — resolution happens at every outbound connection attempt. This
+        // lets mosaic boot cleanly even when a peer's DNS hasn't been
+        // published yet, and lets operators rotate their A records without
+        // requiring restarts on the other side.
+        let (host, port) = parse_host_port(&self.addr)?;
+        Ok(PeerConfig::from_host(self.peer_id()?, host, port))
     }
 }
 
@@ -441,6 +444,44 @@ fn parse_socket_addr(value: &str) -> Result<SocketAddr> {
         .with_context(|| format!("no addresses found for `{value}`"))
 }
 
+/// Split a `host:port` config string into its parts WITHOUT performing DNS
+/// resolution. Accepts IPv4 literals (`127.0.0.1:9000`), bracketed IPv6
+/// literals (`[::1]:9000`), and hostnames (`peer.example.com:9000`). Bare
+/// (unbracketed) IPv6 literals are rejected because the host:port split is
+/// ambiguous — operators must bracket.
+fn parse_host_port(value: &str) -> Result<(String, u16)> {
+    if let Some(rest) = value.strip_prefix('[') {
+        let (host, port) = rest
+            .split_once("]:")
+            .with_context(|| format!("invalid bracketed address `{value}`"))?;
+        if host.is_empty() {
+            bail!("address `{value}` has empty host");
+        }
+        let port = port
+            .parse::<u16>()
+            .with_context(|| format!("invalid port in `{value}`"))?;
+        return Ok((host.to_string(), port));
+    }
+    let (host, port) = value
+        .rsplit_once(':')
+        .with_context(|| format!("address `{value}` must be in `host:port` form"))?;
+    if host.is_empty() {
+        bail!("address `{value}` has empty host");
+    }
+    // Reject bare IPv6: a host portion that itself contains ':' means the
+    // user wrote `2001:db8::1:9000`, which rsplit_once would mis-parse
+    // (the last `:9000` segment is `0` not the intended port).
+    if host.contains(':') {
+        bail!(
+            "address `{value}` looks like a bare IPv6 literal; use bracketed form `[<addr>]:<port>`"
+        );
+    }
+    let port = port
+        .parse::<u16>()
+        .with_context(|| format!("invalid port in `{value}`"))?;
+    Ok((host.to_string(), port))
+}
+
 fn decode_signing_key(value: &str) -> Result<SigningKey> {
     let bytes = decode_exact_hex::<32>(value, "signing key")?;
     Ok(SigningKey::from_bytes(&bytes))
@@ -562,6 +603,37 @@ mod tests {
     use object_store::ClientConfigKey;
 
     use super::*;
+
+    #[test]
+    fn parse_host_port_accepts_ipv4_and_hostname_and_bracketed_ipv6() {
+        assert_eq!(
+            parse_host_port("127.0.0.1:9000").unwrap(),
+            ("127.0.0.1".to_string(), 9000)
+        );
+        assert_eq!(
+            parse_host_port("operator.example.com:9000").unwrap(),
+            ("operator.example.com".to_string(), 9000)
+        );
+        assert_eq!(
+            parse_host_port("[::1]:9000").unwrap(),
+            ("::1".to_string(), 9000)
+        );
+    }
+
+    #[test]
+    fn parse_host_port_rejects_bare_ipv6_empty_host_and_missing_port() {
+        let err = parse_host_port("2001:db8::1:9000").unwrap_err();
+        assert!(err.to_string().contains("bracketed"));
+
+        let err = parse_host_port(":9000").unwrap_err();
+        assert!(err.to_string().contains("empty host"));
+
+        let err = parse_host_port("[]:9000").unwrap_err();
+        assert!(err.to_string().contains("empty host"));
+
+        let err = parse_host_port("operator.example.com").unwrap_err();
+        assert!(err.to_string().contains("host:port"));
+    }
 
     fn sample_config_toml(circuit_path: &Path) -> String {
         format!(

--- a/crates/net/svc-api/src/config.rs
+++ b/crates/net/svc-api/src/config.rs
@@ -14,18 +14,55 @@ use crate::{
 };
 
 /// Configuration for a known peer.
+///
+/// The address is stored as a `host:port` string and resolved on demand at
+/// each outbound connection attempt. This allows mosaic to boot cleanly even
+/// when a peer's DNS hasn't been published yet — resolution failures at
+/// connect-time are treated the same as a connection-refused (fail the
+/// attempt, retry on the reconnect backoff). It also means an operator can
+/// rotate their A record without requiring restarts on the other side.
 #[derive(Debug, Clone)]
 pub struct PeerConfig {
     /// Peer's public key (32-byte Ed25519 public key).
     pub peer_id: PeerId,
-    /// Peer's network address.
-    pub addr: SocketAddr,
+    /// Hostname (or IP literal) where this peer can be reached.
+    pub host: String,
+    /// Port where this peer can be reached.
+    pub port: u16,
 }
 
 impl PeerConfig {
-    /// Create a new peer configuration.
+    /// Create a new peer configuration from an already-resolved address.
+    ///
+    /// Convenience for IP-literal callers (most tests). The hostname stored
+    /// is the IP string form, so on-connect re-resolution is a no-op.
     pub fn new(peer_id: PeerId, addr: SocketAddr) -> Self {
-        Self { peer_id, addr }
+        Self {
+            peer_id,
+            host: addr.ip().to_string(),
+            port: addr.port(),
+        }
+    }
+
+    /// Create a new peer configuration from a hostname and port. The host
+    /// will be resolved at every outbound connection attempt.
+    pub fn from_host(peer_id: PeerId, host: impl Into<String>, port: u16) -> Self {
+        Self {
+            peer_id,
+            host: host.into(),
+            port,
+        }
+    }
+
+    /// `host:port` representation, suitable for `lookup_host`. IPv6 literals
+    /// are emitted in bracketed form so the output round-trips through
+    /// `host:port` parsers without ambiguity.
+    pub fn host_port(&self) -> String {
+        if self.host.contains(':') {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
     }
 }
 
@@ -209,9 +246,12 @@ impl NetServiceConfig {
         self.peers.iter().find(|p| &p.peer_id == peer_id)
     }
 
-    /// Get a peer's address by their ID.
-    pub fn get_peer_addr(&self, peer_id: &PeerId) -> Option<SocketAddr> {
-        self.get_peer(peer_id).map(|p| p.addr)
+    /// Get a peer's `host:port` string by their ID.
+    ///
+    /// Returns the address in `host:port` form for resolution at outbound
+    /// connect time via `tokio::net::lookup_host`.
+    pub fn get_peer_host_port(&self, peer_id: &PeerId) -> Option<String> {
+        self.get_peer(peer_id).map(|p| p.host_port())
     }
 
     /// Get all peer IDs.
@@ -290,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn get_peer_addr_works() {
+    fn get_peer_host_port_works() {
         let config = NetServiceConfig::new(
             test_signing_key(),
             "127.0.0.1:9000".parse().unwrap(),
@@ -301,10 +341,18 @@ mod tests {
         );
 
         assert_eq!(
-            config.get_peer_addr(&test_peer_id(1)),
-            Some("127.0.0.1:9001".parse().unwrap())
+            config.get_peer_host_port(&test_peer_id(1)).as_deref(),
+            Some("127.0.0.1:9001")
         );
-        assert_eq!(config.get_peer_addr(&test_peer_id(2)), None);
+        assert_eq!(config.get_peer_host_port(&test_peer_id(2)), None);
+    }
+
+    #[test]
+    fn from_host_keeps_hostname_for_lazy_resolution() {
+        let peer = PeerConfig::from_host(test_peer_id(1), "operator.example.com", 9000);
+        assert_eq!(peer.host, "operator.example.com");
+        assert_eq!(peer.port, 9000);
+        assert_eq!(peer.host_port(), "operator.example.com:9000");
     }
 
     #[test]

--- a/crates/net/svc/Cargo.toml
+++ b/crates/net/svc/Cargo.toml
@@ -41,6 +41,7 @@ mosaic-net-wire = { path = "../wire" }
 # Utilities
 ahash = "0.8"
 blake3 = "1"
+futures = { workspace = true }
 hex = "0.4"
 tracing = "0.1"
 

--- a/crates/net/svc/src/svc/handlers.rs
+++ b/crates/net/svc/src/svc/handlers.rs
@@ -125,7 +125,7 @@ fn start_outbound_attempt(peer: PeerId, state: &mut ServiceState) {
         return;
     }
 
-    let addr = match state.config.get_peer_addr(&peer) {
+    let host_port = match state.config.get_peer_host_port(&peer) {
         Some(addr) => addr,
         None => return,
     };
@@ -145,7 +145,7 @@ fn start_outbound_attempt(peer: PeerId, state: &mut ServiceState) {
         state.client_config.clone(),
         peer,
         attempt,
-        addr,
+        host_port,
         state.event_tx.clone(),
         state.config.protocol_version,
         state.config.deployment_version.clone(),

--- a/crates/net/svc/src/svc/mod.rs
+++ b/crates/net/svc/src/svc/mod.rs
@@ -286,9 +286,6 @@ async fn run_service_async(
         .map_err(|e| ServiceError::TlsConfig(e.to_string()))?;
     let client_config = apply_client_transport_config(client_config, &config);
 
-    // Signal successful startup now that endpoint + TLS config are created.
-    let _ = startup_tx.send(Ok(())).await;
-
     // Internal event channel for spawned tasks to communicate back to main loop.
     // Unbounded is used to prevent race-resolution liveness from depending on
     // bounded internal backpressure.
@@ -354,23 +351,77 @@ async fn run_service_async(
         "network service started"
     );
 
+    // Build pre-handshake peer-id prediction maps. Best-effort: we try to
+    // resolve each peer's hostname so an inbound connection from a known IP
+    // can be tagged with the likely peer id before TLS confirms. If a peer's
+    // hostname can't be resolved at startup (e.g. its DNS isn't published
+    // yet), we just log and skip — TLS still authenticates inbound
+    // connections, the map is only a hint. The same hostname will be
+    // re-resolved on every outbound attempt, so the peer becomes reachable
+    // as soon as DNS catches up.
+    //
+    // Lookups run in parallel with a short per-peer timeout so startup is
+    // bounded by the slowest single resolver round-trip, not by N×default.
+    // The startup budget is intentionally tighter than the per-reconnect
+    // `CONNECTION_TIMEOUT / 2` DNS budget: at startup we just want the
+    // prediction map, and missing entries are recovered as peers dial in.
+    const STARTUP_DNS_TIMEOUT: Duration = Duration::from_secs(2);
+    let lookups = state.config.peers.iter().map(|peer| {
+        let peer_id = peer.peer_id;
+        let host_port = peer.host_port();
+        async move {
+            // Clone the host_port for `lookup_host` so we can return the
+            // original in the tuple for logging purposes regardless of
+            // outcome.
+            let result = tokio::time::timeout(
+                STARTUP_DNS_TIMEOUT,
+                tokio::net::lookup_host(host_port.clone()),
+            )
+            .await;
+            (peer_id, host_port, result)
+        }
+    });
+    let resolved_peers = futures::future::join_all(lookups).await;
+
     let mut addr_candidates = HashMap::<std::net::SocketAddr, Option<PeerId>>::new();
     let mut port_candidates = HashMap::<u16, Option<PeerId>>::new();
     let mut ip_candidates = HashMap::<std::net::IpAddr, Option<PeerId>>::new();
-    for peer in state.config.peers.iter() {
-        let normalized = tasks::normalize_socket_addr(peer.addr);
+    for (peer_id, host_port, result) in resolved_peers {
+        let resolved = match result {
+            Ok(Ok(mut iter)) => iter.next(),
+            Ok(Err(err)) => {
+                tracing::warn!(
+                    peer = %hex::encode(peer_id),
+                    host_port = %host_port,
+                    %err,
+                    "could not resolve peer at startup; outbound will retry on each reconnect"
+                );
+                None
+            }
+            Err(_) => {
+                tracing::warn!(
+                    peer = %hex::encode(peer_id),
+                    host_port = %host_port,
+                    timeout = ?STARTUP_DNS_TIMEOUT,
+                    "peer DNS lookup timed out at startup; outbound will retry on each reconnect"
+                );
+                None
+            }
+        };
+        let Some(addr) = resolved else { continue };
+        let normalized = tasks::normalize_socket_addr(addr);
         addr_candidates
             .entry(normalized)
             .and_modify(|slot| *slot = None)
-            .or_insert(Some(peer.peer_id));
+            .or_insert(Some(peer_id));
         port_candidates
             .entry(normalized.port())
             .and_modify(|slot| *slot = None)
-            .or_insert(Some(peer.peer_id));
+            .or_insert(Some(peer_id));
         ip_candidates
             .entry(normalized.ip())
             .and_modify(|slot| *slot = None)
-            .or_insert(Some(peer.peer_id));
+            .or_insert(Some(peer_id));
     }
     let peer_by_addr = Arc::new(
         addr_candidates
@@ -390,6 +441,13 @@ async fn run_service_async(
             .filter_map(|(ip, maybe_peer)| maybe_peer.map(|peer| (ip, peer)))
             .collect::<HashMap<_, _>>(),
     );
+
+    // Signal successful startup now that the endpoint, TLS config, and
+    // best-effort peer-prediction maps are all ready. We deliberately wait
+    // until after the DNS lookups so callers of `NetService::new` don't see
+    // it return Ok before the service thread is actually ready to accept
+    // and process commands.
+    let _ = startup_tx.send(Ok(())).await;
 
     // Dedicated accept loop so accept timestamps are captured at source.
     tasks::spawn_accept_loop(

--- a/crates/net/svc/src/svc/tasks.rs
+++ b/crates/net/svc/src/svc/tasks.rs
@@ -509,24 +509,51 @@ pub fn spawn_outbound_connection(
     client_config: quinn::ClientConfig,
     peer: PeerId,
     attempt: OutboundAttempt,
-    addr: std::net::SocketAddr,
+    host_port: String,
     event_tx: UnboundedSender<ServiceEvent>,
     protocol_version: u32,
     deployment_version: Option<String>,
     reduced_circuits: bool,
 ) {
+    let span_host_port = host_port.clone();
     tokio::spawn(async move {
-        tracing::debug!(peer = %hex::encode(peer), addr = %addr, "attempting outbound connection");
+        tracing::debug!(peer = %hex::encode(peer), host_port = %host_port, "attempting outbound connection");
 
         let server_name = overlap_server_name(attempt.overlap_key);
+        // Per-attempt DNS gets a fraction of the overall budget so a slow
+        // resolver can't eat the whole connect window. Phase-distinct error
+        // strings help operator triage (DNS vs connect timeout look the
+        // same on the wire otherwise).
+        // `lookup_host` picks the first record; multi-A-record consistency
+        // across attempts is not guaranteed (resolver order can vary), but
+        // that's pre-existing behavior — peer identity is authenticated by
+        // TLS regardless.
+        let dns_timeout = CONNECTION_TIMEOUT / 2;
         let result = async {
+            let addr = match tokio::time::timeout(
+                dns_timeout,
+                tokio::net::lookup_host(host_port.as_str()),
+            )
+            .await
+            {
+                Ok(Ok(mut iter)) => iter
+                    .next()
+                    .ok_or_else(|| format!("dns returned no addresses for `{host_port}`"))?,
+                Ok(Err(e)) => return Err(format!("dns resolution failed for `{host_port}`: {e}")),
+                Err(_) => {
+                    return Err(format!(
+                        "dns resolution timed out for `{host_port}` after {dns_timeout:?}"
+                    ));
+                }
+            };
+
             let connecting = endpoint
                 .connect_with(client_config, addr, &server_name)
                 .map_err(|e| e.to_string())?;
 
             tokio::time::timeout(CONNECTION_TIMEOUT, connecting)
                 .await
-                .map_err(|_| "connection timed out".to_string())?
+                .map_err(|_| format!("quic connect timed out to {addr}"))?
                 .map_err(|e| e.to_string())
         }
         .await;
@@ -618,7 +645,7 @@ pub fn spawn_outbound_connection(
         "net_svc.outbound_connect",
         peer = %hex::encode(peer),
         attempt_id = attempt.attempt_id,
-        addr = %addr
+        host_port = %span_host_port
     )));
 }
 

--- a/crates/net/svc/tests/integration.rs
+++ b/crates/net/svc/tests/integration.rs
@@ -1401,3 +1401,67 @@ fn version_handshake_incompatible_cache_clears_on_upgraded_reconnect() {
     }
     unreachable!()
 }
+
+// ============================================================================
+// DNS lazy-resolution (issue: mosaic must not crash when a peer's hostname
+// can't be resolved at startup)
+// ============================================================================
+
+#[test]
+fn unresolvable_peer_hostname_does_not_block_startup() {
+    // A's config lists B as a peer at an unresolvable .invalid hostname.
+    // Per RFC 6761, .invalid never resolves, so this exercises the
+    // startup-time NXDOMAIN path without depending on a missing DNS record.
+    //
+    // Expected: NetService::new succeeds within a few seconds (the 2s
+    // per-peer DNS timeout caps the wait, *not* the default resolver
+    // timeout). Wall-clock bound asserts we actually exercised the timeout
+    // path, not a freak resolver hijack returning an IP.
+    init_tracing();
+    for attempt in 0..50 {
+        let port_a = next_port();
+        let key_a = test_key_from_tag(next_key_tag());
+        let addr_a = test_addr(port_a);
+
+        // Synthesize a peer-id for the unresolvable peer.
+        let key_b = test_key_from_tag(next_key_tag());
+        let peer_id_b = peer_id_from_signing_key(&key_b);
+
+        let unresolvable_peer = PeerConfig::from_host(peer_id_b, "no-such-host.invalid", 9999);
+
+        let config_a = NetServiceConfig::new(key_a, addr_a, vec![unresolvable_peer])
+            .with_reconnect_backoff(Duration::from_millis(50));
+
+        let started = std::time::Instant::now();
+        let (handle_a, ctrl_a) = match NetService::new(config_a) {
+            Ok(result) => result,
+            Err(_) if attempt < 49 => continue, // port collision
+            Err(e) => panic!("create net service A: {e}"),
+        };
+        let startup_elapsed = started.elapsed();
+        assert!(
+            startup_elapsed < Duration::from_secs(4),
+            "startup with unresolvable peer took {startup_elapsed:?} (expected <4s — the per-peer DNS timeout is 2s)"
+        );
+
+        // Smoke-test that the service is actually ready to process: issuing
+        // a stream-open request to the unresolvable peer should return an
+        // error rather than wedge. This proves the main loop is running
+        // past the DNS phase.
+        run_async(async {
+            let result = tokio::time::timeout(
+                Duration::from_secs(3),
+                handle_a.open_protocol_stream(peer_id_b, 0),
+            )
+            .await;
+            assert!(
+                matches!(result, Ok(Err(_)) | Err(_)),
+                "expected open_protocol_stream to fail or remain pending, got Ok(Ok(_))"
+            );
+        });
+
+        let _ = shutdown_controller_with_timeout(ctrl_a, Duration::from_secs(2));
+        return;
+    }
+    unreachable!()
+}


### PR DESCRIPTION
## Summary

Fixes a testnet startup crash: mosaic exited at boot if any peer's hostname returned NXDOMAIN, so every operator's node crash-looped until the slowest external operator published their DNS A record. Uncoordinated rollouts couldn't make progress.

Switches peer addresses from eagerly-resolved `SocketAddr` to a host+port pair that's re-resolved on every outbound connection attempt. DNS coming online (or being rotated) is picked up naturally without coordinated restarts.

## Behavior changes

- **Startup**: `NetService::new` no longer requires every peer hostname to resolve. Unresolved peers log a warn and are skipped from the pre-handshake peer-id prediction map (TLS still authenticates inbound regardless). Startup-ready signal is held until best-effort DNS lookups complete, so callers don't see `Ok` return before the service can actually process commands. Lookups run in parallel with a 2s per-peer cap.
- **Outbound attempts**: each attempt re-resolves the hostname before connecting. NXDOMAIN at connect time fails the attempt and falls through to the normal reconnect-backoff schedule. DNS budget is `CONNECTION_TIMEOUT / 2` (2.5s), QUIC connect budget is `CONNECTION_TIMEOUT` (5s); errors are phase-tagged for triage.
- **IP rotation**: an operator changing their A record is picked up on the next outbound attempt without restart.

## Config surface

`PeerConfig::addr: SocketAddr` is replaced with `host: String, port: u16`. The convenience constructor `new(peer_id, SocketAddr)` is kept so tests using IP literals didn't need to change. New `from_host(peer_id, host, port)` is the production path. `NetServiceConfig::get_peer_addr` → `get_peer_host_port`.

`bin/mosaic`'s TOML field shape is unchanged. The binary's `parse_host_port` validates the `host:port` shape without touching DNS, and rejects:
- bare IPv6 literals (require `[<addr>]:<port>`)
- empty hosts (`:9000`, `[]:9000`)
- missing ports (`operator.example.com`)

`PeerConfig::host_port()` emits IPv6 in bracketed form so it round-trips through the parser cleanly.

## Test plan

- [x] `cargo test --release -p mosaic-net-svc-api -p mosaic-net-svc -p mosaic` — all pass
- [x] `cargo +nightly fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] New: `unresolvable_peer_hostname_does_not_block_startup` integration test using `.invalid` TLD (RFC 6761) — asserts startup completes <4s and `open_protocol_stream` fails-not-wedges
- [x] New: `parse_host_port_accepts_*` and `parse_host_port_rejects_*` unit tests on the binary's parser
- [x] New: `from_host_keeps_hostname_for_lazy_resolution`, `get_peer_host_port_works` unit tests on the API
- [ ] Manual: boot a testnet node with one peer's DNS unpublished, confirm no crash; publish DNS, confirm the peer connects without restart

## Notes to reviewers

- Re-resolution on every attempt means an extra `getaddrinfo` per reconnect cycle. The OS resolver caches; under steady state with a healthy upstream this is negligible.
- Pre-handshake peer-id prediction is only a hint — TLS authenticates the peer identity, so partial maps (some peers unresolvable at startup) are correct, just less informative for logs.
- Multi-A-record consistency across attempts isn't guaranteed (resolver order can vary). Pre-existing behavior; TLS authenticates regardless.