### PR TITLE
feat: add vkhash to getCircuitDefs RPC response

### DIFF
--- a/crates/rpc/types/src/circuit.rs
+++ b/crates/rpc/types/src/circuit.rs
@@ -15,6 +15,10 @@ pub struct RpcCircuitInfoEntry {
     pub name: String,
     /// commitment to check circuit integrity
     pub commitment: RpcByte32,
+    /// vk hash the circuit was generated for, taken from the v5c header memo
+    /// field (all-zero for circuits generated without a vk, e.g. the test
+    /// circuit).
+    pub vk_hash: RpcByte32,
     /// additional metadata about the circuit
     pub info: RpcCircuitInfo,
 }
@@ -38,6 +42,7 @@ impl RpcCircuitInfoEntry {
         Ok(Self {
             name,
             commitment: header.checksum.into(),
+            vk_hash: header.memo.into(),
             info: RpcCircuitInfo {
                 total_size_bytes: file_size,
                 total_gates: header.total_gates(),


### PR DESCRIPTION
## Description

This PR adds the memo field of the ckt in the response field of the `getCircuitDefs` RPC so that bridge can query and match against the value it expects.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

## AI Disclosure
AI was used for exploring the repo to see if any more change was needed.

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] If this PR touches the wire-visible protocol surface — message types in `crates/cac/types`, garbler/evaluator STF semantics peers depend on in `crates/cac/protocol`, or net-svc framing/priorities — I bumped `PROTOCOL_VERSION` in `crates/net/svc-api/src/handshake.rs`.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
