### PR TITLE
Block deposits on consumed tablesets

### DIFF
--- a/crates/cac/protocol/src/evaluator/stf.rs
+++ b/crates/cac/protocol/src/evaluator/stf.rs
@@ -25,9 +25,9 @@ use crate::{
     common::{derive_stage_seed, get_eval_commitments, get_eval_indices},
 };
 
-// Note: deposit operations are accepted in any post-setup state (SetupComplete,
-// EvaluatingTables, SetupConsumed), not only SetupComplete. This allows new deposits
-// to be created on a tableset even after the setup has been consumed by a withdrawal.
+// Note: deposit initialization/progression is accepted while the setup is active
+// (SetupComplete or EvaluatingTables), but not after SetupConsumed because the
+// consumed setup cannot support a later disputed withdrawal.
 
 // ============================================================================
 // External event handler
@@ -96,7 +96,7 @@ pub(crate) async fn handle_event<S: StateMut>(
                 deposit_inputs,
             },
         ) => match root_state.step {
-            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. } => {
+            Step::SetupComplete | Step::EvaluatingTables { .. } => {
                 if state
                     .get_deposit(&deposit_id)
                     .await
@@ -144,7 +144,7 @@ pub(crate) async fn handle_event<S: StateMut>(
             _ => return Err(SMError::UnexpectedInput),
         },
         Input::DepositUndisputedWithdrawal(deposit_id) => match root_state.step {
-            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. } => {
+            Step::SetupComplete | Step::EvaluatingTables { .. } => {
                 let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                 match deposit_state.step {
@@ -397,9 +397,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
         }
         ActionResult::DepositAdaptorsGenerated(deposit_id, deposit_adaptors) => {
             match root_state.step {
-                Step::SetupComplete
-                | Step::EvaluatingTables { .. }
-                | Step::SetupConsumed { .. } => {
+                Step::SetupComplete | Step::EvaluatingTables { .. } => {
                     let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                     match &mut deposit_state.step {
@@ -457,7 +455,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
             chunk_idx,
             withdrawal_adaptor_chunk,
         ) => match root_state.step {
-            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. } => {
+            Step::SetupComplete | Step::EvaluatingTables { .. } => {
                 let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                 match &mut deposit_state.step {
@@ -522,7 +520,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
             _ => return Err(SMError::UnexpectedInput),
         },
         ActionResult::DepositAdaptorChunkSent(deposit_id) => match root_state.step {
-            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. } => {
+            Step::SetupComplete | Step::EvaluatingTables { .. } => {
                 let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                 match &mut deposit_state.step {

--- a/crates/cac/protocol/src/garbler/stf.rs
+++ b/crates/cac/protocol/src/garbler/stf.rs
@@ -22,9 +22,9 @@ use crate::{
     common::{derive_stage_seed, get_eval_commitments, get_eval_indices},
 };
 
-// Note: deposit operations are accepted in any post-setup state (SetupComplete,
-// CompletingAdaptors, SetupConsumed), not only SetupComplete. This allows new deposits
-// to be created on a tableset even after the setup has been consumed by a withdrawal.
+// Note: deposit initialization/progression is accepted while the setup is active
+// (SetupComplete or CompletingAdaptors), but not after SetupConsumed because the
+// consumed setup cannot support a later disputed withdrawal.
 
 // ============================================================================
 // External event handler
@@ -229,7 +229,7 @@ pub(crate) async fn handle_event<S: StateMut>(
                 deposit_inputs,
             },
         ) => match root_state.step {
-            Step::SetupComplete | Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. } => {
+            Step::SetupComplete | Step::CompletingAdaptors { .. } => {
                 if state
                     .get_deposit(&deposit_id)
                     .await
@@ -275,7 +275,7 @@ pub(crate) async fn handle_event<S: StateMut>(
             .await?;
         }
         Input::DepositUndisputedWithdrawal(deposit_id) => match root_state.step {
-            Step::SetupComplete | Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. } => {
+            Step::SetupComplete | Step::CompletingAdaptors { .. } => {
                 let mut deposit_state = require_deposit(state, &deposit_id).await?;
 
                 match &mut deposit_state.step {
@@ -537,9 +537,7 @@ pub(crate) async fn handle_action_result<S: StateMut>(
 
         ActionResult::DepositAdaptorVerificationResult(deposit_id, verification_success) => {
             match root_state.step {
-                Step::SetupComplete
-                | Step::CompletingAdaptors { .. }
-                | Step::SetupConsumed { .. } => {
+                Step::SetupComplete | Step::CompletingAdaptors { .. } => {
                     let mut deposit_state = require_deposit(state, &deposit_id).await?;
                     match &mut deposit_state.step {
                         DepositStep::VerifyingAdaptors => {
@@ -779,7 +777,7 @@ async fn handle_recv_deposit_adaptor_msg_chunk<S: StateMut>(
     actions: &mut ActionContainer,
 ) -> SMResult<()> {
     match &mut root_state.step {
-        Step::SetupComplete | Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. } => {
+        Step::SetupComplete | Step::CompletingAdaptors { .. } => {
             if adaptor_msg_chunk.deposit_id != deposit_id {
                 return Err(SMError::invalid_input_data());
             }

--- a/crates/rpc/service/src/default.rs
+++ b/crates/rpc/service/src/default.rs
@@ -323,7 +323,7 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for Defa
         use garbler::Step;
         if !matches!(
             statemachine.step,
-            Step::SetupComplete | Step::CompletingAdaptors { .. } | Step::SetupConsumed { .. }
+            Step::SetupComplete | Step::CompletingAdaptors { .. }
         ) {
             return Err(ServiceError::InvalidInputForState(
                 statemachine.step.step_name().into(),
@@ -370,7 +370,7 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for Defa
         use evaluator::Step;
         if !matches!(
             statemachine.step,
-            Step::SetupComplete | Step::EvaluatingTables { .. } | Step::SetupConsumed { .. }
+            Step::SetupComplete | Step::EvaluatingTables { .. }
         ) {
             return Err(ServiceError::InvalidInputForState(
                 statemachine.step.step_name().into(),
@@ -491,9 +491,7 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for Defa
                     use garbler::Step;
                     if !matches!(
                         statemachine.step,
-                        Step::SetupComplete
-                            | Step::CompletingAdaptors { .. }
-                            | Step::SetupConsumed { .. }
+                        Step::SetupComplete | Step::CompletingAdaptors { .. }
                     ) {
                         return Err(ServiceError::InvalidInputForState(
                             statemachine.step.step_name().into(),
@@ -530,9 +528,7 @@ impl<S: StorageProvider, R: CryptoRng + Rng + Send + 'static> MosaicApi for Defa
                     use evaluator::Step;
                     if !matches!(
                         statemachine.step,
-                        Step::SetupComplete
-                            | Step::EvaluatingTables { .. }
-                            | Step::SetupConsumed { .. }
+                        Step::SetupComplete | Step::EvaluatingTables { .. }
                     ) {
                         return Err(ServiceError::InvalidInputForState(
                             statemachine.step.step_name().into(),

--- a/crates/rpc/service/src/tests.rs
+++ b/crates/rpc/service/src/tests.rs
@@ -618,7 +618,7 @@ async fn init_evaluator_deposit_dispatches_correct_input() {
 }
 
 // ---------------------------------------------------------------------------
-// Group 5b: deposit init accepted in post-setup states
+// Group 5b: deposit init in post-setup states
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -649,7 +649,7 @@ async fn init_garbler_deposit_accepts_completing_adaptors() {
 }
 
 #[tokio::test]
-async fn init_garbler_deposit_accepts_setup_consumed() {
+async fn init_garbler_deposit_rejects_setup_consumed() {
     let h = TestHarness::new();
     h.setup_garbler(garbler::Step::SetupConsumed {
         deposit_id: test_deposit_id(99),
@@ -666,13 +666,16 @@ async fn init_garbler_deposit_accepts_setup_consumed() {
         deposit_inputs: [0u8; N_DEPOSIT_INPUT_WIRES],
     };
 
-    h.api
+    let err = h
+        .api
         .init_garbler_deposit(&h.garbler_sm_id(), &deposit_id, init)
         .await
-        .unwrap();
+        .unwrap_err();
 
-    let cmd = h.recv_command().await;
-    assert!(matches!(cmd.kind, SmCommandKind::DepositInit { .. }));
+    assert!(
+        matches!(err, ServiceError::InvalidInputForState(_)),
+        "expected InvalidInputForState, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -702,7 +705,7 @@ async fn init_evaluator_deposit_accepts_evaluating_tables() {
 }
 
 #[tokio::test]
-async fn init_evaluator_deposit_accepts_setup_consumed() {
+async fn init_evaluator_deposit_rejects_setup_consumed() {
     let h = TestHarness::new();
     h.setup_evaluator(evaluator::Step::SetupConsumed {
         deposit_id: test_deposit_id(99),
@@ -716,13 +719,16 @@ async fn init_evaluator_deposit_accepts_setup_consumed() {
         deposit_inputs: [0u8; N_DEPOSIT_INPUT_WIRES],
     };
 
-    h.api
+    let err = h
+        .api
         .init_evaluator_deposit(&h.evaluator_sm_id(), &deposit_id, init)
         .await
-        .unwrap();
+        .unwrap_err();
 
-    let cmd = h.recv_command().await;
-    assert!(matches!(cmd.kind, SmCommandKind::DepositInit { .. }));
+    assert!(
+        matches!(err, ServiceError::InvalidInputForState(_)),
+        "expected InvalidInputForState, got {err:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- A change allowed new deposits to be initialized and progressed to `DepositReady` on a tableset in `SetupConsumed`, but the disputed-withdrawal path remained gated to `SetupComplete`, leaving such deposits without a dispute/recovery flow and breaking liveness.
- The intent of this PR is to prevent deposits from being created or advanced on a consumed tableset so every `DepositReady` retains a usable disputed-withdrawal path.

### Description

- Restrict RPC deposit entry points in `crates/rpc/service/src/default.rs` so `init_garbler_deposit` and `init_evaluator_deposit` (and relevant withdrawal gating) accept only active post-setup states (`SetupComplete` and `CompletingAdaptors`/`EvaluatingTables` as appropriate) and reject `SetupConsumed`.
- Update garbler STF in `crates/cac/protocol/src/garbler/stf.rs` to remove `SetupConsumed` from match arms that handled `DepositInit`, adaptor-chunk receipt, undisputed withdrawal marking, and adaptor verification so deposits cannot progress when the root step is `SetupConsumed`.
- Update evaluator STF in `crates/cac/protocol/src/evaluator/stf.rs` to remove `SetupConsumed` from deposit init, adaptor generation/chunk handling, and related action-result match arms so evaluator-side deposit progression is similarly blocked after consumption.
- Update RPC unit tests in `crates/rpc/service/src/tests.rs` to assert that deposit initialization on `SetupConsumed` is rejected on both garbler and evaluator paths while preserving acceptance for active post-setup states.

### Testing

- Ran code formatting with `cargo fmt` which completed successfully.
- Ran the updated RPC tests with `cargo test -p mosaic-rpc-service setup_consumed -- --nocapture` and they passed (`init_garbler_deposit_rejects_setup_consumed` and `init_evaluator_deposit_rejects_setup_consumed` succeeded).
- Ran the protocol deposit tests with `cargo test -p mosaic-cac-protocol deposit -- --nocapture` and they passed (protocol deposit-related unit tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4706a31d74832cb37e1483717fb9e1)