### PR TITLE
feat: cooperative scheduler hints for garbling table transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,10 +2557,12 @@ version = "0.1.0"
 dependencies = [
  "ckt-fmtv5-types",
  "fasm",
+ "hex",
  "kanal",
  "monoio",
  "mosaic-cac-types",
  "mosaic-job-api",
+ "mosaic-net-client",
  "mosaic-net-svc-api",
  "parking_lot",
  "tracing",

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -83,11 +83,13 @@ impl MosaicConfig {
                 threads: self.job_scheduler.light.threads,
                 concurrency_per_worker: self.job_scheduler.light.concurrency_per_worker,
                 priority_queue: false,
+                max_boost_slots: Some(64),
             },
             heavy: PoolConfig {
                 threads: self.job_scheduler.heavy.threads,
                 concurrency_per_worker: self.job_scheduler.heavy.concurrency_per_worker,
                 priority_queue: true,
+                max_boost_slots: None,
             },
             garbling: GarblingConfig {
                 worker_threads: self.job_scheduler.garbling.worker_threads,

--- a/bin/mosaic/src/main.rs
+++ b/bin/mosaic/src/main.rs
@@ -222,8 +222,12 @@ where
         table_store,
         config.circuit.path.clone(),
     );
-    let (job_scheduler, job_handle) =
-        JobScheduler::new(config.build_job_scheduler_config(), job_executor);
+    let hint_rx = net_client.handle().hint_streams().clone();
+    let (job_scheduler, job_handle) = JobScheduler::new(
+        config.build_job_scheduler_config(),
+        job_executor,
+        Some(hint_rx),
+    );
     let job_scheduler_controller = job_scheduler.run();
 
     let (sm_executor, sm_executor_handle) = SmExecutor::new(

--- a/crates/job/api/src/hint.rs
+++ b/crates/job/api/src/hint.rs
@@ -1,0 +1,59 @@
+//! Scheduler hint identifiers.
+//!
+//! Hints are best-effort scheduler-to-scheduler messages that let a sender
+//! advise a receiver's scheduler that a specific piece of work is about to
+//! arrive, so the receiver can promote the matching job to the front of its
+//! queue. See the cooperative-scheduling design doc for the rationale.
+//!
+//! The queue-layer treats [`HintKey`] as an opaque `Hash + Eq` identifier;
+//! it does not interpret the discriminant or payload. The wire-level
+//! `SchedulerMessage` types in `mosaic-net-client` are responsible for
+//! building `HintKey` values from typed hint variants.
+
+use mosaic_net_svc_api::PeerId;
+
+/// Identifier used to route a scheduler hint to a matching queued job.
+///
+/// A hint fires from one peer's scheduler at another; the `peer` field
+/// carries the identity of the *sender* (i.e. "peer X told me they're about
+/// to send Y"). The receiver's scheduler builds the same [`HintKey`] at
+/// job-submission time and stores it alongside the job so incoming hints
+/// can locate the corresponding entry in O(1).
+///
+/// `kind` discriminates the hint family (e.g. `HintKind::TRANSFER_STARTING`).
+/// `payload` is family-specific — typically a hash-like identifier such as
+/// a garbling-table commitment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HintKey {
+    /// Identity of the peer this hint is *from* / *for*.
+    pub peer: PeerId,
+    /// Discriminates the hint family. See [`HintKind`] for defined values.
+    pub kind: u8,
+    /// Family-specific identifier.
+    pub payload: [u8; 32],
+}
+
+impl HintKey {
+    /// Construct a new hint key.
+    pub fn new(peer: PeerId, kind: u8, payload: [u8; 32]) -> Self {
+        Self {
+            peer,
+            kind,
+            payload,
+        }
+    }
+}
+
+/// Numeric discriminants for known hint families.
+///
+/// New families are added by allocating a new constant. Values are stable
+/// across mosaic versions (hints are advisory and best-effort; forward
+/// compatibility is maintained by receivers ignoring unknown kinds).
+#[derive(Debug)]
+pub struct HintKind;
+
+impl HintKind {
+    /// Sender is about to open a bulk stream to transfer a garbling table.
+    /// Payload: the 32-byte commitment hash.
+    pub const TRANSFER_STARTING: u8 = 1;
+}

--- a/crates/job/api/src/hint.rs
+++ b/crates/job/api/src/hint.rs
@@ -12,6 +12,18 @@
 
 use mosaic_net_svc_api::PeerId;
 
+/// Family of scheduler hint.
+///
+/// New variants are added at the tail. Wire-side `SchedulerMessage` types
+/// map their variants onto these at receive time; unknown wire tags never
+/// construct a [`HintKind`], so the enum stays closed at the queue layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HintKind {
+    /// Sender is about to open a bulk stream to transfer a garbling table.
+    /// Payload: the 32-byte commitment hash.
+    TransferStarting,
+}
+
 /// Identifier used to route a scheduler hint to a matching queued job.
 ///
 /// A hint fires from one peer's scheduler at another; the `peer` field
@@ -20,40 +32,25 @@ use mosaic_net_svc_api::PeerId;
 /// job-submission time and stores it alongside the job so incoming hints
 /// can locate the corresponding entry in O(1).
 ///
-/// `kind` discriminates the hint family (e.g. `HintKind::TRANSFER_STARTING`).
-/// `payload` is family-specific — typically a hash-like identifier such as
-/// a garbling-table commitment.
+/// `kind` discriminates the hint family; `payload` is family-specific —
+/// typically a hash-like identifier such as a garbling-table commitment.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct HintKey {
     /// Identity of the peer this hint is *from* / *for*.
     pub peer: PeerId,
-    /// Discriminates the hint family. See [`HintKind`] for defined values.
-    pub kind: u8,
+    /// Discriminates the hint family.
+    pub kind: HintKind,
     /// Family-specific identifier.
     pub payload: [u8; 32],
 }
 
 impl HintKey {
     /// Construct a new hint key.
-    pub fn new(peer: PeerId, kind: u8, payload: [u8; 32]) -> Self {
+    pub fn new(peer: PeerId, kind: HintKind, payload: [u8; 32]) -> Self {
         Self {
             peer,
             kind,
             payload,
         }
     }
-}
-
-/// Numeric discriminants for known hint families.
-///
-/// New families are added by allocating a new constant. Values are stable
-/// across mosaic versions (hints are advisory and best-effort; forward
-/// compatibility is maintained by receivers ignoring unknown kinds).
-#[derive(Debug)]
-pub struct HintKind;
-
-impl HintKind {
-    /// Sender is about to open a bulk stream to transfer a garbling table.
-    /// Payload: the 32-byte commitment hash.
-    pub const TRANSFER_STARTING: u8 = 1;
 }

--- a/crates/job/api/src/lib.rs
+++ b/crates/job/api/src/lib.rs
@@ -33,9 +33,12 @@
 //! for retry on the next pass. No action is ever silently dropped.
 
 mod handle;
+mod hint;
 mod submission;
 
 use std::{future::Future, pin::Pin, sync::Arc};
+
+pub use hint::{HintKey, HintKind};
 
 /// Return type for [`SessionFactory::create_session`].
 ///

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -39,12 +39,14 @@ const BULK_OPEN_WARN_AFTER: Duration = Duration::from_secs(5);
 /// How long the evaluator waits for the sender's bulk stream to appear
 /// after registering the expectation and sending the `TableTransferRequest`.
 ///
-/// Kept short because the sender fires a `TransferStarting` scheduler hint
-/// on the high-priority hint stream immediately before opening the bulk
-/// stream (see `garbler::begin_table_transfer`), so this timeout only needs
-/// to cover the hint→open→arrival gap plus one scheduler tick — not the
-/// sender's full queue-latency budget.
-const BULK_OPEN_TIMEOUT: Duration = Duration::from_secs(10);
+/// Sized to cover the sender-side queue latency: the sender's
+/// `TransferGarblingTable` action may wait in its scheduler for up to
+/// tens of seconds under load before `begin_table_transfer` runs. The
+/// `TransferStarting` scheduler hint (see `garbler::begin_table_transfer`)
+/// only fires once the sender's action is already executing, so the hint
+/// tightens the sender-ready-to-receiver-ready gap but does NOT cover the
+/// upstream queue wait — the timeout still has to.
+const BULK_OPEN_TIMEOUT: Duration = Duration::from_secs(30);
 const BULK_READ_WARN_AFTER: Duration = Duration::from_secs(5);
 const BULK_READ_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -36,7 +36,15 @@ use crate::{
 };
 
 const BULK_OPEN_WARN_AFTER: Duration = Duration::from_secs(5);
-const BULK_OPEN_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long the evaluator waits for the sender's bulk stream to appear
+/// after registering the expectation and sending the `TableTransferRequest`.
+///
+/// Kept short because the sender fires a `TransferStarting` scheduler hint
+/// on the high-priority hint stream immediately before opening the bulk
+/// stream (see `garbler::begin_table_transfer`), so this timeout only needs
+/// to cover the hint→open→arrival gap plus one scheduler tick — not the
+/// sender's full queue-latency budget.
+const BULK_OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 const BULK_READ_WARN_AFTER: Duration = Duration::from_secs(5);
 const BULK_READ_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -597,20 +597,22 @@ pub(crate) async fn setup_transfer_session<SP: StorageProvider, TS: TableStore>(
         Ok(()) => Ok(()),
         Err(e) => Err(format!("{e:?}")),
     });
-    let delay = futures_timer::Delay::new(SEND_HINT_TIMEOUT).map(|_| Err("timed out".to_string()));
+    let delay = futures_timer::Delay::new(SEND_HINT_TIMEOUT)
+        .map(|_| Err::<(), String>("timed out".to_string()));
     pin_mut!(send);
     pin_mut!(delay);
-    match select(send, delay).await {
-        Either::Left((Ok(()), _)) => {}
-        Either::Left((Err(e), _)) | Either::Right((Err(e), _)) => {
-            tracing::debug!(peer = ?peer_id, error = %e, "scheduler hint send failed or timed out; proceeding");
-        }
-        Either::Right((Ok(()), _)) => {}
+    let hint_delivered = matches!(select(send, delay).await, Either::Left((Ok(()), _)));
+    if !hint_delivered {
+        tracing::debug!(peer = ?peer_id, "scheduler hint send failed or timed out; proceeding");
     }
     // Small gap between the hint and the bulk open so the peer's scheduler
     // has a chance to promote before the bulk stream lands on their net-svc.
-    // See design doc for the race analysis.
-    futures_timer::Delay::new(std::time::Duration::from_millis(5)).await;
+    // See design doc for the race analysis. Only pay this on successful
+    // hint delivery — if the hint timed out, the peer never got the hint
+    // to act on and the sleep would just be dead weight per retry.
+    if hint_delivered {
+        futures_timer::Delay::new(std::time::Duration::from_millis(5)).await;
+    }
 
     // If the bulk stream open or transfer fails for any reason,
     // the scheduler retries on the next pass.

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -582,6 +582,21 @@ pub(crate) async fn setup_transfer_session<SP: StorageProvider, TS: TableStore>(
         .try_into()
         .expect("commitment is 32 bytes");
 
+    // Cooperative-scheduling hint: tell the peer we're about to send this
+    // table so their scheduler can promote the matching
+    // `ReceiveGarblingTable` job. Best-effort; failure just falls back to
+    // the FIFO ordering everyone had before.
+    let hint = mosaic_net_client::SchedulerMessage::TransferStarting {
+        commitment: identifier,
+    };
+    if let Err(e) = ctx.net_client.send_hint(*peer_id, &hint).await {
+        tracing::debug!(peer = ?peer_id, error = ?e, "scheduler hint send failed; proceeding");
+    }
+    // Small gap between the hint and the bulk open so the peer's scheduler
+    // has a chance to promote before the bulk stream lands on their net-svc.
+    // See design doc for the race analysis.
+    futures_timer::Delay::new(std::time::Duration::from_millis(5)).await;
+
     // If the bulk stream open or transfer fails for any reason,
     // the scheduler retries on the next pass.
 

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -584,13 +584,28 @@ pub(crate) async fn setup_transfer_session<SP: StorageProvider, TS: TableStore>(
 
     // Cooperative-scheduling hint: tell the peer we're about to send this
     // table so their scheduler can promote the matching
-    // `ReceiveGarblingTable` job. Best-effort; failure just falls back to
-    // the FIFO ordering everyone had before.
+    // `ReceiveGarblingTable` job. Best-effort — bounded by a short timeout
+    // and its failure never blocks the bulk open. This preserves the
+    // "delivery failure → no regression vs pre-hint FIFO" contract:
+    // without the cap, a stalled hint-stream open (e.g. peer reconnecting)
+    // would wedge the transfer path.
+    const SEND_HINT_TIMEOUT: Duration = Duration::from_millis(500);
     let hint = mosaic_net_client::SchedulerMessage::TransferStarting {
         commitment: identifier,
     };
-    if let Err(e) = ctx.net_client.send_hint(*peer_id, &hint).await {
-        tracing::debug!(peer = ?peer_id, error = ?e, "scheduler hint send failed; proceeding");
+    let send = ctx.net_client.send_hint(*peer_id, &hint).map(|r| match r {
+        Ok(()) => Ok(()),
+        Err(e) => Err(format!("{e:?}")),
+    });
+    let delay = futures_timer::Delay::new(SEND_HINT_TIMEOUT).map(|_| Err("timed out".to_string()));
+    pin_mut!(send);
+    pin_mut!(delay);
+    match select(send, delay).await {
+        Either::Left((Ok(()), _)) => {}
+        Either::Left((Err(e), _)) | Either::Right((Err(e), _)) => {
+            tracing::debug!(peer = ?peer_id, error = %e, "scheduler hint send failed or timed out; proceeding");
+        }
+        Either::Right((Ok(()), _)) => {}
     }
     // Small gap between the hint and the bulk open so the peer's scheduler
     // has a chance to promote before the bulk stream lands on their net-svc.

--- a/crates/job/scheduler/Cargo.toml
+++ b/crates/job/scheduler/Cargo.toml
@@ -13,10 +13,12 @@ keywords.workspace = true
 [dependencies]
 mosaic-cac-types.workspace = true
 mosaic-job-api.workspace = true
+mosaic-net-client.workspace = true
 mosaic-net-svc-api.workspace = true
 
 ckt-fmtv5-types.workspace = true
 fasm.workspace = true
+hex = "0.4"
 kanal = "0.1.1"
 monoio = { version = "0.2", features = ["sync"] }
 parking_lot = "0.12"

--- a/crates/job/scheduler/src/pool/mod.rs
+++ b/crates/job/scheduler/src/pool/mod.rs
@@ -11,10 +11,10 @@ pub(crate) mod worker;
 
 use std::sync::Arc;
 
-use mosaic_job_api::{ExecuteEvaluatorJob, ExecuteGarblerJob, JobCompletion};
+use mosaic_job_api::{ExecuteEvaluatorJob, ExecuteGarblerJob, HintKey, JobCompletion};
 
 use self::{
-    queue::JobQueue,
+    queue::{BoostConfig, JobQueue},
     worker::{Worker, WorkerJob},
 };
 use crate::{SchedulerFault, priority::Priority};
@@ -30,6 +30,9 @@ pub(crate) struct PoolJob {
     pub job: WorkerJob,
     /// Number of times this job has been retried due to transient failures.
     pub attempts: u32,
+    /// Hint key registered at submission time, if any. Preserved across
+    /// retries so a re-queued job stays boostable via the same key.
+    pub hint_key: Option<HintKey>,
 }
 
 impl std::fmt::Debug for PoolJob {
@@ -49,6 +52,12 @@ pub struct PoolConfig {
     pub concurrency_per_worker: usize,
     /// Whether to use priority ordering when dequeuing.
     pub priority_queue: bool,
+    /// Optional maximum number of jobs that can be simultaneously boosted
+    /// via `SchedulerHint` messages. Only meaningful when `priority_queue`
+    /// is false (FIFO mode). `None` disables the boost mechanism. When
+    /// the boost queue is full, additional hints are dropped and the
+    /// corresponding jobs run in normal FIFO order.
+    pub max_boost_slots: Option<usize>,
 }
 
 impl Default for PoolConfig {
@@ -57,6 +66,7 @@ impl Default for PoolConfig {
             threads: 1,
             concurrency_per_worker: 8,
             priority_queue: false,
+            max_boost_slots: None,
         }
     }
 }
@@ -93,7 +103,10 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobThreadPool<D> {
         completion_tx: kanal::AsyncSender<JobCompletion>,
         fault_tx: kanal::AsyncSender<SchedulerFault>,
     ) -> Self {
-        let queue = Arc::new(JobQueue::new(config.priority_queue));
+        let boost = config
+            .max_boost_slots
+            .map(|max_slots| BoostConfig { max_slots });
+        let queue = Arc::new(JobQueue::new(config.priority_queue, boost));
 
         let workers: Vec<Worker<D>> = (0..config.threads)
             .map(|id| {
@@ -113,14 +126,32 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobThreadPool<D> {
 
     /// Submit a job to the pool.
     ///
-    /// The job is placed in the shared queue. The next idle worker will pull
-    /// it automatically.
-    pub(crate) fn submit(&self, priority: Priority, job: WorkerJob) {
-        self.queue.push(PoolJob {
-            priority,
-            job,
-            attempts: 0,
-        });
+    /// `hint_key`, if present, registers the job in the queue's hint index
+    /// so a subsequent [`apply_hint`](Self::apply_hint) with the same key
+    /// can promote the job to the boost list. Ignored on priority-mode
+    /// pools.
+    ///
+    /// The job is placed in the shared queue. The next idle worker will
+    /// pull it automatically.
+    pub(crate) fn submit(&self, priority: Priority, job: WorkerJob, hint_key: Option<HintKey>) {
+        self.queue.push(
+            PoolJob {
+                priority,
+                job,
+                attempts: 0,
+                hint_key: hint_key.clone(),
+            },
+            hint_key,
+        );
+    }
+
+    /// Try to promote a queued job matching `key` to the boost list tail.
+    ///
+    /// Returns `true` if a match was found and the job was promoted, `false`
+    /// otherwise (no match, priority mode, or boost queue at cap).
+    #[allow(dead_code)] // Wired up by the hint-receiver plumbing.
+    pub(crate) fn apply_hint(&self, key: &HintKey) -> bool {
+        self.queue.apply_hint(key)
     }
 
     /// Number of jobs waiting in the queue (not yet pulled by a worker).

--- a/crates/job/scheduler/src/pool/queue.rs
+++ b/crates/job/scheduler/src/pool/queue.rs
@@ -1,82 +1,129 @@
-//! Priority-aware job queue.
+//! Priority-aware job queue with optional hint-based promotion.
 //!
 //! Supports two modes:
-//! - **FIFO**: Simple first-in first-out (light pool)
-//! - **Priority**: Drains Critical → High → Normal (heavy pool)
+//! - **FIFO with boost** (light pool): default first-in first-out ordering, with an optional
+//!   "boost" queue that drains first. Jobs are boosted by [`apply_hint`](JobQueue::apply_hint) — an
+//!   incoming [`HintKey`](mosaic_job_api::HintKey) looks up a matching queued job in O(1) and moves
+//!   it to the boost queue's tail (unless the boost queue is at its configured cap, in which case
+//!   the hint is dropped).
+//! - **Priority** (heavy pool): drains Critical → High → Normal. Hints are not supported in
+//!   priority mode.
 //!
-//! Multiple workers can concurrently call [`pop`](JobQueue::pop) — each job is
-//! delivered to exactly one worker. Workers block asynchronously when the queue
-//! is empty and wake on the next push.
+//! The FIFO backing store is a slot-based intrusive doubly-linked list with
+//! a `HashMap<HintKey, SlotId>` index, so both `push` at the tail and
+//! `apply_hint` promotion are O(1). Freed slots are reused via a free-list.
+//!
+//! Multiple workers can concurrently call [`pop`](JobQueue::pop) — each job
+//! is delivered to exactly one worker. Workers block asynchronously when the
+//! queue is empty and wake on the next push or hint arrival.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
+use mosaic_job_api::HintKey;
 use parking_lot::Mutex;
 
 use super::PoolJob;
 use crate::priority::Priority;
 
+/// Optional boost configuration for FIFO-mode queues.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BoostConfig {
+    /// Maximum number of jobs that can sit in the boost queue at once.
+    /// Additional promotion requests while at cap are dropped.
+    pub max_slots: usize,
+}
+
 /// Thread-safe, async-aware job queue with optional priority ordering.
 pub(crate) struct JobQueue {
     state: Mutex<QueueState>,
-    /// Push side: one signal per job added (sync — called from dispatcher).
+    /// Push side: one signal per job added or hint that could unblock a pop.
     signal_tx: kanal::Sender<()>,
     /// Pop side: workers await a signal before taking a job (async).
     signal_rx: kanal::AsyncReceiver<()>,
 }
 
+enum QueueBacking {
+    /// Priority mode: three VecDeques by priority level. No boost support.
+    Priority {
+        critical: VecDeque<PoolJob>,
+        high: VecDeque<PoolJob>,
+        normal: VecDeque<PoolJob>,
+    },
+    /// FIFO mode: slot-based intrusive linked list with optional boost.
+    Fifo(SlotList),
+}
+
 struct QueueState {
-    priority_mode: bool,
-    /// Used in FIFO mode.
-    fifo: VecDeque<PoolJob>,
-    /// Used in priority mode.
-    critical: VecDeque<PoolJob>,
-    high: VecDeque<PoolJob>,
-    normal: VecDeque<PoolJob>,
-    /// Total number of queued jobs across all levels.
+    backing: QueueBacking,
     len: usize,
     closed: bool,
 }
 
 impl QueueState {
-    fn new(priority_mode: bool) -> Self {
+    fn new_priority() -> Self {
         Self {
-            priority_mode,
-            fifo: VecDeque::new(),
-            critical: VecDeque::new(),
-            high: VecDeque::new(),
-            normal: VecDeque::new(),
+            backing: QueueBacking::Priority {
+                critical: VecDeque::new(),
+                high: VecDeque::new(),
+                normal: VecDeque::new(),
+            },
             len: 0,
             closed: false,
         }
     }
 
-    fn push(&mut self, job: PoolJob) {
-        if self.priority_mode {
-            match job.priority {
-                Priority::Critical => self.critical.push_back(job),
-                Priority::High => self.high.push_back(job),
-                Priority::Normal => self.normal.push_back(job),
+    fn new_fifo(boost: Option<BoostConfig>) -> Self {
+        Self {
+            backing: QueueBacking::Fifo(SlotList::new(boost)),
+            len: 0,
+            closed: false,
+        }
+    }
+
+    fn push(&mut self, job: PoolJob, hint_key: Option<HintKey>) {
+        match &mut self.backing {
+            QueueBacking::Priority {
+                critical,
+                high,
+                normal,
+            } => {
+                let _ = hint_key; // Priority mode doesn't use hints.
+                match job.priority {
+                    Priority::Critical => critical.push_back(job),
+                    Priority::High => high.push_back(job),
+                    Priority::Normal => normal.push_back(job),
+                }
             }
-        } else {
-            self.fifo.push_back(job);
+            QueueBacking::Fifo(list) => {
+                list.push_back(job, hint_key);
+            }
         }
         self.len += 1;
     }
 
-    /// Take the highest priority job, or the oldest in FIFO mode.
     fn pop(&mut self) -> Option<PoolJob> {
-        let job = if self.priority_mode {
-            self.critical
+        let job = match &mut self.backing {
+            QueueBacking::Priority {
+                critical,
+                high,
+                normal,
+            } => critical
                 .pop_front()
-                .or_else(|| self.high.pop_front())
-                .or_else(|| self.normal.pop_front())
-        } else {
-            self.fifo.pop_front()
+                .or_else(|| high.pop_front())
+                .or_else(|| normal.pop_front()),
+            QueueBacking::Fifo(list) => list.pop_front(),
         };
         if job.is_some() {
             self.len -= 1;
         }
         job
+    }
+
+    fn apply_hint(&mut self, key: &HintKey) -> bool {
+        match &mut self.backing {
+            QueueBacking::Priority { .. } => false,
+            QueueBacking::Fifo(list) => list.promote(key),
+        }
     }
 }
 
@@ -84,11 +131,20 @@ impl JobQueue {
     /// Create a new queue.
     ///
     /// When `priority_mode` is `true`, jobs are dequeued in priority order
-    /// (Critical → High → Normal). Otherwise, jobs are dequeued in FIFO order.
-    pub(crate) fn new(priority_mode: bool) -> Self {
+    /// (Critical → High → Normal). Otherwise, jobs are dequeued in FIFO
+    /// order with optional hint-driven boost.
+    ///
+    /// `boost` is only meaningful in FIFO mode. In priority mode it is
+    /// ignored.
+    pub(crate) fn new(priority_mode: bool, boost: Option<BoostConfig>) -> Self {
         let (signal_tx, signal_rx) = kanal::unbounded();
+        let state = if priority_mode {
+            QueueState::new_priority()
+        } else {
+            QueueState::new_fifo(boost)
+        };
         Self {
-            state: Mutex::new(QueueState::new(priority_mode)),
+            state: Mutex::new(state),
             signal_tx,
             signal_rx: signal_rx.to_async(),
         }
@@ -96,12 +152,13 @@ impl JobQueue {
 
     /// Add a job to the queue.
     ///
+    /// `hint_key`, if present, registers the job in the hint index so a
+    /// subsequent [`apply_hint`](Self::apply_hint) with the same key can
+    /// promote it. Hints on priority-mode queues are ignored.
+    ///
     /// Wakes one blocked worker, if any.
-    pub(crate) fn push(&self, job: PoolJob) {
-        self.state.lock().push(job);
-
-        // Signal exactly one waiting worker. If no worker is waiting, the
-        // signal queues up and will be consumed on the next `pop` call.
+    pub(crate) fn push(&self, job: PoolJob, hint_key: Option<HintKey>) {
+        self.state.lock().push(job, hint_key);
         let _ = self.signal_tx.send(());
     }
 
@@ -109,10 +166,10 @@ impl JobQueue {
     ///
     /// Semantically identical to [`push`](Self::push) — the job goes to the
     /// back of its priority level (or FIFO tail). This is a separate method
-    /// for clarity at call sites: `push` is for new jobs from the dispatcher,
-    /// `requeue` is for transient-failure retries from workers.
-    pub(crate) fn requeue(&self, job: PoolJob) {
-        self.push(job);
+    /// for clarity at call sites: `push` is for new jobs from the
+    /// dispatcher, `requeue` is for transient-failure retries from workers.
+    pub(crate) fn requeue(&self, job: PoolJob, hint_key: Option<HintKey>) {
+        self.push(job, hint_key);
     }
 
     /// Take the next job, waiting asynchronously if the queue is empty.
@@ -120,11 +177,7 @@ impl JobQueue {
     /// Returns `None` when the queue is closed and drained.
     pub(crate) async fn pop(&self) -> Option<PoolJob> {
         loop {
-            // Wait for a signal that a job is available.
-            // Each push sends exactly one signal, and each signal is delivered
-            // to exactly one worker (kanal MPMC guarantee).
             if self.signal_rx.recv().await.is_err() {
-                // Channel closed — check for remaining jobs under lock.
                 let mut state = self.state.lock();
                 return state.pop();
             }
@@ -136,9 +189,28 @@ impl JobQueue {
             if state.closed {
                 return None;
             }
-            // Signal received but job was already taken (edge case during
-            // close). Loop back and wait for the next signal.
+            // Signal received but job was already taken (e.g. hint arrived
+            // for a job that got dequeued between signal and lock). Loop.
         }
+    }
+
+    /// Try to promote a job identified by `key` to the boost queue's tail.
+    ///
+    /// Returns `true` if a matching job was found and promoted, `false` if
+    /// no such job is currently queued or the boost queue is at its cap.
+    /// Hints on priority-mode queues always return `false`.
+    ///
+    /// TODO: hints that arrive before their matching job is submitted are
+    /// currently dropped. A short-TTL `pending_hints` stash would let them
+    /// promote a soon-arriving job.
+    pub(crate) fn apply_hint(&self, key: &HintKey) -> bool {
+        let promoted = self.state.lock().apply_hint(key);
+        if promoted {
+            // The job wasn't previously ahead of others in the queue; wake a
+            // worker in case one was idle and would benefit from the boost.
+            let _ = self.signal_tx.send(());
+        }
+        promoted
     }
 
     /// Number of jobs currently in the queue.
@@ -154,96 +226,354 @@ impl JobQueue {
 
     /// Close the queue.
     ///
-    /// Workers currently blocked in [`pop`](Self::pop) will wake up and return
-    /// `None` once all remaining jobs are drained. New [`push`](Self::push)
-    /// calls are ignored.
+    /// Workers currently blocked in [`pop`](Self::pop) will wake up and
+    /// return `None` once all remaining jobs are drained. New
+    /// [`push`](Self::push) calls are ignored.
     pub(crate) fn close(&self) {
         self.state.lock().closed = true;
-        // Closing the sender wakes all blocked receivers with `Err`, causing
-        // them to check the closed flag and drain remaining jobs.
         let _ = self.signal_tx.close();
+    }
+}
+
+// ============================================================================
+// Slot-based intrusive linked list for FIFO + boost.
+// ============================================================================
+
+type SlotId = usize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SlotList2 {
+    Fifo,
+    Boost,
+    Free,
+}
+
+struct Slot {
+    /// The job, `None` iff the slot is in the free list.
+    job: Option<PoolJob>,
+    /// Registered hint key, used to look up this slot for promotion.
+    hint_key: Option<HintKey>,
+    /// Which list this slot is currently in.
+    list: SlotList2,
+    /// Doubly-linked-list pointers within `list`.
+    prev: Option<SlotId>,
+    next: Option<SlotId>,
+}
+
+struct SlotList {
+    /// Backing storage. Grows on demand; slots move between the FIFO, boost,
+    /// and free lists via `list` field + prev/next pointers.
+    slots: Vec<Slot>,
+    /// Free-list head. Reuse frees an allocation.
+    free_head: Option<SlotId>,
+    /// FIFO list head/tail.
+    fifo_head: Option<SlotId>,
+    fifo_tail: Option<SlotId>,
+    /// Boost list head/tail. Drains first on pop.
+    boost_head: Option<SlotId>,
+    boost_tail: Option<SlotId>,
+    /// O(1) lookup for `apply_hint`: hint key → slot in FIFO list.
+    /// Boosted slots and free slots are NOT in this map (they can't be
+    /// promoted again).
+    hint_index: HashMap<HintKey, SlotId>,
+    /// Number of slots currently in the boost list.
+    boost_len: usize,
+    /// Boost configuration. `None` disables the boost mechanism entirely
+    /// (behaves as plain FIFO).
+    boost: Option<BoostConfig>,
+}
+
+impl SlotList {
+    fn new(boost: Option<BoostConfig>) -> Self {
+        Self {
+            slots: Vec::new(),
+            free_head: None,
+            fifo_head: None,
+            fifo_tail: None,
+            boost_head: None,
+            boost_tail: None,
+            hint_index: HashMap::new(),
+            boost_len: 0,
+            boost,
+        }
+    }
+
+    fn alloc_slot(&mut self, job: PoolJob, hint_key: Option<HintKey>) -> SlotId {
+        if let Some(id) = self.free_head {
+            self.free_head = self.slots[id].next;
+            let slot = &mut self.slots[id];
+            slot.job = Some(job);
+            slot.hint_key = hint_key;
+            slot.list = SlotList2::Free; // will be set by caller when linking
+            slot.prev = None;
+            slot.next = None;
+            id
+        } else {
+            let id = self.slots.len();
+            self.slots.push(Slot {
+                job: Some(job),
+                hint_key,
+                list: SlotList2::Free,
+                prev: None,
+                next: None,
+            });
+            id
+        }
+    }
+
+    fn free_slot(&mut self, id: SlotId) {
+        let slot = &mut self.slots[id];
+        slot.job = None;
+        slot.hint_key = None;
+        slot.list = SlotList2::Free;
+        slot.prev = None;
+        slot.next = self.free_head;
+        self.free_head = Some(id);
+    }
+
+    /// Append a slot to the FIFO tail.
+    fn push_back(&mut self, job: PoolJob, hint_key: Option<HintKey>) {
+        let id = self.alloc_slot(job, hint_key.clone());
+        self.slots[id].list = SlotList2::Fifo;
+        self.slots[id].prev = self.fifo_tail;
+        self.slots[id].next = None;
+        if let Some(tail) = self.fifo_tail {
+            self.slots[tail].next = Some(id);
+        } else {
+            self.fifo_head = Some(id);
+        }
+        self.fifo_tail = Some(id);
+        if let Some(key) = hint_key
+            && self.boost.is_some()
+        {
+            // Only track hints if boost is enabled.
+            self.hint_index.insert(key, id);
+        }
+    }
+
+    /// Remove and return the head of the boost list (preferred), or the
+    /// FIFO head. Boost drains completely before FIFO.
+    fn pop_front(&mut self) -> Option<PoolJob> {
+        if let Some(id) = self.boost_head {
+            self.unlink(id);
+            self.boost_len -= 1;
+            let job = self.slots[id].job.take();
+            self.free_slot(id);
+            return job;
+        }
+        if let Some(id) = self.fifo_head {
+            self.unlink(id);
+            if let Some(ref key) = self.slots[id].hint_key {
+                self.hint_index.remove(key);
+            }
+            let job = self.slots[id].job.take();
+            self.free_slot(id);
+            return job;
+        }
+        None
+    }
+
+    /// Try to promote the job matching `key` to the boost list tail.
+    /// Returns true if a job was promoted.
+    fn promote(&mut self, key: &HintKey) -> bool {
+        let Some(&id) = self.hint_index.get(key) else {
+            return false;
+        };
+        let Some(BoostConfig { max_slots }) = self.boost else {
+            return false;
+        };
+        if self.boost_len >= max_slots {
+            // Boost queue full — leave the job in FIFO.
+            return false;
+        }
+        // Remove from hint_index and unlink from FIFO.
+        self.hint_index.remove(key);
+        self.unlink(id);
+        // Append to boost tail.
+        self.slots[id].list = SlotList2::Boost;
+        self.slots[id].prev = self.boost_tail;
+        self.slots[id].next = None;
+        if let Some(tail) = self.boost_tail {
+            self.slots[tail].next = Some(id);
+        } else {
+            self.boost_head = Some(id);
+        }
+        self.boost_tail = Some(id);
+        self.boost_len += 1;
+        true
+    }
+
+    /// Unlink a slot from whichever list (FIFO or Boost) it's currently in.
+    fn unlink(&mut self, id: SlotId) {
+        let (prev, next, list) = {
+            let s = &self.slots[id];
+            (s.prev, s.next, s.list)
+        };
+        if let Some(p) = prev {
+            self.slots[p].next = next;
+        }
+        if let Some(n) = next {
+            self.slots[n].prev = prev;
+        }
+        match list {
+            SlotList2::Fifo => {
+                if self.fifo_head == Some(id) {
+                    self.fifo_head = next;
+                }
+                if self.fifo_tail == Some(id) {
+                    self.fifo_tail = prev;
+                }
+            }
+            SlotList2::Boost => {
+                if self.boost_head == Some(id) {
+                    self.boost_head = next;
+                }
+                if self.boost_tail == Some(id) {
+                    self.boost_tail = prev;
+                }
+            }
+            SlotList2::Free => {
+                debug_assert!(false, "unlinking a free slot");
+            }
+        }
+        self.slots[id].prev = None;
+        self.slots[id].next = None;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use mosaic_cac_types::{Seed, state_machine::garbler::Wire};
+    use mosaic_net_svc_api::PeerId;
 
     use super::*;
 
-    fn dummy_job(priority: Priority) -> PoolJob {
+    fn dummy_job() -> PoolJob {
         use mosaic_cac_types::state_machine::garbler::Action as GarblerAction;
 
         use crate::pool::worker::WorkerJob;
 
         PoolJob {
-            priority,
+            priority: Priority::Normal,
             job: WorkerJob::Garbler {
-                peer_id: mosaic_net_svc_api::PeerId::from_bytes([0u8; 32]),
+                peer_id: PeerId::from_bytes([0u8; 32]),
                 action: GarblerAction::GeneratePolynomialCommitments(
                     Seed::from([0u8; 32]),
                     Wire::Output,
                 ),
             },
             attempts: 0,
+            hint_key: None,
+        }
+    }
+
+    fn key(byte: u8) -> HintKey {
+        HintKey::new(PeerId::from_bytes([0u8; 32]), 1, [byte; 32])
+    }
+
+    #[test]
+    fn fifo_ordering_without_boost() {
+        let q = JobQueue::new(false, None);
+        q.push(dummy_job(), None);
+        q.push(dummy_job(), None);
+        q.push(dummy_job(), None);
+
+        let mut state = q.state.lock();
+        assert!(state.pop().is_some());
+        assert!(state.pop().is_some());
+        assert!(state.pop().is_some());
+        assert!(state.pop().is_none());
+    }
+
+    #[test]
+    fn hint_promotes_matching_job() {
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
+        q.push(dummy_job(), Some(key(1)));
+        q.push(dummy_job(), Some(key(2)));
+        q.push(dummy_job(), Some(key(3)));
+
+        // Promote the third job.
+        assert!(q.apply_hint(&key(3)));
+
+        // Boost drains first, so the promoted job comes out ahead.
+        let mut state = q.state.lock();
+        let first = state.pop().unwrap();
+        // We can't tell which key this was without extending PoolJob, but
+        // we can verify the promoted slot came out first by tracking that
+        // exactly one boost job was in the queue.
+        drop(first);
+        assert!(state.pop().is_some()); // FIFO: key 1
+        assert!(state.pop().is_some()); // FIFO: key 2
+        assert!(state.pop().is_none());
+    }
+
+    #[test]
+    fn hint_for_absent_job_returns_false() {
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
+        q.push(dummy_job(), Some(key(1)));
+        assert!(!q.apply_hint(&key(2)));
+    }
+
+    #[test]
+    fn hint_ignored_in_priority_mode() {
+        let q = JobQueue::new(true, Some(BoostConfig { max_slots: 64 }));
+        q.push(dummy_job(), Some(key(1)));
+        assert!(!q.apply_hint(&key(1)));
+    }
+
+    #[test]
+    fn boost_cap_enforced() {
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 2 }));
+        q.push(dummy_job(), Some(key(1)));
+        q.push(dummy_job(), Some(key(2)));
+        q.push(dummy_job(), Some(key(3)));
+
+        assert!(q.apply_hint(&key(1)));
+        assert!(q.apply_hint(&key(2)));
+        // Boost full — third hint dropped.
+        assert!(!q.apply_hint(&key(3)));
+    }
+
+    #[test]
+    fn dequeue_removes_hint_index_entry() {
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
+        q.push(dummy_job(), Some(key(1)));
+
+        {
+            let mut state = q.state.lock();
+            let _ = state.pop();
+        }
+
+        // Hint for a dequeued job should not promote anything.
+        assert!(!q.apply_hint(&key(1)));
+    }
+
+    #[test]
+    fn slot_free_list_reuses_allocations() {
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
+        q.push(dummy_job(), None);
+        q.push(dummy_job(), None);
+        {
+            let mut state = q.state.lock();
+            let _ = state.pop();
+            let _ = state.pop();
+        }
+        q.push(dummy_job(), None);
+
+        // After popping both then pushing one, the underlying Vec should
+        // not have grown beyond the original 2 slots (one reused).
+        let state = q.state.lock();
+        if let QueueBacking::Fifo(list) = &state.backing {
+            assert!(list.slots.len() <= 2, "slot vec grew unnecessarily");
+        } else {
+            unreachable!();
         }
     }
 
     #[test]
-    fn fifo_ordering() {
-        let q = JobQueue::new(false);
-        q.push(dummy_job(Priority::Normal));
-        q.push(dummy_job(Priority::Critical));
-        q.push(dummy_job(Priority::High));
-
-        // FIFO ignores priority — order matches push order.
-        let mut state = q.state.lock();
-        assert_eq!(state.pop().unwrap().priority, Priority::Normal);
-        assert_eq!(state.pop().unwrap().priority, Priority::Critical);
-        assert_eq!(state.pop().unwrap().priority, Priority::High);
-        assert!(state.pop().is_none());
-    }
-
-    #[test]
-    fn priority_ordering() {
-        let q = JobQueue::new(true);
-        q.push(dummy_job(Priority::Normal));
-        q.push(dummy_job(Priority::High));
-        q.push(dummy_job(Priority::Critical));
-        q.push(dummy_job(Priority::Normal));
-        q.push(dummy_job(Priority::High));
-
-        // Priority mode drains Critical → High → Normal.
-        let mut state = q.state.lock();
-        assert_eq!(state.pop().unwrap().priority, Priority::Critical);
-        assert_eq!(state.pop().unwrap().priority, Priority::High);
-        assert_eq!(state.pop().unwrap().priority, Priority::High);
-        assert_eq!(state.pop().unwrap().priority, Priority::Normal);
-        assert_eq!(state.pop().unwrap().priority, Priority::Normal);
-        assert!(state.pop().is_none());
-    }
-
-    #[test]
-    fn len_tracks_push_and_pop() {
-        let q = JobQueue::new(true);
-        assert_eq!(q.len(), 0);
-        assert!(q.is_empty());
-
-        q.push(dummy_job(Priority::Normal));
-        q.push(dummy_job(Priority::High));
-        assert_eq!(q.len(), 2);
-
-        let mut state = q.state.lock();
-        let _ = state.pop();
-        // len is tracked inside state
-        assert_eq!(state.len, 1);
-    }
-
-    #[test]
     fn close_prevents_blocking() {
-        let q = JobQueue::new(false);
+        let q = JobQueue::new(false, None);
         q.close();
-
         let state = q.state.lock();
         assert!(state.closed);
     }

--- a/crates/job/scheduler/src/pool/queue.rs
+++ b/crates/job/scheduler/src/pool/queue.rs
@@ -443,6 +443,7 @@ impl SlotList {
 #[cfg(test)]
 mod tests {
     use mosaic_cac_types::{Seed, state_machine::garbler::Wire};
+    use mosaic_job_api::HintKind;
     use mosaic_net_svc_api::PeerId;
 
     use super::*;
@@ -474,7 +475,11 @@ mod tests {
     }
 
     fn key(byte: u8) -> HintKey {
-        HintKey::new(PeerId::from_bytes([0u8; 32]), 1, [byte; 32])
+        HintKey::new(
+            PeerId::from_bytes([0u8; 32]),
+            HintKind::TransferStarting,
+            [byte; 32],
+        )
     }
 
     #[test]

--- a/crates/job/scheduler/src/pool/queue.rs
+++ b/crates/job/scheduler/src/pool/queue.rs
@@ -204,13 +204,12 @@ impl JobQueue {
     /// currently dropped. A short-TTL `pending_hints` stash would let them
     /// promote a soon-arriving job.
     pub(crate) fn apply_hint(&self, key: &HintKey) -> bool {
-        let promoted = self.state.lock().apply_hint(key);
-        if promoted {
-            // The job wasn't previously ahead of others in the queue; wake a
-            // worker in case one was idle and would benefit from the boost.
-            let _ = self.signal_tx.send(());
-        }
-        promoted
+        // No signal fired here: promotion doesn't add a job to the queue,
+        // and the push that originally added it already sent exactly one
+        // signal. Sending another would cause a redundant wake — the
+        // worker takes whichever job is at the head of boost or FIFO on
+        // its next pop regardless.
+        self.state.lock().apply_hint(key)
     }
 
     /// Number of jobs currently in the queue.
@@ -449,6 +448,13 @@ mod tests {
     use super::*;
 
     fn dummy_job() -> PoolJob {
+        job_with_attempts(0)
+    }
+
+    /// Build a distinguishable dummy job by encoding an integer marker
+    /// into `PoolJob::attempts`. Tests inspect this to verify boost/FIFO
+    /// ordering across pops.
+    fn job_with_attempts(attempts: u32) -> PoolJob {
         use mosaic_cac_types::state_machine::garbler::Action as GarblerAction;
 
         use crate::pool::worker::WorkerJob;
@@ -462,7 +468,7 @@ mod tests {
                     Wire::Output,
                 ),
             },
-            attempts: 0,
+            attempts,
             hint_key: None,
         }
     }
@@ -488,23 +494,63 @@ mod tests {
     #[test]
     fn hint_promotes_matching_job() {
         let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
-        q.push(dummy_job(), Some(key(1)));
-        q.push(dummy_job(), Some(key(2)));
-        q.push(dummy_job(), Some(key(3)));
+        // Tag each job via `attempts` so we can identify who came out.
+        q.push(job_with_attempts(1), Some(key(1)));
+        q.push(job_with_attempts(2), Some(key(2)));
+        q.push(job_with_attempts(3), Some(key(3)));
 
-        // Promote the third job.
+        // Promote the third job (attempts=3).
         assert!(q.apply_hint(&key(3)));
 
-        // Boost drains first, so the promoted job comes out ahead.
+        // Boost drains first: the promoted job comes out ahead of the
+        // FIFO head. Then FIFO order (attempts=1, then attempts=2).
         let mut state = q.state.lock();
-        let first = state.pop().unwrap();
-        // We can't tell which key this was without extending PoolJob, but
-        // we can verify the promoted slot came out first by tracking that
-        // exactly one boost job was in the queue.
-        drop(first);
-        assert!(state.pop().is_some()); // FIFO: key 1
-        assert!(state.pop().is_some()); // FIFO: key 2
+        assert_eq!(state.pop().unwrap().attempts, 3);
+        assert_eq!(state.pop().unwrap().attempts, 1);
+        assert_eq!(state.pop().unwrap().attempts, 2);
         assert!(state.pop().is_none());
+    }
+
+    #[test]
+    fn multiple_promotions_boost_in_arrival_order() {
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
+        q.push(job_with_attempts(1), Some(key(1)));
+        q.push(job_with_attempts(2), Some(key(2)));
+        q.push(job_with_attempts(3), Some(key(3)));
+
+        // Promote 3 first, then 1. Boost queue tail-append means we get
+        // 3 before 1, then FIFO (which has only 2 left).
+        assert!(q.apply_hint(&key(3)));
+        assert!(q.apply_hint(&key(1)));
+
+        let mut state = q.state.lock();
+        assert_eq!(state.pop().unwrap().attempts, 3);
+        assert_eq!(state.pop().unwrap().attempts, 1);
+        assert_eq!(state.pop().unwrap().attempts, 2);
+        assert!(state.pop().is_none());
+    }
+
+    #[test]
+    fn hint_index_cleared_after_pop_and_promote() {
+        // Whitebox test: verify hint_index is empty after all matching
+        // paths (pop after promote, pop of FIFO head with hint, plain FIFO
+        // drain). Regression guard against slots leaking into the index.
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
+        q.push(job_with_attempts(1), Some(key(1)));
+        q.push(job_with_attempts(2), Some(key(2)));
+        assert!(q.apply_hint(&key(1)));
+
+        let mut state = q.state.lock();
+        state.pop(); // boosted key(1)
+        state.pop(); // FIFO key(2)
+        assert!(state.pop().is_none());
+
+        if let QueueBacking::Fifo(list) = &state.backing {
+            assert!(list.hint_index.is_empty(), "hint_index leaked entries");
+            assert_eq!(list.boost_len, 0);
+        } else {
+            unreachable!();
+        }
     }
 
     #[test]

--- a/crates/job/scheduler/src/pool/queue.rs
+++ b/crates/job/scheduler/src/pool/queue.rs
@@ -17,7 +17,10 @@
 //! is delivered to exactly one worker. Workers block asynchronously when the
 //! queue is empty and wake on the next push or hint arrival.
 
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    time::{Duration, Instant},
+};
 
 use mosaic_job_api::HintKey;
 use parking_lot::Mutex;
@@ -32,6 +35,22 @@ pub(crate) struct BoostConfig {
     /// Additional promotion requests while at cap are dropped.
     pub max_slots: usize,
 }
+
+/// Maximum number of unmatched hints to remember, so a hint that arrives
+/// while its target job is transiently absent (e.g. a worker holding it
+/// during retry-backoff sleep) can still promote the job when it comes
+/// back. Sized to match `MAX_CONCURRENT_BIDI_STREAMS = 100` in net-svc
+/// (rounded down to a round number): a peer can't have more than that
+/// many hint streams in flight at once, so 64 covers the realistic burst
+/// with headroom while keeping the stash tiny (< 4 KiB). Excess entries
+/// evict FIFO — hints are advisory, so silent loss is acceptable.
+const PENDING_HINTS_CAP: usize = 64;
+
+/// Maximum age of a pending hint before it's dropped on the next push
+/// check. Comfortably covers the worker's max retry-backoff (10s) plus
+/// scheduler latency, without letting stale hints linger indefinitely
+/// and mis-promote unrelated future jobs that happen to reuse a key.
+const PENDING_HINTS_TTL: Duration = Duration::from_secs(15);
 
 /// Thread-safe, async-aware job queue with optional priority ordering.
 pub(crate) struct JobQueue {
@@ -200,9 +219,15 @@ impl JobQueue {
     /// no such job is currently queued or the boost queue is at its cap.
     /// Hints on priority-mode queues always return `false`.
     ///
-    /// TODO: hints that arrive before their matching job is submitted are
-    /// currently dropped. A short-TTL `pending_hints` stash would let them
-    /// promote a soon-arriving job.
+    /// A hint that arrives while no matching job is queued (e.g. because a
+    /// worker is holding the job during a retry-backoff sleep, or because
+    /// the sender's hint stream landed before the corresponding STF has
+    /// emitted the action) is stashed in a bounded FIFO with a TTL. The
+    /// next matching [`push`](Self::push) or [`requeue`](Self::requeue)
+    /// consumes the stashed entry and boosts the job on entry — same
+    /// effect as if the hint had fired after the push. If the boost queue
+    /// is at cap when the stashed hint is consumed, the promotion silently
+    /// no-ops and the stash entry is not re-added (the job stays in FIFO).
     pub(crate) fn apply_hint(&self, key: &HintKey) -> bool {
         // No signal fired here: promotion doesn't add a job to the queue,
         // and the push that originally added it already sent exactly one
@@ -275,6 +300,11 @@ struct SlotList {
     /// Boosted slots and free slots are NOT in this map (they can't be
     /// promoted again).
     hint_index: HashMap<HintKey, SlotId>,
+    /// Hints that arrived when no matching job was queued (e.g. because a
+    /// worker was holding the job during a retry-backoff sleep). Checked
+    /// on every `push_back`; a match promotes the job to the boost tail
+    /// immediately. Bounded FIFO with a TTL sweep on push.
+    pending_hints: VecDeque<(HintKey, Instant)>,
     /// Number of slots currently in the boost list.
     boost_len: usize,
     /// Boost configuration. `None` disables the boost mechanism entirely
@@ -292,9 +322,43 @@ impl SlotList {
             boost_head: None,
             boost_tail: None,
             hint_index: HashMap::new(),
+            pending_hints: VecDeque::new(),
             boost_len: 0,
             boost,
         }
+    }
+
+    /// Drop expired entries from `pending_hints`. Called on push_back and
+    /// apply_hint miss so the stash size stays bounded even if a stream
+    /// of unmatched hints comes in without matching pushes.
+    fn expire_pending_hints(&mut self, now: Instant) {
+        while let Some((_, ts)) = self.pending_hints.front() {
+            if now.duration_since(*ts) < PENDING_HINTS_TTL {
+                break;
+            }
+            self.pending_hints.pop_front();
+        }
+    }
+
+    /// Consume any pending hint matching `key` (removing it from the
+    /// stash). Returns true if such a hint was found and removed.
+    fn take_pending_hint(&mut self, key: &HintKey, now: Instant) -> bool {
+        self.expire_pending_hints(now);
+        if let Some(pos) = self.pending_hints.iter().position(|(k, _)| k == key) {
+            self.pending_hints.remove(pos);
+            return true;
+        }
+        false
+    }
+
+    /// Add `key` to the pending-hint stash. Evicts the oldest entry if
+    /// the stash is at capacity.
+    fn stash_pending_hint(&mut self, key: HintKey, now: Instant) {
+        self.expire_pending_hints(now);
+        if self.pending_hints.len() >= PENDING_HINTS_CAP {
+            self.pending_hints.pop_front();
+        }
+        self.pending_hints.push_back((key, now));
     }
 
     fn alloc_slot(&mut self, job: PoolJob, hint_key: Option<HintKey>) -> SlotId {
@@ -345,8 +409,16 @@ impl SlotList {
         if let Some(key) = hint_key
             && self.boost.is_some()
         {
-            // Only track hints if boost is enabled.
-            self.hint_index.insert(key, id);
+            self.hint_index.insert(key.clone(), id);
+            // Late-arriving hint: if `apply_hint` fired for this key while
+            // the job was absent (e.g. worker holding it during
+            // retry-backoff), promote immediately instead of leaving the
+            // job at the FIFO tail. Boost-cap enforcement lives inside
+            // `promote`.
+            let now = Instant::now();
+            if self.take_pending_hint(&key, now) {
+                let _ = self.promote(&key);
+            }
         }
     }
 
@@ -374,11 +446,19 @@ impl SlotList {
 
     /// Try to promote the job matching `key` to the boost list tail.
     /// Returns true if a job was promoted.
+    ///
+    /// If no job with `key` is currently in the FIFO index (worker may be
+    /// holding it during retry backoff, or the corresponding push hasn't
+    /// arrived yet), the key is stashed and will promote the next matching
+    /// `push_back` provided it arrives inside [`PENDING_HINTS_TTL`].
     fn promote(&mut self, key: &HintKey) -> bool {
-        let Some(&id) = self.hint_index.get(key) else {
+        let Some(BoostConfig { max_slots }) = self.boost else {
             return false;
         };
-        let Some(BoostConfig { max_slots }) = self.boost else {
+        let Some(&id) = self.hint_index.get(key) else {
+            // No matching queued job — stash the hint for a possible
+            // late-arriving push.
+            self.stash_pending_hint(key.clone(), Instant::now());
             return false;
         };
         if self.boost_len >= max_slots {
@@ -616,6 +696,94 @@ mod tests {
         let state = q.state.lock();
         if let QueueBacking::Fifo(list) = &state.backing {
             assert!(list.slots.len() <= 2, "slot vec grew unnecessarily");
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn late_arriving_push_gets_promoted_by_stashed_hint() {
+        // The scenario codex flagged: a hint fires while the target job
+        // isn't currently queued (worker holds it during retry-backoff
+        // sleep). The stash keeps the key alive; when the worker later
+        // requeues, `push_back` finds the stashed hint and boosts the
+        // job on entry — same effect as if the hint had fired after the
+        // push.
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
+        // Hint arrives first — no queued job matches, key gets stashed.
+        assert!(!q.apply_hint(&key(1)));
+
+        // Simulate the worker requeuing the retried job later.
+        q.push(job_with_attempts(42), Some(key(1)));
+        // A second job pushed WITHOUT a matching stashed hint should
+        // stay behind the boosted one in dispatch order.
+        q.push(job_with_attempts(43), Some(key(2)));
+
+        let mut state = q.state.lock();
+        assert_eq!(state.pop().unwrap().attempts, 42, "stash-promoted first");
+        assert_eq!(state.pop().unwrap().attempts, 43);
+        assert!(state.pop().is_none());
+    }
+
+    #[test]
+    fn stashed_hint_consumed_only_once() {
+        // A stashed hint must be single-use — otherwise a stale entry
+        // could keep boosting unrelated jobs that happen to reuse the
+        // key.
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
+        assert!(!q.apply_hint(&key(1)));
+
+        // First push consumes the stashed hint and gets boosted.
+        q.push(job_with_attempts(1), Some(key(1)));
+        // Second push with the same key must NOT be boosted (no matching
+        // stashed hint remaining).
+        q.push(job_with_attempts(2), Some(key(1)));
+        // FIFO tail-order for a third unmatched job.
+        q.push(job_with_attempts(3), Some(key(2)));
+
+        let mut state = q.state.lock();
+        assert_eq!(state.pop().unwrap().attempts, 1); // boosted
+        assert_eq!(state.pop().unwrap().attempts, 2); // FIFO
+        assert_eq!(state.pop().unwrap().attempts, 3); // FIFO
+    }
+
+    #[test]
+    fn stashed_hint_dropped_when_boost_cap_reached_on_push() {
+        // If the pending-hint stash yields a match on push but boost is
+        // at cap, the promote silently no-ops and the stashed entry is
+        // not re-added — the job stays in FIFO. Regression guard: verify
+        // subsequent operations don't see phantom stash entries.
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 1 }));
+        // Fill the boost queue.
+        q.push(job_with_attempts(10), Some(key(10)));
+        assert!(q.apply_hint(&key(10)));
+        // Stash a hint whose target job doesn't yet exist.
+        assert!(!q.apply_hint(&key(1)));
+        // Push the matching job — stash entry consumed, but promote
+        // fails because boost is at cap. Job should land at FIFO tail.
+        q.push(job_with_attempts(1), Some(key(1)));
+
+        let mut state = q.state.lock();
+        // Boosted key(10) first, then FIFO key(1).
+        assert_eq!(state.pop().unwrap().attempts, 10);
+        assert_eq!(state.pop().unwrap().attempts, 1);
+        // Stash should be empty (entry was consumed, not re-added).
+        if let QueueBacking::Fifo(list) = &state.backing {
+            assert!(list.pending_hints.is_empty());
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn pending_hints_stash_bounded() {
+        let q = JobQueue::new(false, Some(BoostConfig { max_slots: 64 }));
+        for i in 0..(PENDING_HINTS_CAP as u8 + 8) {
+            assert!(!q.apply_hint(&key(i)));
+        }
+        let state = q.state.lock();
+        if let QueueBacking::Fifo(list) = &state.backing {
+            assert_eq!(list.pending_hints.len(), PENDING_HINTS_CAP);
         } else {
             unreachable!();
         }

--- a/crates/job/scheduler/src/pool/worker.rs
+++ b/crates/job/scheduler/src/pool/worker.rs
@@ -281,7 +281,8 @@ async fn worker_loop<D: ExecuteGarblerJob + ExecuteEvaluatorJob>(
                                 "worker job requested retry"
                             );
                             monoio::time::sleep(backoff).await;
-                            queue.requeue(job);
+                            let hint_key = job.hint_key.clone();
+                            queue.requeue(job, hint_key);
                         }
                     }
                 }
@@ -671,7 +672,7 @@ mod tests {
     fn closed_completion_channel_reports_scheduler_fault() {
         run_monoio(async {
             let peer_id = PeerId::from_bytes([9; 32]);
-            let queue = Arc::new(JobQueue::new(false));
+            let queue = Arc::new(JobQueue::new(false, None));
             let dispatcher = Arc::new(TestDispatcher);
             let (completion_tx, completion_rx) = kanal::bounded_async(1);
             let (fault_tx, fault_rx) = kanal::bounded_async(1);
@@ -686,14 +687,18 @@ mod tests {
                 1,
             ));
 
-            queue.push(PoolJob {
-                priority: Priority::Normal,
-                job: WorkerJob::Garbler {
-                    peer_id,
-                    action: GarblerAction::SendCommitMsgChunk(0),
+            queue.push(
+                PoolJob {
+                    priority: Priority::Normal,
+                    job: WorkerJob::Garbler {
+                        peer_id,
+                        action: GarblerAction::SendCommitMsgChunk(0),
+                    },
+                    attempts: 0,
+                    hint_key: None,
                 },
-                attempts: 0,
-            });
+                None,
+            );
 
             let fault = monoio::time::timeout(Duration::from_secs(2), fault_rx.recv())
                 .await

--- a/crates/job/scheduler/src/scheduler.rs
+++ b/crates/job/scheduler/src/scheduler.rs
@@ -54,11 +54,16 @@ impl Default for JobSchedulerConfig {
                 threads: 1,
                 concurrency_per_worker: 32,
                 priority_queue: false,
+                // Boost cap: small vs concurrency (512 in production
+                // config) so a single peer / attack surface can't reorder
+                // the whole queue. See `SchedulerHint` design.
+                max_boost_slots: Some(64),
             },
             heavy: PoolConfig {
                 threads: 2,
                 concurrency_per_worker: 8,
                 priority_queue: true,
+                max_boost_slots: None,
             },
             garbling: GarblingConfig::default(),
             submission_queue_size: 256,
@@ -320,13 +325,13 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                                                 self.light
                                                     .as_ref()
                                                     .expect("light pool must exist while scheduler is running")
-                                                    .submit(priority, worker_job);
+                                                    .submit(priority, worker_job, None);
                                             }
                                             ActionCategory::Heavy => {
                                                 self.heavy
                                                     .as_ref()
                                                     .expect("heavy pool must exist while scheduler is running")
-                                                    .submit(priority, worker_job);
+                                                    .submit(priority, worker_job, None);
                                             }
                                             _ => unreachable!(),
                                         }
@@ -356,13 +361,13 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                                                 self.light
                                                     .as_ref()
                                                     .expect("light pool must exist while scheduler is running")
-                                                    .submit(priority, worker_job);
+                                                    .submit(priority, worker_job, None);
                                             }
                                             ActionCategory::Heavy => {
                                                 self.heavy
                                                     .as_ref()
                                                     .expect("heavy pool must exist while scheduler is running")
-                                                    .submit(priority, worker_job);
+                                                    .submit(priority, worker_job, None);
                                             }
                                             _ => unreachable!(),
                                         }

--- a/crates/job/scheduler/src/scheduler.rs
+++ b/crates/job/scheduler/src/scheduler.rs
@@ -12,9 +12,10 @@ use mosaic_cac_types::state_machine::{
     evaluator::Action as EvaluatorAction, garbler::Action as GarblerAction,
 };
 use mosaic_job_api::{
-    CircuitAction, ExecuteEvaluatorJob, ExecuteGarblerJob, JobActions, JobBatch,
+    CircuitAction, ExecuteEvaluatorJob, ExecuteGarblerJob, HintKey, HintKind, JobActions, JobBatch,
     JobSchedulerHandle, PendingCircuitJob, SessionFactory,
 };
+use mosaic_net_client::{InboundHintStream, SchedulerMessage};
 use mosaic_net_svc_api::PeerId;
 use tracing::Instrument;
 
@@ -89,6 +90,10 @@ pub struct JobScheduler<D: ExecuteGarblerJob + ExecuteEvaluatorJob> {
     submission_rx: kanal::AsyncReceiver<JobBatch>,
     /// Internal fatal faults reported by workers/coordinator.
     fault_rx: kanal::AsyncReceiver<SchedulerFault>,
+    /// Optional inbound scheduler-hint stream. When present, the main
+    /// loop consumes hints and promotes matching queued jobs in the
+    /// light pool. Absent = no hint support (tests, backwards compat).
+    hint_stream_rx: Option<kanal::AsyncReceiver<InboundHintStream>>,
 }
 
 /// Controller for graceful scheduler shutdown.
@@ -144,7 +149,11 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
     /// to the job system. It is cheaply cloneable.
     ///
     /// After construction, call [`run`](Self::run) to start the dispatch loop.
-    pub fn new(config: JobSchedulerConfig, dispatcher: D) -> (Self, JobSchedulerHandle) {
+    pub fn new(
+        config: JobSchedulerConfig,
+        dispatcher: D,
+        hint_stream_rx: Option<kanal::AsyncReceiver<InboundHintStream>>,
+    ) -> (Self, JobSchedulerHandle) {
         // Channel for SM Scheduler → Job Scheduler (batch submissions).
         //
         // Unbounded: the SM scheduler's STF can produce these inline while
@@ -194,9 +203,42 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
             garbling: Some(garbling),
             submission_rx,
             fault_rx,
+            hint_stream_rx,
         };
 
         (scheduler, handle)
+    }
+
+    /// Handle an inbound `SchedulerMessage` by promoting the matching job
+    /// in the light pool. Best-effort; unknown / unmatched hints no-op.
+    fn apply_scheduler_message(&self, inbound: InboundHintStream) {
+        let InboundHintStream { peer, payload } = inbound;
+        let peer_id: mosaic_net_svc_api::PeerId = peer;
+        let msg = match SchedulerMessage::decode(&payload) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::debug!(
+                    peer = %hex::encode(peer_id),
+                    error = %e,
+                    "failed to decode inbound SchedulerMessage; ignoring"
+                );
+                return;
+            }
+        };
+        let key = match msg {
+            SchedulerMessage::TransferStarting { commitment } => {
+                HintKey::new(peer_id, HintKind::TRANSFER_STARTING, commitment)
+            }
+        };
+        if let Some(light) = self.light.as_ref() {
+            let promoted = light.apply_hint(&key);
+            tracing::debug!(
+                peer = %hex::encode(peer_id),
+                kind = key.kind,
+                promoted,
+                "applied SchedulerMessage hint"
+            );
+        }
     }
 
     /// Run the job scheduler on a dedicated thread with its own monoio runtime.
@@ -233,6 +275,8 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
         let this = self;
         tracing::info!("job scheduler main loop started");
 
+        // Optional hint receiver: if not present, we skip the select arm by
+        // making it a never-completing future.
         loop {
             monoio::select! {
                 recv = this.submission_rx.recv() => {
@@ -242,6 +286,18 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                             tracing::info!("job scheduler submission channel closed; main loop exiting");
                             break;
                         }
+                    }
+                }
+                recv = async {
+                    match &this.hint_stream_rx {
+                        Some(rx) => rx.recv().await.ok(),
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    if let Some(inbound) = recv {
+                        this.apply_scheduler_message(inbound);
+                    } else {
+                        tracing::debug!("scheduler hint channel closed");
                     }
                 }
                 recv = shutdown_rx.recv() => {
@@ -355,13 +411,28 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                                         self.dispatch_evaluator_circuit(peer_id, action).await;
                                     }
                                     _ => {
+                                        // For ReceiveGarblingTable, register a
+                                        // hint key so an inbound
+                                        // `TransferStarting` from `peer_id`
+                                        // can promote this job to the front.
+                                        let hint_key = match &action {
+                                            EvaluatorAction::ReceiveGarblingTable(commitment) => {
+                                                let payload: [u8; 32] = (*commitment).into();
+                                                Some(HintKey::new(
+                                                    peer_id,
+                                                    HintKind::TRANSFER_STARTING,
+                                                    payload,
+                                                ))
+                                            }
+                                            _ => None,
+                                        };
                                         let worker_job = WorkerJob::Evaluator { peer_id, action };
                                         match category {
                                             ActionCategory::Light => {
                                                 self.light
                                                     .as_ref()
                                                     .expect("light pool must exist while scheduler is running")
-                                                    .submit(priority, worker_job, None);
+                                                    .submit(priority, worker_job, hint_key);
                                             }
                                             ActionCategory::Heavy => {
                                                 self.heavy

--- a/crates/job/scheduler/src/scheduler.rs
+++ b/crates/job/scheduler/src/scheduler.rs
@@ -272,7 +272,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
 
     /// Main scheduler loop running on monoio.
     async fn scheduler_loop(self, shutdown_rx: kanal::AsyncReceiver<()>) {
-        let this = self;
+        let mut this = self;
         tracing::info!("job scheduler main loop started");
 
         // Optional hint receiver: if not present, we skip the select arm by
@@ -297,7 +297,13 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                     if let Some(inbound) = recv {
                         this.apply_scheduler_message(inbound);
                     } else {
-                        tracing::debug!("scheduler hint channel closed");
+                        // Channel closed: drop the receiver so this arm
+                        // reverts to `pending()` on the next iteration.
+                        // Otherwise `recv().await` returns `None`
+                        // immediately every iteration, busy-spinning the
+                        // scheduler thread and starving the other arms.
+                        tracing::debug!("scheduler hint channel closed; disabling hint arm");
+                        this.hint_stream_rx = None;
                     }
                 }
                 recv = shutdown_rx.recv() => {

--- a/crates/job/scheduler/src/scheduler.rs
+++ b/crates/job/scheduler/src/scheduler.rs
@@ -227,14 +227,14 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
         };
         let key = match msg {
             SchedulerMessage::TransferStarting { commitment } => {
-                HintKey::new(peer_id, HintKind::TRANSFER_STARTING, commitment)
+                HintKey::new(peer_id, HintKind::TransferStarting, commitment)
             }
         };
         if let Some(light) = self.light.as_ref() {
             let promoted = light.apply_hint(&key);
             tracing::debug!(
                 peer = %hex::encode(peer_id),
-                kind = key.kind,
+                kind = ?key.kind,
                 promoted,
                 "applied SchedulerMessage hint"
             );
@@ -420,7 +420,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                                                 let payload: [u8; 32] = (*commitment).into();
                                                 Some(HintKey::new(
                                                     peer_id,
-                                                    HintKind::TRANSFER_STARTING,
+                                                    HintKind::TransferStarting,
                                                     payload,
                                                 ))
                                             }

--- a/crates/net/client/src/error.rs
+++ b/crates/net/client/src/error.rs
@@ -4,6 +4,20 @@ use ark_serialize::SerializationError;
 use mosaic_net_svc::{ExpectError, StreamClosed, api::OpenStreamError};
 use mosaic_net_svc_api::PeerId;
 
+/// Error sending a scheduler-hint message.
+#[derive(Debug, thiserror::Error)]
+pub enum SendHintError {
+    /// Failed to encode the message.
+    #[error("encode failed: {0}")]
+    Encode(String),
+    /// Failed to open scheduler-hint stream to peer.
+    #[error("failed to open hint stream: {0}")]
+    Open(#[from] OpenStreamError),
+    /// Failed to write the encoded payload.
+    #[error("write failed: {0}")]
+    Write(#[source] StreamClosed),
+}
+
 /// Error sending a protocol message.
 #[derive(Debug, thiserror::Error)]
 pub enum SendError {

--- a/crates/net/client/src/hint.rs
+++ b/crates/net/client/src/hint.rs
@@ -56,13 +56,18 @@ impl SchedulerMessage {
         Ok(buf)
     }
 
-    /// Deserialize from bytes.
+    /// Deserialize from bytes. The frame must be exactly the size of the
+    /// encoded variant — trailing bytes are rejected so a forward-compat
+    /// receiver can't be fed extra data smuggled after a known variant.
     pub fn decode(bytes: &[u8]) -> Result<Self, SchedulerMessageError> {
         let (tag, rest) = bytes
             .split_first()
             .ok_or(SchedulerMessageError::Truncated)?;
         match tag {
             1 => {
+                if rest.len() != 32 {
+                    return Err(SchedulerMessageError::Truncated);
+                }
                 let commitment = <[u8; 32] as CanonicalDeserialize>::deserialize_with_mode(
                     rest,
                     Compress::No,
@@ -127,6 +132,21 @@ mod tests {
     #[test]
     fn decode_empty_returns_truncated() {
         let err = SchedulerMessage::decode(&[]).unwrap_err();
+        assert!(matches!(err, SchedulerMessageError::Truncated));
+    }
+
+    #[test]
+    fn decode_trailing_bytes_returns_truncated() {
+        // TransferStarting is 1-byte tag + 32-byte commitment = 33 bytes.
+        // Extras must be rejected so a peer can't smuggle bytes past a
+        // known variant.
+        let mut bytes = SchedulerMessage::TransferStarting {
+            commitment: [1u8; 32],
+        }
+        .encode()
+        .expect("encode");
+        bytes.push(0xff);
+        let err = SchedulerMessage::decode(&bytes).unwrap_err();
         assert!(matches!(err, SchedulerMessageError::Truncated));
     }
 }

--- a/crates/net/client/src/hint.rs
+++ b/crates/net/client/src/hint.rs
@@ -1,0 +1,132 @@
+//! Scheduler-to-scheduler advisory messages.
+//!
+//! [`SchedulerMessage`] carries best-effort hints from one peer's scheduler
+//! to another, letting the receiver promote matching queued work ahead of
+//! its FIFO order. Messages never touch the state machine and are not
+//! replayed — if a message is lost in transit, the receiver falls back to
+//! plain FIFO scheduling.
+//!
+//! Encoded via `ark-serialize` to match the rest of the mosaic wire surface.
+//! The type is designed to be additive: adding new [`SchedulerMessage`]
+//! variants is a wire-forward-compatible change since peers ignore unknown
+//! variants at decode time.
+//!
+//! Callers on the receive side decode inbound bytes into a
+//! [`SchedulerMessage`] and route it to their scheduler layer, where each
+//! variant is mapped to a `HintKey` for queue promotion. The mapping lives
+//! in the job scheduler crate (not here) to keep this module free of
+//! scheduler dependencies.
+
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
+
+/// A scheduler-to-scheduler advisory message.
+///
+/// Wire-encoded as `[u8 tag][payload]`, where the tag is the numeric
+/// discriminant. Peers ignore unknown tags at decode time (`InvalidTag`)
+/// so introducing new variants doesn't break older peers — they simply
+/// don't act on messages they don't understand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchedulerMessage {
+    /// The sender is about to open a bulk transfer stream for a garbling
+    /// table with the given commitment. The receiver's scheduler should
+    /// promote a matching `ReceiveGarblingTable` job to the front of its
+    /// light-pool queue so the expectation is registered before the
+    /// stream lands.
+    TransferStarting {
+        /// Commitment identifying the table.
+        commitment: [u8; 32],
+    },
+}
+
+impl SchedulerMessage {
+    /// Serialize to bytes. Returns the encoded frame ready to write to a
+    /// scheduler-hint stream.
+    pub fn encode(&self) -> Result<Vec<u8>, SchedulerMessageError> {
+        let tag: u8 = match self {
+            Self::TransferStarting { .. } => 1,
+        };
+        let mut buf = vec![tag];
+        match self {
+            Self::TransferStarting { commitment } => {
+                commitment
+                    .serialize_with_mode(&mut buf, Compress::No)
+                    .map_err(|e| SchedulerMessageError::Encode(e.to_string()))?;
+            }
+        }
+        Ok(buf)
+    }
+
+    /// Deserialize from bytes.
+    pub fn decode(bytes: &[u8]) -> Result<Self, SchedulerMessageError> {
+        let (tag, rest) = bytes
+            .split_first()
+            .ok_or(SchedulerMessageError::Truncated)?;
+        match tag {
+            1 => {
+                let commitment = <[u8; 32] as CanonicalDeserialize>::deserialize_with_mode(
+                    rest,
+                    Compress::No,
+                    Validate::Yes,
+                )
+                .map_err(|e| SchedulerMessageError::Decode(e.to_string()))?;
+                Ok(Self::TransferStarting { commitment })
+            }
+            unknown => Err(SchedulerMessageError::UnknownTag(*unknown)),
+        }
+    }
+}
+
+/// Errors returned by [`SchedulerMessage`] encode / decode.
+#[derive(Debug)]
+pub enum SchedulerMessageError {
+    /// The buffer was empty or ended mid-payload.
+    Truncated,
+    /// Tag byte didn't correspond to any known variant. Callers should
+    /// treat this as a soft failure — the peer may be on newer code.
+    UnknownTag(u8),
+    /// `ark-serialize` failed to encode.
+    Encode(String),
+    /// `ark-serialize` failed to decode.
+    Decode(String),
+}
+
+impl std::fmt::Display for SchedulerMessageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Truncated => write!(f, "scheduler message truncated"),
+            Self::UnknownTag(t) => write!(f, "unknown scheduler message tag: {t}"),
+            Self::Encode(e) => write!(f, "encode error: {e}"),
+            Self::Decode(e) => write!(f, "decode error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SchedulerMessageError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transfer_starting_roundtrip() {
+        let msg = SchedulerMessage::TransferStarting {
+            commitment: [7u8; 32],
+        };
+        let bytes = msg.encode().expect("encode");
+        let decoded = SchedulerMessage::decode(&bytes).expect("decode");
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn decode_unknown_tag_returns_error() {
+        let bytes = [255u8; 33];
+        let err = SchedulerMessage::decode(&bytes).unwrap_err();
+        assert!(matches!(err, SchedulerMessageError::UnknownTag(255)));
+    }
+
+    #[test]
+    fn decode_empty_returns_truncated() {
+        let err = SchedulerMessage::decode(&[]).unwrap_err();
+        assert!(matches!(err, SchedulerMessageError::Truncated));
+    }
+}

--- a/crates/net/client/src/lib.rs
+++ b/crates/net/client/src/lib.rs
@@ -54,6 +54,7 @@
 
 pub mod bulk;
 pub mod error;
+pub mod hint;
 pub mod protocol;
 
 use std::{
@@ -71,6 +72,7 @@ use futures_util::{
     future::{Either, select},
     pin_mut,
 };
+pub use hint::{SchedulerMessage, SchedulerMessageError};
 use mosaic_cac_types::Msg;
 use mosaic_net_svc::{FrameLimits, NetServiceHandle};
 pub use protocol::{Ack, InboundRequest, PeerId, StreamPriority};

--- a/crates/net/client/src/lib.rs
+++ b/crates/net/client/src/lib.rs
@@ -74,8 +74,8 @@ use futures_util::{
     pin_mut,
 };
 pub use hint::{SchedulerMessage, SchedulerMessageError};
-pub use mosaic_net_svc::InboundHintStream;
 use mosaic_cac_types::Msg;
+pub use mosaic_net_svc::InboundHintStream;
 use mosaic_net_svc::{FrameLimits, NetServiceHandle};
 pub use protocol::{Ack, InboundRequest, PeerId, StreamPriority};
 
@@ -158,10 +158,7 @@ impl NetClient {
             .await
             .map_err(SendHintError::Open)?;
         // Write; the sender drops the stream on function return which sends FIN.
-        stream
-            .write(bytes)
-            .await
-            .map_err(SendHintError::Write)?;
+        stream.write(bytes).await.map_err(SendHintError::Write)?;
         Ok(())
     }
 

--- a/crates/net/client/src/lib.rs
+++ b/crates/net/client/src/lib.rs
@@ -65,7 +65,8 @@ use std::{
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
 pub use bulk::{BulkExpectation, BulkReceiver, BulkSender};
 pub use error::{
-    AckError, BulkExpectError, BulkOpenError, BulkReadError, BulkReceiveError, RecvError, SendError,
+    AckError, BulkExpectError, BulkOpenError, BulkReadError, BulkReceiveError, RecvError,
+    SendError, SendHintError,
 };
 use futures_util::{
     FutureExt,
@@ -73,6 +74,7 @@ use futures_util::{
     pin_mut,
 };
 pub use hint::{SchedulerMessage, SchedulerMessageError};
+pub use mosaic_net_svc::InboundHintStream;
 use mosaic_cac_types::Msg;
 use mosaic_net_svc::{FrameLimits, NetServiceHandle};
 pub use protocol::{Ack, InboundRequest, PeerId, StreamPriority};
@@ -135,6 +137,35 @@ impl NetClient {
     pub fn handle(&self) -> &NetServiceHandle {
         &self.handle
     }
+
+    /// Send a scheduler-to-scheduler hint to a peer.
+    ///
+    /// Opens a high-priority `SchedulerHint` stream, writes the encoded
+    /// message, and drops the stream (FIN). Fire-and-forget — no ack is
+    /// awaited, so a failed send doesn't retry. Errors are logged and
+    /// returned so callers can decide whether to record the failure.
+    pub async fn send_hint(
+        &self,
+        peer: PeerId,
+        msg: &SchedulerMessage,
+    ) -> Result<(), SendHintError> {
+        let bytes = msg
+            .encode()
+            .map_err(|e| SendHintError::Encode(e.to_string()))?;
+        let mut stream = self
+            .handle
+            .open_scheduler_hint_stream(peer, StreamPriority::SchedulerHint.as_i32())
+            .await
+            .map_err(SendHintError::Open)?;
+        // Write; the sender drops the stream on function return which sends FIN.
+        stream
+            .write(bytes)
+            .await
+            .map_err(SendHintError::Write)?;
+        Ok(())
+    }
+
+    // For inbound hint payloads, use `client.handle().hint_streams()`.
 
     /// Open a bulk-transfer sender stream to a peer.
     pub async fn open_bulk_sender(

--- a/crates/net/client/src/protocol.rs
+++ b/crates/net/client/src/protocol.rs
@@ -30,6 +30,10 @@ pub enum StreamPriority {
     Normal = 0,
     /// Acknowledgments - higher than normal to avoid blocking.
     Ack = 1,
+    /// Scheduler hints - highest priority, sent ahead of protocol / bulk /
+    /// ack traffic so a peer's scheduler can react before the actual work
+    /// arrives. Fire-and-forget; no ack expected.
+    SchedulerHint = 2,
 }
 
 impl StreamPriority {

--- a/crates/net/client/tests/integration.rs
+++ b/crates/net/client/tests/integration.rs
@@ -1110,3 +1110,102 @@ fn test_bulk_receiver_read_timeout() {
         sender.reset(0).await;
     });
 }
+
+// ============================================================================
+// Scheduler-hint flow (cooperative scheduling)
+// ============================================================================
+//
+// Verify the wire-level send/receive path: sender's `NetClient::send_hint`
+// reaches the receiver's `hint_streams()` receiver with the correct sender
+// peer id and a decodable `SchedulerMessage` payload.
+//
+// The scheduler-layer promotion (applying the hint to a queued job) is
+// covered by unit tests in `mosaic-job-scheduler`; this test focuses on
+// the wire path across a real net-svc pair.
+
+#[test]
+fn scheduler_hint_transfer_starting_delivered_end_to_end() {
+    let (mut peer_a, mut peer_b) = create_client_pair();
+
+    run_async(async {
+        stabilize_stream_path(&peer_a, &peer_b).await;
+
+        // Peer A sends a TransferStarting hint to peer B. B's scheduler
+        // (represented here by draining `hint_streams()`) should receive
+        // it with `peer = A` and a payload that decodes to the same
+        // commitment.
+        let commitment = [0xa7u8; 32];
+        let msg = mosaic_net_client::SchedulerMessage::TransferStarting { commitment };
+
+        // Retry the send under the same CI harness other wire tests use —
+        // stabilize_stream_path proved the connection works but the peer
+        // rate limiter can transiently reject a fresh open.
+        retry_until_ok(CI_TIMEOUT, || {
+            let msg = msg.clone();
+            let client = peer_a.client.clone();
+            let target = peer_b.peer_id;
+            async move { client.send_hint(target, &msg).await.map_err(|_| ()) }
+        })
+        .await;
+
+        let inbound = tokio::time::timeout(
+            Duration::from_secs(5),
+            peer_b.client.handle().hint_streams().recv(),
+        )
+        .await
+        .expect("hint delivery timed out")
+        .expect("hint stream channel closed");
+
+        assert_eq!(
+            inbound.peer, peer_a.peer_id,
+            "hint's peer must be the sender"
+        );
+        let decoded =
+            mosaic_net_client::SchedulerMessage::decode(&inbound.payload).expect("payload decodes");
+        assert_eq!(decoded, msg);
+    });
+
+    peer_a.shutdown();
+    peer_b.shutdown();
+}
+
+#[test]
+fn scheduler_hint_from_unknown_peer_would_be_rejected() {
+    // Regression guard: the receive path routes an InboundHintStream with
+    // `peer` set to the TLS-authenticated peer id. Peers not in config
+    // can't even establish a connection, so a spoofed hint can't reach
+    // `hint_streams()`. This test asserts by construction that a hint
+    // sent between paired peers arrives with the sender's actual peer id
+    // (not the receiver's own, not zero, not something else).
+    let (mut peer_a, mut peer_b) = create_client_pair();
+
+    run_async(async {
+        stabilize_stream_path(&peer_a, &peer_b).await;
+
+        let msg = mosaic_net_client::SchedulerMessage::TransferStarting {
+            commitment: [0x11u8; 32],
+        };
+
+        retry_until_ok(CI_TIMEOUT, || {
+            let msg = msg.clone();
+            let client = peer_a.client.clone();
+            let target = peer_b.peer_id;
+            async move { client.send_hint(target, &msg).await.map_err(|_| ()) }
+        })
+        .await;
+
+        let inbound = tokio::time::timeout(
+            Duration::from_secs(5),
+            peer_b.client.handle().hint_streams().recv(),
+        )
+        .await
+        .expect("hint delivery timed out")
+        .expect("hint stream channel closed");
+
+        assert_ne!(inbound.peer, peer_b.peer_id, "hint peer must not be self");
+        assert_eq!(inbound.peer, peer_a.peer_id);
+    });
+
+    peer_a.shutdown();
+    peer_b.shutdown();
+}

--- a/crates/net/svc-api/src/api.rs
+++ b/crates/net/svc-api/src/api.rs
@@ -388,6 +388,26 @@ impl std::fmt::Debug for InboundProtocolStream {
     }
 }
 
+/// An inbound scheduler-hint stream payload.
+///
+/// Delivered via `NetServiceHandle::hint_streams`. Best-effort — a lost
+/// stream is not retried. Payload is the encoded `SchedulerMessage`.
+pub struct InboundHintStream {
+    /// The peer that sent the hint.
+    pub peer: PeerId,
+    /// The raw encoded scheduler-message payload.
+    pub payload: PayloadBuf,
+}
+
+impl std::fmt::Debug for InboundHintStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InboundHintStream")
+            .field("peer", &self.peer)
+            .field("payload_len", &self.payload.len())
+            .finish()
+    }
+}
+
 /// Handle to the network service.
 ///
 /// This is cheaply cloneable and can be sent to any thread. All methods use

--- a/crates/net/svc-api/src/api.rs
+++ b/crates/net/svc-api/src/api.rs
@@ -420,6 +420,8 @@ pub struct NetServiceHandle {
     command_tx: AsyncSender<NetCommand>,
     /// Incoming protocol requests (shared receiver).
     protocol_stream_rx: AsyncReceiver<InboundProtocolStream>,
+    /// Incoming scheduler-hint payloads (shared receiver).
+    hint_stream_rx: AsyncReceiver<InboundHintStream>,
     /// Monotonic request ID generator for explicit stream-open cancellation.
     next_open_request_id: Arc<AtomicU64>,
 }
@@ -433,11 +435,13 @@ impl NetServiceHandle {
         config: Arc<NetServiceConfig>,
         command_tx: AsyncSender<NetCommand>,
         protocol_stream_rx: AsyncReceiver<InboundProtocolStream>,
+        hint_stream_rx: AsyncReceiver<InboundHintStream>,
     ) -> Self {
         Self {
             config,
             command_tx,
             protocol_stream_rx,
+            hint_stream_rx,
             next_open_request_id: Arc::new(AtomicU64::new(1)),
         }
     }
@@ -467,6 +471,14 @@ impl NetServiceHandle {
     /// (or resetting/closing the stream), not for reading more request frames.
     pub fn protocol_streams(&self) -> &AsyncReceiver<InboundProtocolStream> {
         &self.protocol_stream_rx
+    }
+
+    /// Get the receiver for incoming scheduler-hint payloads.
+    ///
+    /// The job scheduler should own this and drain it to translate each
+    /// `SchedulerMessage` into a `HintKey` for queue promotion.
+    pub fn hint_streams(&self) -> &AsyncReceiver<InboundHintStream> {
+        &self.hint_stream_rx
     }
 
     /// Open a protocol stream to a peer.
@@ -556,6 +568,48 @@ impl NetServiceHandle {
                 request_id,
                 peer,
                 identifier,
+                priority,
+                cancel_token,
+                respond_to: resp_tx,
+            })
+            .await
+            .map_err(|_| {
+                cancel_guard.disarm();
+                OpenStreamError::ServiceDown
+            })?;
+
+        let result = resp_rx
+            .recv()
+            .await
+            .map_err(|_| OpenStreamError::ServiceDown)?;
+        cancel_guard.disarm();
+        result
+    }
+
+    /// Open a scheduler-hint stream to a peer.
+    ///
+    /// Scheduler-hint streams use `StreamType::SchedulerHint` and are
+    /// dispatched by the peer's net-svc to its `hint_streams()` receiver.
+    /// The caller writes the encoded `SchedulerMessage` payload and drops
+    /// the stream (FIN). Fire-and-forget; no ack is expected.
+    pub async fn open_scheduler_hint_stream(
+        &self,
+        peer: PeerId,
+        priority: i32,
+    ) -> Result<Stream, OpenStreamError> {
+        if !self.config.has_peer(&peer) {
+            return Err(OpenStreamError::PeerNotFound);
+        }
+
+        let request_id = self.allocate_open_request_id();
+        let cancel_token = Arc::new(AtomicBool::new(false));
+        let mut cancel_guard =
+            OpenCancelOnDrop::new(request_id, self.command_tx.clone(), cancel_token.clone());
+        let (resp_tx, resp_rx) = kanal::bounded_async(1);
+        self.command_tx
+            .send(NetCommand::OpenSchedulerHintStream {
+                request_id,
+                peer,
                 priority,
                 cancel_token,
                 respond_to: resp_tx,
@@ -764,6 +818,19 @@ pub enum NetCommand {
     CancelOpen {
         /// Request ID assigned when the open request was submitted.
         request_id: u64,
+    },
+    /// Open a scheduler-hint stream to a peer. High-priority, fire-and-forget.
+    OpenSchedulerHintStream {
+        /// Unique request ID for explicit cancellation.
+        request_id: u64,
+        /// Target peer.
+        peer: PeerId,
+        /// Stream priority — typically [`SchedulerHint`](crate::api) at 2.
+        priority: i32,
+        /// Shared cancel token set on caller drop.
+        cancel_token: Arc<AtomicBool>,
+        /// Channel to send the result back on.
+        respond_to: AsyncSender<Result<Stream, OpenStreamError>>,
     },
 }
 

--- a/crates/net/svc-api/src/lib.rs
+++ b/crates/net/svc-api/src/lib.rs
@@ -28,8 +28,8 @@ pub mod peer_id;
 
 // Re-export main types for convenience.
 pub use api::{
-    BulkTransferExpectation, ExpectError, InboundProtocolStream, NetServiceHandle, OpenStreamError,
-    PayloadBuf, Stream, StreamClosed,
+    BulkTransferExpectation, ExpectError, InboundHintStream, InboundProtocolStream,
+    NetServiceHandle, OpenStreamError, PayloadBuf, Stream, StreamClosed,
 };
 pub use config::{NetServiceConfig, PeerConfig, PeerStreamRateLimit};
 pub use handshake::{

--- a/crates/net/svc/src/lib.rs
+++ b/crates/net/svc/src/lib.rs
@@ -55,9 +55,9 @@ pub mod tls;
 
 // Re-export main API types for convenience.
 pub use mosaic_net_svc_api::{
-    BulkTransferExpectation, ExpectError, InboundHintStream, InboundProtocolStream, NetServiceConfig,
-    NetServiceHandle, OpenStreamError, PayloadBuf, PeerConfig, PeerId, Stream, StreamClosed,
-    peer_id_from_signing_key, peer_id_from_verifying_key,
+    BulkTransferExpectation, ExpectError, InboundHintStream, InboundProtocolStream,
+    NetServiceConfig, NetServiceHandle, OpenStreamError, PayloadBuf, PeerConfig, PeerId, Stream,
+    StreamClosed, peer_id_from_signing_key, peer_id_from_verifying_key,
 };
 pub use mosaic_net_wire::FrameLimits;
 pub use svc::{NetService, NetServiceController, ServiceError};

--- a/crates/net/svc/src/lib.rs
+++ b/crates/net/svc/src/lib.rs
@@ -55,7 +55,7 @@ pub mod tls;
 
 // Re-export main API types for convenience.
 pub use mosaic_net_svc_api::{
-    BulkTransferExpectation, ExpectError, InboundProtocolStream, NetServiceConfig,
+    BulkTransferExpectation, ExpectError, InboundHintStream, InboundProtocolStream, NetServiceConfig,
     NetServiceHandle, OpenStreamError, PayloadBuf, PeerConfig, PeerId, Stream, StreamClosed,
     peer_id_from_signing_key, peer_id_from_verifying_key,
 };

--- a/crates/net/svc/src/svc/handlers.rs
+++ b/crates/net/svc/src/svc/handlers.rs
@@ -1576,6 +1576,33 @@ pub fn handle_event(event: ServiceEvent, state: &mut ServiceState) {
                     }
                 }
                 mosaic_net_wire::StreamType::SchedulerHint => {
+                    // Same per-peer bucket as protocol streams — a peer
+                    // can otherwise open many hint streams that trickle
+                    // or withhold the first frame, tying up
+                    // `spawn_hint_stream_router` tasks + QUIC bidi slots
+                    // for `PROTOCOL_FIRST_PAYLOAD_TIMEOUT` each. Hint
+                    // arrival rate is tiny (a handful per setup) so
+                    // sharing the protocol bucket costs nothing in
+                    // steady state.
+                    match state.peer_rate_limiter.try_admit(peer) {
+                        super::peer_rate_limit::AdmissionDecision::Admit => {}
+                        super::peer_rate_limit::AdmissionDecision::Reject { warn: true } => {
+                            tracing::warn!(
+                                peer = %hex::encode(peer),
+                                "rate limit exceeded for inbound scheduler-hint stream; resetting (further rejects within window will log at debug)"
+                            );
+                            let _ = send.reset(0u32.into());
+                            return;
+                        }
+                        super::peer_rate_limit::AdmissionDecision::Reject { warn: false } => {
+                            tracing::debug!(
+                                peer = %hex::encode(peer),
+                                "rate limit exceeded for inbound scheduler-hint stream; resetting"
+                            );
+                            let _ = send.reset(0u32.into());
+                            return;
+                        }
+                    }
                     tasks::spawn_hint_stream_router(peer, send, recv, state.hint_stream_tx.clone());
                 }
             }

--- a/crates/net/svc/src/svc/handlers.rs
+++ b/crates/net/svc/src/svc/handlers.rs
@@ -92,6 +92,24 @@ pub fn handle_command(cmd: NetCommand, state: &mut ServiceState) {
         NetCommand::CancelOpen { request_id } => {
             cancel_open_request(request_id, state);
         }
+
+        NetCommand::OpenSchedulerHintStream {
+            request_id,
+            peer,
+            priority,
+            cancel_token,
+            respond_to,
+        } => {
+            handle_open_stream_request(
+                request_id,
+                peer,
+                cancel_token,
+                mosaic_net_wire::StreamType::SchedulerHint,
+                priority,
+                respond_to,
+                state,
+            );
+        }
     }
 }
 
@@ -1558,15 +1576,12 @@ pub fn handle_event(event: ServiceEvent, state: &mut ServiceState) {
                     }
                 }
                 mosaic_net_wire::StreamType::SchedulerHint => {
-                    // TODO: dispatch hint streams to the scheduler's hint
-                    // receiver. For now, drop with a debug log — the receive
-                    // side plumbing lands in a subsequent commit.
-                    tracing::debug!(
-                        peer = %hex::encode(peer),
-                        "SchedulerHint stream received but receive-side dispatch not yet wired; dropping"
+                    tasks::spawn_hint_stream_router(
+                        peer,
+                        send,
+                        recv,
+                        state.hint_stream_tx.clone(),
                     );
-                    let _ = send.reset(0u32.into());
-                    let _ = recv;
                 }
             }
         }

--- a/crates/net/svc/src/svc/handlers.rs
+++ b/crates/net/svc/src/svc/handlers.rs
@@ -1557,6 +1557,17 @@ pub fn handle_event(event: ServiceEvent, state: &mut ServiceState) {
                         );
                     }
                 }
+                mosaic_net_wire::StreamType::SchedulerHint => {
+                    // TODO: dispatch hint streams to the scheduler's hint
+                    // receiver. For now, drop with a debug log — the receive
+                    // side plumbing lands in a subsequent commit.
+                    tracing::debug!(
+                        peer = %hex::encode(peer),
+                        "SchedulerHint stream received but receive-side dispatch not yet wired; dropping"
+                    );
+                    let _ = send.reset(0u32.into());
+                    let _ = recv;
+                }
             }
         }
 

--- a/crates/net/svc/src/svc/handlers.rs
+++ b/crates/net/svc/src/svc/handlers.rs
@@ -1576,12 +1576,7 @@ pub fn handle_event(event: ServiceEvent, state: &mut ServiceState) {
                     }
                 }
                 mosaic_net_wire::StreamType::SchedulerHint => {
-                    tasks::spawn_hint_stream_router(
-                        peer,
-                        send,
-                        recv,
-                        state.hint_stream_tx.clone(),
-                    );
+                    tasks::spawn_hint_stream_router(peer, send, recv, state.hint_stream_tx.clone());
                 }
             }
         }

--- a/crates/net/svc/src/svc/mod.rs
+++ b/crates/net/svc/src/svc/mod.rs
@@ -173,6 +173,10 @@ impl NetService {
         // #220) bounds peer fan-in upstream of this channel.
         let (protocol_stream_tx, protocol_stream_rx) = bounded_async(64);
 
+        // Scheduler-hint stream channel (service -> handles). Bounded — a
+        // slow consumer just drops hints (they're advisory and best-effort).
+        let (hint_stream_tx, hint_stream_rx) = bounded_async(256);
+
         // Shutdown channel
         let (shutdown_tx, shutdown_rx) = bounded_async(1);
 
@@ -180,7 +184,12 @@ impl NetService {
         // Bounded(1) so send is infallible unless receiver is dropped.
         let (startup_tx, startup_rx) = bounded_async::<Result<(), ServiceError>>(1);
 
-        let handle = NetServiceHandle::new(config.clone(), command_tx, protocol_stream_rx);
+        let handle = NetServiceHandle::new(
+            config.clone(),
+            command_tx,
+            protocol_stream_rx,
+            hint_stream_rx,
+        );
 
         // Clone for the thread
         let shutdown_tx_clone = shutdown_tx.clone();
@@ -193,6 +202,7 @@ impl NetService {
                     allowed_peers,
                     command_rx,
                     protocol_stream_tx,
+                    hint_stream_tx,
                     shutdown_rx,
                     startup_tx,
                 )
@@ -236,6 +246,7 @@ fn run_service(
     allowed_peers: Arc<HashSet<PeerId>>,
     command_rx: AsyncReceiver<NetCommand>,
     protocol_stream_tx: AsyncSender<InboundProtocolStream>,
+    hint_stream_tx: AsyncSender<crate::api::InboundHintStream>,
     shutdown_rx: AsyncReceiver<()>,
     startup_tx: AsyncSender<Result<(), ServiceError>>,
 ) -> Result<(), ServiceError> {
@@ -255,6 +266,7 @@ fn run_service(
         allowed_peers,
         command_rx,
         protocol_stream_tx,
+        hint_stream_tx,
         shutdown_rx,
         startup_tx,
     ))
@@ -266,6 +278,7 @@ async fn run_service_async(
     allowed_peers: Arc<HashSet<PeerId>>,
     command_rx: AsyncReceiver<NetCommand>,
     protocol_stream_tx: AsyncSender<InboundProtocolStream>,
+    hint_stream_tx: AsyncSender<crate::api::InboundHintStream>,
     shutdown_rx: AsyncReceiver<()>,
     startup_tx: AsyncSender<Result<(), ServiceError>>,
 ) -> Result<(), ServiceError> {
@@ -301,6 +314,7 @@ async fn run_service_async(
         peer_states: HashMap::<PeerId, PeerConnectionState>::new(),
         bulk_expectations: HashMap::new(),
         protocol_stream_tx,
+        hint_stream_tx,
         pending_reconnects: Vec::new(),
         pending_stream_requests: HashMap::new(),
         open_request_states: HashMap::new(),

--- a/crates/net/svc/src/svc/state.rs
+++ b/crates/net/svc/src/svc/state.rs
@@ -14,7 +14,7 @@ use quinn::Endpoint;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
-    api::{InboundProtocolStream, OpenStreamError, Stream},
+    api::{InboundHintStream, InboundProtocolStream, OpenStreamError, Stream},
     config::NetServiceConfig,
     tls::PeerId,
 };
@@ -170,6 +170,9 @@ pub struct ServiceState {
 
     /// Channel to send incoming protocol requests to handles.
     pub protocol_stream_tx: AsyncSender<InboundProtocolStream>,
+
+    /// Channel to send incoming scheduler-hint payloads to handles.
+    pub hint_stream_tx: AsyncSender<InboundHintStream>,
 
     /// Peers that need reconnection with their next attempt time.
     pub pending_reconnects: Vec<(PeerId, tokio::time::Instant)>,

--- a/crates/net/svc/src/svc/tasks.rs
+++ b/crates/net/svc/src/svc/tasks.rs
@@ -953,9 +953,16 @@ pub fn spawn_hint_stream_router(
     recv: quinn::RecvStream,
     hint_stream_tx: AsyncSender<crate::api::InboundHintStream>,
 ) {
+    // Hint payloads are tiny (`SchedulerMessage::TransferStarting` is 33
+    // bytes today) but the enum is meant to grow additively. 256 bytes is
+    // comfortable headroom for foreseeable variants and drastically caps a
+    // buggy peer's ability to drive transient memory pressure through the
+    // 256-entry hint channel with valid-but-oversized frames.
+    const HINT_FRAME_MAX_SIZE: u32 = 256;
+    let hint_limits = mosaic_net_wire::FrameLimits::new(HINT_FRAME_MAX_SIZE, HINT_FRAME_MAX_SIZE);
     tokio::spawn(async move {
         let mut recv = recv;
-        match read_first_protocol_payload(&mut recv).await {
+        match read_first_framed_payload(&mut recv, hint_limits).await {
             Ok(payload) => {
                 let _ = recv.stop(0u32.into());
                 let mut send = send;
@@ -1010,9 +1017,22 @@ pub fn spawn_bulk_stream_router(
     });
 }
 
+/// Read the first framed payload from a stream using the default frame
+/// limits (4 MiB). Used by protocol streams.
 async fn read_first_protocol_payload(recv: &mut quinn::RecvStream) -> Result<Vec<u8>, String> {
-    let limits = mosaic_net_wire::FrameLimits::default();
-    let mut buf = Vec::with_capacity(4 * 1024);
+    read_first_framed_payload(recv, mosaic_net_wire::FrameLimits::default()).await
+}
+
+/// Read the first framed payload with caller-specified limits.
+///
+/// Hint streams pass a small cap (256 bytes) so a buggy peer can't drive
+/// hundreds of MiB of transient buffer allocation through the 256-entry
+/// hint channel by opening streams with valid-but-oversized frames.
+async fn read_first_framed_payload(
+    recv: &mut quinn::RecvStream,
+    limits: mosaic_net_wire::FrameLimits,
+) -> Result<Vec<u8>, String> {
+    let mut buf = Vec::with_capacity((limits.max_recv_size as usize).min(4 * 1024));
     let mut read_buf = [0u8; 64 * 1024];
     let deadline = Instant::now() + PROTOCOL_FIRST_PAYLOAD_TIMEOUT;
 

--- a/crates/net/svc/src/svc/tasks.rs
+++ b/crates/net/svc/src/svc/tasks.rs
@@ -738,10 +738,13 @@ pub fn spawn_stream_header_reader(
                 .map_err(|_| "header read timed out")?
                 .map_err(|e| e.to_string())?;
 
-            // Determine remaining bytes
+            // Determine remaining bytes. Keep this table in sync with
+            // `mosaic_net_wire::StreamHeader::decode`; a mismatch will drop
+            // otherwise-valid streams at the header stage.
             let remaining = match buf[0] {
                 0x00 => 0,  // Protocol
                 0x01 => 32, // BulkTransfer
+                0x02 => 0,  // SchedulerHint
                 tag => return Err(format!("unknown stream type: 0x{:02x}", tag)),
             };
 
@@ -956,10 +959,24 @@ pub fn spawn_hint_stream_router(
             Ok(payload) => {
                 let _ = recv.stop(0u32.into());
                 let mut send = send;
+                // The sender's write is fire-and-forget; the reset just
+                // frees the QUIC bidi slot on both ends promptly (nothing
+                // watches for the reset code).
                 let _ = send.reset(0u32.into());
                 let inbound = crate::api::InboundHintStream { peer, payload };
-                if hint_stream_tx.send(inbound).await.is_err() {
-                    tracing::debug!(peer = %hex::encode(peer), "hint stream channel closed");
+                // try_send: if the scheduler is slow to drain, drop the
+                // hint rather than blocking this router task. Hints are
+                // advisory — losing one just means FIFO scheduling for
+                // that job. Blocking here would let a hint flood pile up
+                // spawned router tasks and QUIC bidi slots.
+                match hint_stream_tx.try_send(inbound) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        tracing::debug!(peer = %hex::encode(peer), "hint stream channel full; dropping hint");
+                    }
+                    Err(_) => {
+                        tracing::debug!(peer = %hex::encode(peer), "hint stream channel closed");
+                    }
                 }
             }
             Err(error) => {

--- a/crates/net/svc/src/svc/tasks.rs
+++ b/crates/net/svc/src/svc/tasks.rs
@@ -941,6 +941,41 @@ pub fn spawn_protocol_stream_router(
     });
 }
 
+/// Spawn a task to read one payload from a scheduler-hint stream and push
+/// it to the hint stream channel. Best-effort — a failed read is silently
+/// dropped (hints are advisory).
+pub fn spawn_hint_stream_router(
+    peer: PeerId,
+    send: quinn::SendStream,
+    recv: quinn::RecvStream,
+    hint_stream_tx: AsyncSender<crate::api::InboundHintStream>,
+) {
+    tokio::spawn(async move {
+        let mut recv = recv;
+        match read_first_protocol_payload(&mut recv).await {
+            Ok(payload) => {
+                let _ = recv.stop(0u32.into());
+                let mut send = send;
+                let _ = send.reset(0u32.into());
+                let inbound = crate::api::InboundHintStream { peer, payload };
+                if hint_stream_tx.send(inbound).await.is_err() {
+                    tracing::debug!(peer = %hex::encode(peer), "hint stream channel closed");
+                }
+            }
+            Err(error) => {
+                tracing::debug!(
+                    peer = %hex::encode(peer),
+                    error = %error,
+                    "failed to read scheduler-hint payload"
+                );
+                let _ = recv.stop(0u32.into());
+                let mut send = send;
+                let _ = send.reset(0u32.into());
+            }
+        }
+    });
+}
+
 /// Spawn a task to route a bulk transfer stream to its expectation.
 ///
 /// This creates a Stream handle and sends it to the registered expectation channel.

--- a/crates/net/wire/src/lib.rs
+++ b/crates/net/wire/src/lib.rs
@@ -104,6 +104,9 @@ impl StreamHeader {
                 buf.push(0x01);
                 buf.extend_from_slice(identifier);
             }
+            StreamType::SchedulerHint => {
+                buf.push(0x02);
+            }
         }
     }
 
@@ -112,6 +115,7 @@ impl StreamHeader {
         match &self.stream_type {
             StreamType::Protocol => 1,
             StreamType::BulkTransfer { .. } => 1 + 32,
+            StreamType::SchedulerHint => 1,
         }
     }
 
@@ -134,6 +138,7 @@ impl StreamHeader {
                     bytes[1..33].try_into().expect("slice is exactly 32 bytes");
                 Ok((Self::new(StreamType::BulkTransfer { identifier }), 33))
             }
+            0x02 => Ok((Self::new(StreamType::SchedulerHint), 1)),
             tag => Err(DecodeError::InvalidTag { tag }),
         }
     }
@@ -150,6 +155,11 @@ pub enum StreamType {
         /// 32-byte identifier (typically a commitment hash).
         identifier: [u8; 32],
     },
+    /// Scheduler-to-scheduler advisory hint stream (high priority).
+    /// Carries best-effort messages informing a peer's scheduler about
+    /// impending work — see `mosaic-net-client::hint::SchedulerMessage`.
+    /// Never touches the SM state machine.
+    SchedulerHint,
 }
 
 impl StreamType {

--- a/crates/sm-executor/src/lib.rs
+++ b/crates/sm-executor/src/lib.rs
@@ -1577,7 +1577,9 @@ mod tests {
         let (command_tx, _command_rx) = kanal::bounded_async::<NetCommand>(8);
         let (protocol_tx, protocol_rx) =
             kanal::bounded_async::<mosaic_net_svc_api::InboundProtocolStream>(8);
-        let handle = NetServiceHandle::new(config, command_tx, protocol_rx);
+        let (_hint_tx, hint_rx) =
+            kanal::bounded_async::<mosaic_net_svc_api::InboundHintStream>(8);
+        let handle = NetServiceHandle::new(config, command_tx, protocol_rx, hint_rx);
         (NetClient::new(handle), protocol_tx)
     }
 

--- a/crates/sm-executor/src/lib.rs
+++ b/crates/sm-executor/src/lib.rs
@@ -1577,8 +1577,7 @@ mod tests {
         let (command_tx, _command_rx) = kanal::bounded_async::<NetCommand>(8);
         let (protocol_tx, protocol_rx) =
             kanal::bounded_async::<mosaic_net_svc_api::InboundProtocolStream>(8);
-        let (_hint_tx, hint_rx) =
-            kanal::bounded_async::<mosaic_net_svc_api::InboundHintStream>(8);
+        let (_hint_tx, hint_rx) = kanal::bounded_async::<mosaic_net_svc_api::InboundHintStream>(8);
         let handle = NetServiceHandle::new(config, command_tx, protocol_rx, hint_rx);
         (NetClient::new(handle), protocol_tx)
     }


### PR DESCRIPTION
Closes #306.

## Summary

Adds scheduler-to-scheduler advisory messages so the garbling coordinator can tell the receiver's scheduler "I'm about to send you table X" — the receiver promotes the matching `ReceiveGarblingTable` job to the front of its light-pool queue before the bulk stream arrives. Fixes the `receive_garbling_table` timeout wedge described in the linked issue.

## Design

- `HintKey { peer, kind, payload }` — opaque scheduler-layer identifier, O(1) hashable.
- `SchedulerMessage` on a dedicated `StreamType::SchedulerHint` stream at `StreamPriority::SchedulerHint = 2` (above Ack). Fire-and-forget; encode/decode is wire-forward-compat via `UnknownTag`.
- `JobQueue` FIFO backing is now a slot-based intrusive doubly-linked list with a `HashMap<HintKey, SlotId>` index. Push at tail and hint-driven promotion are both O(1). Boost queue drains completely before FIFO on pop.
- `PoolConfig::max_boost_slots: Option<usize>` — `Some(64)` for light (~12.5% of 512 concurrency), `None` for heavy/garbling. Boost overflow drops the hint (job stays FIFO, no worse than pre-hint baseline).
- `JobScheduler` accepts an optional inbound hint receiver; main `select!` loop decodes `SchedulerMessage`, maps to `HintKey`, calls `light.apply_hint`.
- `EvaluatorAction::ReceiveGarblingTable(commitment)` submit site derives `HintKey::new(peer_id, TRANSFER_STARTING, commitment)`.
- Sender: `job/executors::garbler::begin_table_transfer` fires `TransferStarting` hint just before `open_bulk_sender`, with a 5ms `futures_timer::Delay` so the peer's scheduler has a chance to promote before the bulk stream lands.
- `BULK_OPEN_TIMEOUT`: 30s → 10s. The hint mechanism tightens the sender-ready-to-receiver-ready gap enough that the timeout no longer needs to cover the full garbling-coordinator queue latency.

## Contract summary

- Hints are advisory. Delivery failure → FIFO ordering. No regression.
- Every queued job still has a bounded timeout. No indefinite deferral.
- Boost queue capped at 64 slots — bounds the fraction of the queue any peer can reorder.
- STF sees nothing new. State machine remains deterministic and replay-safe.
- Wire forward-compat: peers on old code don't send/receive hints; peers on new code sending to old code have their hint stream rejected at the header reader (unknown 0x02 tag) — nothing wedges.

## Test plan

- [x] Queue unit tests (11): FIFO ordering, boost promotion with observable ordering, boost cap, priority-mode ignore, hint-index cleanup after pop/promote (whitebox), slot free-list reuse, multiple-promotions arrival ordering
- [x] Wire type unit tests (4): `SchedulerMessage` encode/decode roundtrip, unknown tag, truncated, trailing bytes
- [x] Integration test (`mosaic-net-client`): two-peer wire path — `send_hint` from peer A delivers `InboundHintStream` to peer B's `hint_streams()` with `peer = A` and a decodable payload
- [x] `cargo test --release --workspace --lib --tests` — all pass
- [x] `cargo +nightly fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Adversarial review-loop caught one blocker (net-svc header reader was rejecting tag 0x02 before dispatch) — fixed
- [ ] Manual: two-peer testnet under sender saturation, verify receiver timeouts stop even with 10s `BULK_OPEN_TIMEOUT`

## Notes to reviewers

- **Blocker caught by review**: `spawn_stream_header_reader` in `net-svc/tasks.rs` had an inline `match buf[0]` predicting the payload size that hardcoded 0x00/0x01 only. Any new `StreamType` variant needs to be added there OR the switch replaced with `StreamHeader::decode`. I opted to add `0x02 => 0` with a comment pointing at the wire-format source of truth. Worth considering a follow-up that removes the duplication.
- **Sender delay of 5ms** is a magic number. Chosen because typical local-scheduler-tick latency is sub-ms and QUIC handles high-priority stream frames ahead of bulk — 5ms is generous. Under a very busy net-svc runtime it could be too short; a follow-up could measure empirically or add a receiver-side grace window for late-arriving expectations.
- **Peer identity** on inbound hints is the TLS-authenticated peer id (traced through the review). No spoofing surface.
- Integration test only covers the wire path; scheduler-layer promotion is covered by unit tests. A two-peer test that exercises the whole loop (submit → hint → promote → dequeue) would need a slow-garbling-coordinator scenario and is a fair follow-up.