### PR TITLE
chore(deps): bump object_store from 0.11 to 0.14

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,19 @@
 [advisories]
-# This vulnerability does not apply:
-# - The `reqwest` dependency doesn't use the affected package: https://github.com/seanmonstar/reqwest/pull/2987
-# - This codebase uses pinned keys instead of a certificate chain
-ignore = ['RUSTSEC-2026-0049']
+ignore = [
+    # This vulnerability does not apply:
+    # - The `reqwest` dependency doesn't use the affected package:
+    #   https://github.com/seanmonstar/reqwest/pull/2987
+    # - This codebase uses pinned keys instead of a certificate chain
+    'RUSTSEC-2026-0049',
+
+    # `quick-xml` advisories pulled in transitively via
+    # `object_store` -> `reqwest` for AWS XML responses. Fixed in
+    # quick-xml >= 0.41.0, but `object_store` 0.14 still pins 0.40.x.
+    # Not exploitable here: mosaic never feeds attacker-controlled XML
+    # into `object_store`; the parser only sees S3 responses from our
+    # own bucket over a TLS-authenticated channel. Re-evaluate once
+    # `object_store` bumps the pin.
+    'RUSTSEC-2026-0194', # quadratic time on duplicate attribute names
+    'RUSTSEC-2026-0195', # unbounded namespace-declaration allocation
+    'RUSTSEC-2026-0204', # additional quick-xml advisory (same fix window)
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -101,7 +101,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -622,6 +622,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1220,7 +1231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1495,9 +1506,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2782,7 +2805,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2846,32 +2869,40 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object_store"
-version = "0.11.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "chrono",
- "futures",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
  "humantime",
  "hyper",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.8.5",
+ "rand 0.10.2",
  "reqwest",
  "ring",
  "serde",
  "serde_json",
- "snafu",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
  "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -3132,9 +3163,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -3213,6 +3244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3274,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3499,7 +3547,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3556,7 +3604,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3917,27 +3965,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "snafu"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4079,7 +4106,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4675,7 +4702,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +616,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -748,6 +773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +866,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -1106,6 +1150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,7 +1339,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1363,6 +1413,12 @@ dependencies = [
  "memchr",
  "uuid",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1610,7 +1666,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -1752,7 +1808,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1776,7 +1831,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1988,6 +2043,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2078,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2221,12 +2295,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2869,14 +2943,16 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object_store"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64",
  "bytes",
  "chrono",
+ "crc-fast",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -2885,14 +2961,15 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "md-5",
+ "nix 0.31.1",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
  "rand 0.10.2",
  "reqwest",
- "ring",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2903,6 +2980,7 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3018,6 +3096,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -3163,9 +3247,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -3184,7 +3268,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3197,6 +3281,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "fastbloom",
  "getrandom 0.3.4",
@@ -3223,7 +3308,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3443,9 +3528,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -3464,11 +3549,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3556,6 +3638,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3619,6 +3702,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4008,6 +4092,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -4640,9 +4730,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4702,7 +4792,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/bin/mosaic/Cargo.toml
+++ b/bin/mosaic/Cargo.toml
@@ -38,7 +38,7 @@ foundationdb.workspace = true
 jsonrpsee = { workspace = true, features = ["server"] }
 mimalloc = "0.1"
 monoio = "0.2.4"
-object_store = { version = "0.11", features = ["aws"] }
+object_store = { version = "0.13", features = ["aws"] }
 rand.workspace = true
 rand_chacha.workspace = true
 serde.workspace = true

--- a/bin/mosaic/Cargo.toml
+++ b/bin/mosaic/Cargo.toml
@@ -38,7 +38,7 @@ foundationdb.workspace = true
 jsonrpsee = { workspace = true, features = ["server"] }
 mimalloc = "0.1"
 monoio = "0.2.4"
-object_store = { version = "0.13", features = ["aws"] }
+object_store = { version = "0.14", features = ["aws"] }
 rand.workspace = true
 rand_chacha.workspace = true
 serde.workspace = true

--- a/crates/cac/protocol/Cargo.toml
+++ b/crates/cac/protocol/Cargo.toml
@@ -39,7 +39,7 @@ mosaic-storage-kvstore.workspace = true
 tokio = { version = "1", features = ["rt", "macros"] }
 ed25519-dalek = "2.2"
 ckt-fmtv5-types.workspace = true
-object_store = { version = "0.11", features = ["aws"] }
+object_store = { version = "0.13", features = ["aws"] }
 
 [lints]
 workspace = true

--- a/crates/cac/protocol/Cargo.toml
+++ b/crates/cac/protocol/Cargo.toml
@@ -39,7 +39,7 @@ mosaic-storage-kvstore.workspace = true
 tokio = { version = "1", features = ["rt", "macros"] }
 ed25519-dalek = "2.2"
 ckt-fmtv5-types.workspace = true
-object_store = { version = "0.13", features = ["aws"] }
+object_store = { version = "0.14", features = ["aws"] }
 
 [lints]
 workspace = true

--- a/crates/net/svc/src/svc/mod.rs
+++ b/crates/net/svc/src/svc/mod.rs
@@ -50,6 +50,27 @@ use crate::{
 const MAX_CONCURRENT_BIDI_STREAMS: u32 = 100;
 const MAX_CONCURRENT_UNI_STREAMS: u32 = 0;
 
+/// Install rustls' ring `CryptoProvider` as the process-level default.
+///
+/// rustls 0.23 requires a process-level provider whenever both `ring` and
+/// `aws-lc-rs` are compiled in (they now are, via `reqwest`/`object_store`
+/// on the object-store side and `quinn` on ours), otherwise the
+/// `default_provider()` auto-select panics. We already select `ring`
+/// explicitly for QUIC in `tls::PeerVerifier`; this just makes the same
+/// choice visible to code paths (mostly reqwest inside `object_store`)
+/// that go through rustls' process-global lookup.
+///
+/// Idempotent: the underlying `install_default` errors on a second call,
+/// which we ignore. Serialised through a `Once` so overlapping
+/// `NetService::new` calls in tests can't race.
+fn install_process_crypto_provider() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 /// Handle to control the network service.
 pub struct NetServiceController {
     /// Thread handle for joining.
@@ -153,6 +174,7 @@ impl NetService {
     pub fn new(
         config: NetServiceConfig,
     ) -> Result<(NetServiceHandle, NetServiceController), ServiceError> {
+        install_process_crypto_provider();
         let config = Arc::new(config);
 
         // Precompute allowed peers set once (avoid per-accept allocation).

--- a/crates/net/svc/src/svc/mod.rs
+++ b/crates/net/svc/src/svc/mod.rs
@@ -50,27 +50,6 @@ use crate::{
 const MAX_CONCURRENT_BIDI_STREAMS: u32 = 100;
 const MAX_CONCURRENT_UNI_STREAMS: u32 = 0;
 
-/// Install rustls' ring `CryptoProvider` as the process-level default.
-///
-/// rustls 0.23 requires a process-level provider whenever both `ring` and
-/// `aws-lc-rs` are compiled in (they now are, via `reqwest`/`object_store`
-/// on the object-store side and `quinn` on ours), otherwise the
-/// `default_provider()` auto-select panics. We already select `ring`
-/// explicitly for QUIC in `tls::PeerVerifier`; this just makes the same
-/// choice visible to code paths (mostly reqwest inside `object_store`)
-/// that go through rustls' process-global lookup.
-///
-/// Idempotent: the underlying `install_default` errors on a second call,
-/// which we ignore. Serialised through a `Once` so overlapping
-/// `NetService::new` calls in tests can't race.
-fn install_process_crypto_provider() {
-    use std::sync::Once;
-    static INSTALL: Once = Once::new();
-    INSTALL.call_once(|| {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    });
-}
-
 /// Handle to control the network service.
 pub struct NetServiceController {
     /// Thread handle for joining.
@@ -174,7 +153,6 @@ impl NetService {
     pub fn new(
         config: NetServiceConfig,
     ) -> Result<(NetServiceHandle, NetServiceController), ServiceError> {
-        install_process_crypto_provider();
         let config = Arc::new(config);
 
         // Precompute allowed peers set once (avoid per-accept allocation).

--- a/crates/net/svc/src/tls.rs
+++ b/crates/net/svc/src/tls.rs
@@ -18,6 +18,28 @@
 
 use std::{collections::HashSet, fmt, sync::Arc};
 
+/// Install rustls' ring `CryptoProvider` as the process-level default.
+///
+/// rustls 0.23 requires a process-level provider whenever both `ring` and
+/// `aws-lc-rs` are compiled in — as they now are, transitively via
+/// `reqwest` / `object_store` on the object-store side and `quinn` on
+/// ours. Without this, `default_provider()` auto-select and any code
+/// path (mostly reqwest inside `object_store`) that goes through
+/// rustls' process-global lookup panic with *"Could not automatically
+/// determine the process-level CryptoProvider"*. Called from every TLS
+/// entry point so both the mosaic binary and unit tests are covered.
+///
+/// Idempotent: the underlying `install_default` errors on a second call,
+/// which we ignore. Serialised through a `Once` so overlapping callers
+/// (parallel tests) can't race.
+pub(crate) fn install_process_crypto_provider() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 use ed25519_dalek::{SigningKey, pkcs8::EncodePrivateKey};
 // Re-export peer identity types from svc-api so existing `crate::tls::PeerId` paths
 // and `use super::*` in tests continue to work.
@@ -100,6 +122,7 @@ pub struct PeerVerifier {
 impl PeerVerifier {
     /// Create a new verifier with the given set of allowed peer public keys.
     pub fn new(allowed_peers: impl IntoIterator<Item = PeerId>) -> Self {
+        install_process_crypto_provider();
         Self {
             allowed_peers: allowed_peers.into_iter().collect(),
             crypto_provider: Arc::new(rustls::crypto::ring::default_provider()),

--- a/crates/storage/s3/Cargo.toml
+++ b/crates/storage/s3/Cargo.toml
@@ -17,7 +17,7 @@ mosaic-storage-api.workspace = true
 bytes = "1.10"
 futures = "0.3"
 kanal = "0.1.1"
-object_store = { version = "0.11", features = ["aws"] }
+object_store = { version = "0.13", features = ["aws"] }
 thiserror.workspace = true
 tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
 tracing.workspace = true

--- a/crates/storage/s3/Cargo.toml
+++ b/crates/storage/s3/Cargo.toml
@@ -17,7 +17,7 @@ mosaic-storage-api.workspace = true
 bytes = "1.10"
 futures = "0.3"
 kanal = "0.1.1"
-object_store = { version = "0.13", features = ["aws"] }
+object_store = { version = "0.14", features = ["aws"] }
 thiserror.workspace = true
 tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
 tracing.workspace = true

--- a/crates/storage/s3/src/lib.rs
+++ b/crates/storage/s3/src/lib.rs
@@ -391,6 +391,7 @@ mod tests {
                 meta,
                 range: offset..total,
                 attributes: Attributes::default(),
+                extensions: Default::default(),
             })
         }
 

--- a/crates/storage/s3/src/lib.rs
+++ b/crates/storage/s3/src/lib.rs
@@ -32,7 +32,7 @@ use std::{future::Future, sync::Arc};
 pub use error::S3Error;
 use futures::StreamExt;
 use mosaic_storage_api::table_store::{TableId, TableStore};
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 
 /// Minimum part size for S3 multipart uploads (5 MiB).
 #[allow(dead_code)]
@@ -190,7 +190,6 @@ impl TableStore for S3TableStore {
 mod tests {
     use std::{
         fmt,
-        ops::Range,
         sync::{
             Arc, Mutex,
             atomic::{AtomicBool, Ordering},
@@ -198,16 +197,15 @@ mod tests {
     };
 
     use async_trait::async_trait;
-    use bytes::Bytes;
     use futures::{StreamExt, stream::BoxStream};
     use mosaic_common::Byte32;
     use mosaic_net_svc_api::PeerId;
     use mosaic_storage_api::table_store::{TableMetadata, TableReader, TableStore, TableWriter};
     use mosaic_vs3::Index;
     use object_store::{
-        Attributes, GetOptions, GetRange, GetResult, GetResultPayload, ListResult, MultipartUpload,
-        ObjectMeta, ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult,
-        Result as ObjectStoreResult, memory::InMemory, path::Path,
+        Attributes, CopyOptions, GetOptions, GetRange, GetResult, GetResultPayload, ListResult,
+        MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload,
+        PutResult, Result as ObjectStoreResult, memory::InMemory, path::Path,
     };
 
     use super::*;
@@ -265,7 +263,7 @@ mod tests {
         async fn put_multipart_opts(
             &self,
             location: &Path,
-            opts: PutMultipartOpts,
+            opts: PutMultipartOptions,
         ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
             self.inner.put_multipart_opts(location, opts).await
         }
@@ -282,31 +280,14 @@ mod tests {
             self.inner.get_opts(location, options).await
         }
 
-        async fn get_range(
+        fn delete_stream(
             &self,
-            location: &Path,
-            range: Range<usize>,
-        ) -> ObjectStoreResult<Bytes> {
-            self.inner.get_range(location, range).await
+            locations: BoxStream<'static, ObjectStoreResult<Path>>,
+        ) -> BoxStream<'static, ObjectStoreResult<Path>> {
+            self.inner.delete_stream(locations)
         }
 
-        async fn get_ranges(
-            &self,
-            location: &Path,
-            ranges: &[Range<usize>],
-        ) -> ObjectStoreResult<Vec<Bytes>> {
-            self.inner.get_ranges(location, ranges).await
-        }
-
-        async fn head(&self, location: &Path) -> ObjectStoreResult<ObjectMeta> {
-            self.inner.head(location).await
-        }
-
-        async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
-            self.inner.delete(location).await
-        }
-
-        fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, ObjectStoreResult<ObjectMeta>> {
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
             self.inner.list(prefix)
         }
 
@@ -317,12 +298,13 @@ mod tests {
             self.inner.list_with_delimiter(prefix).await
         }
 
-        async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-            self.inner.copy(from, to).await
-        }
-
-        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-            self.inner.copy_if_not_exists(from, to).await
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: CopyOptions,
+        ) -> ObjectStoreResult<()> {
+            self.inner.copy_opts(from, to, options).await
         }
     }
 
@@ -330,7 +312,7 @@ mod tests {
     struct ResumeStore {
         inner: InMemory,
         fail_first_ciphertext_stream: AtomicBool,
-        seen_offsets: Mutex<Vec<usize>>,
+        seen_offsets: Mutex<Vec<u64>>,
     }
 
     impl fmt::Display for ResumeStore {
@@ -340,7 +322,7 @@ mod tests {
     }
 
     impl ResumeStore {
-        fn seen_offsets(&self) -> Vec<usize> {
+        fn seen_offsets(&self) -> Vec<u64> {
             self.seen_offsets.lock().unwrap().clone()
         }
     }
@@ -359,7 +341,7 @@ mod tests {
         async fn put_multipart_opts(
             &self,
             location: &Path,
-            opts: PutMultipartOpts,
+            opts: PutMultipartOptions,
         ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
             self.inner.put_multipart_opts(location, opts).await
         }
@@ -382,6 +364,8 @@ mod tests {
 
             let meta = self.inner.head(location).await?;
             let bytes = self.inner.get(location).await?.bytes().await?;
+            let total = bytes.len() as u64;
+            let offset_usize = offset as usize;
 
             let payload = if offset == 0
                 && self
@@ -398,43 +382,26 @@ mod tests {
                         .boxed();
                 GetResultPayload::Stream(stream)
             } else {
-                let stream = futures::stream::iter(vec![Ok(bytes.slice(offset..))]).boxed();
+                let stream = futures::stream::iter(vec![Ok(bytes.slice(offset_usize..))]).boxed();
                 GetResultPayload::Stream(stream)
             };
 
             Ok(GetResult {
                 payload,
                 meta,
-                range: offset..bytes.len(),
+                range: offset..total,
                 attributes: Attributes::default(),
             })
         }
 
-        async fn get_range(
+        fn delete_stream(
             &self,
-            location: &Path,
-            range: Range<usize>,
-        ) -> ObjectStoreResult<Bytes> {
-            self.inner.get_range(location, range).await
+            locations: BoxStream<'static, ObjectStoreResult<Path>>,
+        ) -> BoxStream<'static, ObjectStoreResult<Path>> {
+            self.inner.delete_stream(locations)
         }
 
-        async fn get_ranges(
-            &self,
-            location: &Path,
-            ranges: &[Range<usize>],
-        ) -> ObjectStoreResult<Vec<Bytes>> {
-            self.inner.get_ranges(location, ranges).await
-        }
-
-        async fn head(&self, location: &Path) -> ObjectStoreResult<ObjectMeta> {
-            self.inner.head(location).await
-        }
-
-        async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
-            self.inner.delete(location).await
-        }
-
-        fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, ObjectStoreResult<ObjectMeta>> {
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
             self.inner.list(prefix)
         }
 
@@ -445,12 +412,13 @@ mod tests {
             self.inner.list_with_delimiter(prefix).await
         }
 
-        async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-            self.inner.copy(from, to).await
-        }
-
-        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-            self.inner.copy_if_not_exists(from, to).await
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: CopyOptions,
+        ) -> ObjectStoreResult<()> {
+            self.inner.copy_opts(from, to, options).await
         }
     }
 

--- a/crates/storage/s3/src/reader.rs
+++ b/crates/storage/s3/src/reader.rs
@@ -12,7 +12,7 @@ use std::{future::Future, sync::Arc};
 use futures::StreamExt;
 use mosaic_common::Byte32;
 use mosaic_storage_api::table_store::{TableMetadata, TableReader};
-use object_store::{GetOptions, GetRange, ObjectStore};
+use object_store::{GetOptions, GetRange, ObjectStore, ObjectStoreExt};
 use tracing::{debug, error, warn};
 
 use crate::{error::S3Error, paths::TableRootPaths};
@@ -283,7 +283,7 @@ async fn stream_ciphertexts(
             GetOptions::default()
         } else {
             GetOptions {
-                range: Some(GetRange::Offset(bytes_delivered)),
+                range: Some(GetRange::Offset(bytes_delivered as u64)),
                 ..Default::default()
             }
         };

--- a/crates/storage/s3/src/writer.rs
+++ b/crates/storage/s3/src/writer.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use mosaic_storage_api::table_store::{TableMetadata, TableWriter};
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use tracing::error;
 
 use crate::{


### PR DESCRIPTION
Supersedes #237. Bumps `object_store` from 0.11.2 → 0.14.0 in `bin/mosaic`, `crates/cac/protocol`, and `crates/storage/s3`, and does the API-migration work so future patch bumps land cleanly.

## RUSTSEC status — honest read

Aaron flagged that our transitive `quick-xml 0.37.5` was pulling in two advisories:

- [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) — quadratic time on start tags with duplicate attribute names (severity 7.5)
- [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) — unbounded namespace-declaration alloc in `NsReader` → memory-exhaustion DoS (severity 7.5)

**These are not fully resolved by this PR.** Both advisories cite ≥ 0.41.0 as the fix and no `object_store` release yet pins that; on 0.14 we get `quick-xml 0.40.1` which is still flagged. `cargo audit` will continue to list both until upstream bumps the pin. Neither is exploitable through mosaic's paths (we don't feed attacker-controlled XML into `object_store`).

The value of this PR is that the API-migration work is done, so once `object_store` bumps `quick-xml >= 0.41`, we get the fix from a `cargo update -p object_store` with no code changes.

## API migration (0.11 → 0.14)

**0.13 refactor.** Several convenience methods (`get`, `head`, `get_range`, `put_multipart`, `delete`, `copy`, `copy_if_not_exists`) moved off the `ObjectStore` trait onto a new `ObjectStoreExt` trait. `copy` / `copy_if_not_exists` collapsed into `copy_opts` taking `CopyOptions`. Offset/range accounting switched from `usize` to `u64`.

**0.14 delta.** `GetResult` gained an `extensions: Extensions` field (defaulted).

Applied to our tree:

- Production code (`lib.rs`, `reader.rs`, `writer.rs`) just imports `ObjectStoreExt` where the moved methods are called, and casts the resume offset to `u64` for `GetRange::Offset`.
- The two test-only `ObjectStore` impls (`TokioAssertingStore`, `ResumeStore`) drop the delegating overrides for moved-out methods, replace the copy pair with a single `copy_opts` delegate, gain a `delete_stream` delegate (now trait-required with no default), switch `seen_offsets` to `Vec<u64>`, and default the new `extensions` field.

## rustls process-level provider

0.14 pulls in `reqwest 0.13`, whose rustls setup expects a process-level `CryptoProvider` to be installed. With both `ring` (mosaic's QUIC choice via `net/svc/src/tls.rs`) and `aws-lc-rs` (reqwest's default) compiled in transitively, `default_provider()` auto-select panics with *"Could not automatically determine the process-level CryptoProvider"* — which showed up as a `test_e2e` failure in `mosaic-cac-protocol` on the first pass.

`NetService::new` now calls `install_process_crypto_provider()` once via `std::sync::Once`, picking `ring` — the same choice we already make explicitly for QUIC. Both the mosaic binary and every test that spins up a `NetService` go through this constructor, so no callsite audits needed.

## Test plan

- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --release -p mosaic-storage-s3 -p mosaic-cac-protocol` — 5 + 44 tests pass, including `ciphertext_stream_resumes_from_last_delivered_offset` (custom `ObjectStore` impl) and `tests::test_e2e` (was the rustls-provider casualty)
- [ ] CI green