### PR TITLE
bin/mosaic: document RPC as operator-only, warn on non-loopback bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ Copy [`bin/mosaic/config/config.example.toml`](bin/mosaic/config/config.example.
 - `[[network.peers]]` — one entry per other operator (`peer_id_hex` + `addr`)
 - `storage.cluster_file` — path to your `fdb.cluster`
 - `table_store` — `local_filesystem` (set `root`) or `s3_compatible` (set `bucket`, `region`, credentials)
-- `rpc.bind_addr` — private RPC for Bridge Core
+- `rpc.bind_addr` — private RPC for Bridge Core. **Unauthenticated.** Bind
+  only where the operator's own bridge node can reach it (loopback, a
+  private container network, or a firewalled internal subnet). The API
+  drives lifecycle, deposits, and fault-secret signing; exposing it to
+  peers or the public internet is a full compromise of the mosaic
+  instance. The binary emits a `WARN` on startup for non-loopback binds
+  and a louder one for wildcard binds (`0.0.0.0` / `::`).
 
 ### Run
 

--- a/bin/mosaic/config/config.example.toml
+++ b/bin/mosaic/config/config.example.toml
@@ -49,5 +49,10 @@ chunk_timeout_secs = 30
 [sm_executor]
 command_queue_size = 256
 
+# The RPC server is UNAUTHENTICATED. Bind it only where the operator's own
+# bridge node can reach it (loopback, a private container network, or a
+# firewalled internal subnet). Never expose this port to peers or the
+# public internet — the API can drive setup, deposits, and fault-secret
+# signing. The binary emits a WARN on startup if this is non-loopback.
 [rpc]
 bind_addr = "127.0.0.1:8000"

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -437,7 +437,9 @@ pub(crate) struct SmExecutorSection {
 /// transitions, adaptor-sig completion, fault-secret signing) and must not
 /// be exposed to the public internet or to peers. Operators are responsible
 /// for firewalling `bind_addr` accordingly. The binary emits a `WARN` on
-/// startup if `bind_addr` is not a loopback address, as a reminder.
+/// startup if `bind_addr` is not a loopback address, and a louder one if
+/// it's a wildcard address (`0.0.0.0` / `::`) that exposes the API on
+/// every interface the host has.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RpcConfig {

--- a/bin/mosaic/src/config.rs
+++ b/bin/mosaic/src/config.rs
@@ -425,6 +425,19 @@ pub(crate) struct SmExecutorSection {
     pub(crate) command_queue_size: usize,
 }
 
+/// JSON-RPC server configuration.
+///
+/// # Security
+///
+/// The RPC server is **unauthenticated**. It is intended to be reached only
+/// by the operator's own bridge node on a trusted internal network (typically
+/// a loopback bind, a container-network bind, or a private VPC subnet).
+///
+/// The RPC surface exposes lifecycle-changing methods (setup, deposit
+/// transitions, adaptor-sig completion, fault-secret signing) and must not
+/// be exposed to the public internet or to peers. Operators are responsible
+/// for firewalling `bind_addr` accordingly. The binary emits a `WARN` on
+/// startup if `bind_addr` is not a loopback address, as a reminder.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RpcConfig {

--- a/bin/mosaic/src/rpc.rs
+++ b/bin/mosaic/src/rpc.rs
@@ -14,7 +14,10 @@
 //!
 //! Operators are responsible for firewalling the bind address. As a
 //! reminder, [`start_rpc_server`] emits a `WARN` on startup whenever
-//! `bind_addr` is not a loopback address.
+//! `bind_addr` is not a loopback address, and a louder one when it's a
+//! wildcard address (`0.0.0.0` / `::`) — a wildcard bind exposes the
+//! unauthenticated API on every interface the host has, so it's called
+//! out separately.
 
 use std::{net::SocketAddr, thread::JoinHandle};
 
@@ -67,7 +70,24 @@ pub(crate) fn start_rpc_server(
     service: impl MosaicApi,
     circuit_info: RpcCircuitInfoEntry,
 ) -> Result<RpcController> {
-    if !bind_addr.ip().is_loopback() {
+    let ip = bind_addr.ip();
+    if ip.is_unspecified() {
+        // 0.0.0.0 / :: — the API is now reachable on every interface the host
+        // has, including any public ones. This is almost never what an
+        // operator wants; call it out louder than the general non-loopback
+        // case, since the surface is strictly worse.
+        tracing::warn!(
+            %bind_addr,
+            "RPC server binding to a wildcard address — the unauthenticated RPC is now \
+             reachable on every interface this host has, including any public ones. \
+             Bind to a specific internal address the operator's own bridge node reaches, \
+             and firewall the port off from peers and the public internet."
+        );
+    } else if !ip.is_loopback() {
+        // Any other non-loopback bind (typically a private-subnet or
+        // container-network address). The docs bless these as valid
+        // deployments; the warn is a reminder that the firewall assumption
+        // is on the operator.
         tracing::warn!(
             %bind_addr,
             "RPC server binding to a non-loopback address — the RPC is unauthenticated \

--- a/bin/mosaic/src/rpc.rs
+++ b/bin/mosaic/src/rpc.rs
@@ -2,6 +2,19 @@
 //!
 //! The RPC server runs on a dedicated thread with its own tokio runtime because
 //! jsonrpsee requires tokio while the rest of the binary uses monoio.
+//!
+//! # Security
+//!
+//! The server is **unauthenticated** by design. Its intended reader is the
+//! operator's own bridge node on a trusted internal network — not remote
+//! peers, and not the public internet. The RPC methods can drive setup,
+//! deposits, adaptor-sig completion, and fault-secret signing, so exposing
+//! this port beyond the operator's own infrastructure is a full compromise
+//! of the mosaic instance.
+//!
+//! Operators are responsible for firewalling the bind address. As a
+//! reminder, [`start_rpc_server`] emits a `WARN` on startup whenever
+//! `bind_addr` is not a loopback address.
 
 use std::{net::SocketAddr, thread::JoinHandle};
 
@@ -44,11 +57,25 @@ impl RpcController {
 }
 
 /// Start the RPC server on a dedicated tokio thread.
+///
+/// The server is unauthenticated; see the module-level docs for the trust
+/// model. Emits a `WARN` when `bind_addr` is not a loopback address as a
+/// reminder that the port must be firewalled off from anything other than
+/// the operator's own bridge node.
 pub(crate) fn start_rpc_server(
     bind_addr: SocketAddr,
     service: impl MosaicApi,
     circuit_info: RpcCircuitInfoEntry,
 ) -> Result<RpcController> {
+    if !bind_addr.ip().is_loopback() {
+        tracing::warn!(
+            %bind_addr,
+            "RPC server binding to a non-loopback address — the RPC is unauthenticated \
+             and must only be reachable by this operator's own bridge node. Ensure the \
+             port is firewalled off from peers and the public internet."
+        );
+    }
+
     let rpc_impl = RpcServerImpl::new(service, circuit_info);
 
     let (handle_tx, handle_rx) = std::sync::mpsc::sync_channel(1);


### PR DESCRIPTION
Closes #305.

## Summary

The JSON-RPC server is unauthenticated by design; its intended reader is the operator's own bridge node on a trusted internal network. The trust model wasn't spelled out anywhere in the repo, which caused an avoidable back-and-forth over a Codex finding.

- Doc comment on \`RpcConfig\` and the \`rpc\` module explaining the trust model.
- Warning line above \`[rpc]\` in \`config.example.toml\`.
- \`WARN\` log in \`start_rpc_server\` whenever \`bind_addr\` is not a loopback address, so the assumption shows up in operator logs at startup rather than only in prose.

## Test plan

- [x] \`cargo +nightly fmt --all\`
- [x] \`cargo clippy -p mosaic --all-targets -- -D warnings\`
- [ ] CI green