### PR TITLE
job/executors,scheduler: make garbling-coordinator jobs idempotent against SM state

### DIFF
--- a/crates/job/api/src/lib.rs
+++ b/crates/job/api/src/lib.rs
@@ -88,6 +88,13 @@ pub enum CircuitError {
     ChunkFailed(String),
     /// Transient network or I/O failure during session setup — retryable.
     TransientFailure(String),
+    /// The state machine has already recorded this action's work as done
+    /// (e.g. a duplicate transfer job for a table the evaluator has
+    /// receipted, or the SM has moved past the step entirely). The job is
+    /// an idempotent success: drop it without retry. Distinct from
+    /// [`StorageUnavailable`](Self::StorageUnavailable), which means the
+    /// data is not written *yet* and retrying will eventually succeed.
+    AlreadyComplete,
 }
 
 /// A block of circuit gate data shared across concurrent sessions via [`Arc`].

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -12,7 +12,9 @@ use ckt_gobble::{
 use mosaic_cac_types::{
     Adaptor, ChallengeIndices, CircuitInputShares, DepositAdaptors, GarblingTableCommitment,
     TableTransferReceiptMsg, TableTransferRequestMsg, WideLabelWirePolynomialCommitments,
-    state_machine::evaluator::{ActionId, ActionResult, ChunkIndex, StateRead as _, Step},
+    state_machine::evaluator::{
+        ActionId, ActionResult, ChunkIndex, StateRead as _, Step, StepPhase,
+    },
 };
 use mosaic_common::constants::{
     N_CIRCUITS, N_DEPOSIT_INPUT_WIRES, N_INPUT_WIRES, N_OPEN_CIRCUITS, N_SETUP_INPUT_WIRES,
@@ -835,6 +837,101 @@ pub(crate) async fn handle_generate_withdrawal_adaptors_chunk<
 // ============================================================================
 // Circuit session setup (called by MosaicExecutor trait impls)
 // ============================================================================
+/// Classify an evaluator table-verification job against the evaluator
+/// root state.
+///
+/// Verification jobs must be idempotent: after a restart, restore may
+/// re-emit verification actions whose completions were already recorded,
+/// and duplicate jobs can also be queued while an earlier one is in
+/// flight. Classifying here skips the (expensive) re-garbling pass.
+///
+/// - [`CircuitError::AlreadyComplete`] — the SM has already recorded this circuit as verified, or
+///   has moved past the verification step entirely. The coordinator drops the job.
+/// - [`CircuitError::StorageUnavailable`] — the SM hasn't reached the verification step yet; the
+///   STF will write the state shortly. Retry.
+/// - [`CircuitError::SetupFailed`] — the index is not in the opened challenge indices (programming
+///   error; the STF only emits verification actions for opened circuits).
+pub(crate) fn resolve_pending_evaluator_commitment(
+    step: &Step,
+    index: Index,
+) -> Result<(), CircuitError> {
+    let (opened_indices, verified) = match step {
+        Step::VerifyingTableCommitments {
+            opened_indices,
+            verified,
+            ..
+        } => (opened_indices, verified),
+        step if step.phase() > StepPhase::VerifyingTableCommitments => {
+            return Err(CircuitError::AlreadyComplete);
+        }
+        // Steps before the verification phase. In practice unreachable —
+        // the STF only emits verification actions while in the verification
+        // step and the SM never moves backward — but kept as defense: if a
+        // job did arrive early, retrying until the SM advances is correct.
+        _ => return Err(CircuitError::StorageUnavailable),
+    };
+
+    // Same lookup as the STF's completion handler (opened_indices is
+    // sorted — it comes from the deterministic challenge selection).
+    let Ok(pos) = opened_indices.binary_search(&index) else {
+        return Err(CircuitError::SetupFailed(
+            "index not in opened challenge indices".into(),
+        ));
+    };
+
+    if verified[pos] {
+        return Err(CircuitError::AlreadyComplete);
+    }
+
+    Ok(())
+}
+
+/// Classify an `EvaluateGarblingTable` job against the evaluator root
+/// state.
+///
+/// Evaluation jobs must be idempotent: after a restart, restore may
+/// re-emit evaluation actions whose completions were already recorded,
+/// and duplicate jobs can also be queued while an earlier one is in
+/// flight.
+///
+/// - [`CircuitError::AlreadyComplete`] — the circuit has already been evaluated, or the SM has
+///   moved past the evaluation step entirely. The coordinator drops the job.
+/// - [`CircuitError::StorageUnavailable`] — the SM hasn't reached the evaluation step yet; the STF
+///   will write the state shortly. Retry.
+/// - [`CircuitError::SetupFailed`] — the index is not in the evaluation indices (programming
+///   error).
+pub(crate) fn resolve_pending_evaluator_evaluation(
+    step: &Step,
+    index: Index,
+) -> Result<(), CircuitError> {
+    let (eval_indices, evaluated) = match step {
+        Step::EvaluatingTables {
+            eval_indices,
+            evaluated,
+            ..
+        } => (eval_indices, evaluated),
+        step if step.phase() > StepPhase::EvaluatingTables => {
+            return Err(CircuitError::AlreadyComplete);
+        }
+        // Steps before the evaluation phase (including SetupComplete,
+        // which precedes it). In practice unreachable — the STF only
+        // emits evaluation actions while in the evaluation step and the
+        // SM never moves backward — but kept as defense: if a job did
+        // arrive early, retrying until the SM advances is correct.
+        _ => return Err(CircuitError::StorageUnavailable),
+    };
+
+    let pos = eval_indices
+        .iter()
+        .position(|&idx| idx == index)
+        .ok_or_else(|| CircuitError::SetupFailed("index not in evaluation indices".into()))?;
+
+    if evaluated[pos] {
+        return Err(CircuitError::AlreadyComplete);
+    }
+
+    Ok(())
+}
 
 /// Set up an [`EvaluationSession`] for E8 (`EvaluateGarblingTable`).
 ///
@@ -861,15 +958,22 @@ pub(crate) async fn setup_evaluation_session<SP: StorageProvider, TS: TableStore
         .await
         .map_err(|_| CircuitError::StorageUnavailable)?;
 
-    // ── Resolve deposit_id from root state ──────────────────────────────
+    // ── Classify against the SM step (idempotency guard) ────────────────
     let root_state = eval_state
         .get_root_state()
         .await
         .ok()
         .flatten()
         .ok_or(CircuitError::StorageUnavailable)?;
+
+    resolve_pending_evaluator_evaluation(&root_state.step, index)?;
+
+    // ── Resolve deposit_id from root state ──────────────────────────────
     let deposit_id = match &root_state.step {
         Step::EvaluatingTables { deposit_id, .. } => *deposit_id,
+        // Unreachable: the resolver above only accepts EvaluatingTables on
+        // this same root-state snapshot. Return rather than panic so a
+        // future loosening of the resolver can't crash the operator.
         _ => return Err(CircuitError::StorageUnavailable),
     };
 
@@ -1144,9 +1248,239 @@ pub(crate) async fn setup_evaluation_session<SP: StorageProvider, TS: TableStore
 mod tests {
     use std::collections::VecDeque;
 
+    use mosaic_common::constants::N_EVAL_CIRCUITS;
     use mosaic_storage_api::table_store::{TableMetadata, TableWriter};
 
     use super::*;
+
+    // Tests for resolve_pending_evaluator_commitment
+
+    /// Circuit indices are 1-based; helper for readable tests.
+    fn index(i: usize) -> Index {
+        Index::new(i).expect("test index in range")
+    }
+
+    /// Verification step with opened indices 1..=N_OPEN_CIRCUITS (sorted,
+    /// as the deterministic challenge selection produces them).
+    fn commitment_verification_step(verified_mask: &[bool]) -> Step {
+        assert_eq!(verified_mask.len(), N_OPEN_CIRCUITS);
+        Step::VerifyingTableCommitments {
+            opened_indices: mosaic_cac_types::ChallengeIndices::new(|i| index(i + 1)),
+            opened_seeds: mosaic_cac_types::OpenedGarblingSeeds::new(|_| {
+                mosaic_cac_types::GarblingSeed::from([0u8; 32])
+            }),
+            opened_commitments: mosaic_cac_types::OpenedGarblingTableCommitments::new(|_| {
+                [0u8; 32].into()
+            }),
+            verified: HeapArray::new(|i| verified_mask[i]),
+        }
+    }
+
+    #[test]
+    fn resolve_evaluator_commitment_proceeds_for_unverified_circuit() {
+        let step = commitment_verification_step(&[false; N_OPEN_CIRCUITS]);
+        assert!(
+            resolve_pending_evaluator_commitment(&step, index(N_OPEN_CIRCUITS)).is_ok(),
+            "should proceed for opened index during verification step"
+        );
+    }
+
+    #[test]
+    fn resolve_evaluator_commitment_already_complete_for_verified_circuit() {
+        // The STF already recorded this circuit as verified: a duplicate
+        // job resolves AlreadyComplete while others still proceed.
+        let mut mask = [false; N_OPEN_CIRCUITS];
+        mask[N_OPEN_CIRCUITS - 1] = true;
+        let step = commitment_verification_step(&mask);
+        assert!(matches!(
+            resolve_pending_evaluator_commitment(&step, index(N_OPEN_CIRCUITS)),
+            Err(CircuitError::AlreadyComplete)
+        ));
+        assert!(resolve_pending_evaluator_commitment(&step, index(1)).is_ok());
+    }
+
+    #[test]
+    fn resolve_evaluator_commitment_already_complete_after_step_advances() {
+        // SM moved past the verification phase: any straggler job should
+        // resolve AlreadyComplete instead of StorageUnavailable.
+        assert!(matches!(
+            resolve_pending_evaluator_commitment(&Step::SetupComplete, index(1)),
+            Err(CircuitError::AlreadyComplete)
+        ));
+        assert!(matches!(
+            resolve_pending_evaluator_commitment(
+                &Step::ReceivingGarblingTables {
+                    eval_indices: std::array::from_fn(|i| index(i + 1)),
+                    eval_commitments: mosaic_cac_types::EvalGarblingTableCommitments::new(|_| {
+                        [0u8; 32].into()
+                    }),
+                    received: HeapArray::new(|_| false),
+                    receipt_acked: HeapArray::new(|_| false),
+                },
+                index(1)
+            ),
+            Err(CircuitError::AlreadyComplete)
+        ));
+    }
+
+    #[test]
+    fn resolve_evaluator_commitment_already_complete_for_aborted_setup() {
+        // Aborted phases after the verification step in the variant order:
+        // stale jobs for an aborted setup must drop, not retry forever.
+        assert!(matches!(
+            resolve_pending_evaluator_commitment(
+                &Step::Aborted {
+                    reason: "test".into(),
+                },
+                index(1)
+            ),
+            Err(CircuitError::AlreadyComplete)
+        ));
+    }
+
+    #[test]
+    fn resolve_evaluator_commitment_handles_non_contiguous_opened_indices() {
+        // Opened indices in production are a sorted-but-non-contiguous
+        // subset of 1..=N_CIRCUITS. Exercise the binary_search lookup with
+        // a gap: {1, 3, 4, ..., N_OPEN_CIRCUITS + 1} — index 2 is skipped.
+        // (Bounded by N_OPEN_CIRCUITS + 1 <= N_CIRCUITS in both circuit
+        // configurations.)
+        let step = Step::VerifyingTableCommitments {
+            opened_indices: mosaic_cac_types::ChallengeIndices::new(|i| {
+                if i == 0 { index(1) } else { index(i + 2) }
+            }),
+            opened_seeds: mosaic_cac_types::OpenedGarblingSeeds::new(|_| {
+                mosaic_cac_types::GarblingSeed::from([0u8; 32])
+            }),
+            opened_commitments: mosaic_cac_types::OpenedGarblingTableCommitments::new(|_| {
+                [0u8; 32].into()
+            }),
+            verified: HeapArray::new(|_| false),
+        };
+        // In the set (index 3): proceeds.
+        assert!(resolve_pending_evaluator_commitment(&step, index(3)).is_ok());
+        // In the gap (index 2): SetupFailed.
+        assert!(matches!(
+            resolve_pending_evaluator_commitment(&step, index(2)),
+            Err(CircuitError::SetupFailed(_))
+        ));
+    }
+
+    #[test]
+    fn resolve_evaluator_commitment_storage_unavailable_before_verification_step() {
+        // SM not yet at the verification step: state genuinely missing,
+        // retry is correct.
+        assert!(matches!(
+            resolve_pending_evaluator_commitment(
+                &Step::WaitingForCommit {
+                    header: false,
+                    chunks: HeapArray::new(|_| false),
+                },
+                index(1)
+            ),
+            Err(CircuitError::StorageUnavailable)
+        ));
+    }
+
+    #[test]
+    fn resolve_evaluator_commitment_setup_failed_for_index_not_in_challenges() {
+        // Opened indices are 1..=N_OPEN_CIRCUITS; the next index up is a
+        // valid Index but not an opened circuit.
+        let step = commitment_verification_step(&[false; N_OPEN_CIRCUITS]);
+        assert!(matches!(
+            resolve_pending_evaluator_commitment(&step, index(N_OPEN_CIRCUITS + 1)),
+            Err(CircuitError::SetupFailed(_))
+        ));
+    }
+
+    // Tests for resolve_pending_evaluator_evaluation
+
+    /// Evaluation step with eval indices 1..=N_EVAL_CIRCUITS.
+    fn evaluation_step(evaluated_mask: &[bool]) -> Step {
+        assert_eq!(evaluated_mask.len(), N_EVAL_CIRCUITS);
+        Step::EvaluatingTables {
+            deposit_id: mosaic_cac_types::DepositId::from([0u8; 32]),
+            eval_indices: std::array::from_fn(|i| index(i + 1)),
+            eval_commitments: mosaic_cac_types::EvalGarblingTableCommitments::new(|i| {
+                [i as u8; 32].into()
+            }),
+            evaluated: HeapArray::new(|i| evaluated_mask[i]),
+        }
+    }
+
+    #[test]
+    fn resolve_evaluator_evaluation_proceeds_for_unevaluated_circuit() {
+        let step = evaluation_step(&[false; N_EVAL_CIRCUITS]);
+        assert!(
+            resolve_pending_evaluator_evaluation(&step, index(N_EVAL_CIRCUITS)).is_ok(),
+            "should proceed for circuit that hasn't been evaluated yet"
+        );
+    }
+
+    #[test]
+    fn resolve_evaluator_evaluation_already_complete_for_evaluated_circuit() {
+        // Circuit was already evaluated: should resolve AlreadyComplete,
+        // while other circuits still proceed.
+        let mut mask = [false; N_EVAL_CIRCUITS];
+        mask[N_EVAL_CIRCUITS - 1] = true;
+        let step = evaluation_step(&mask);
+        assert!(matches!(
+            resolve_pending_evaluator_evaluation(&step, index(N_EVAL_CIRCUITS)),
+            Err(CircuitError::AlreadyComplete)
+        ));
+        assert!(resolve_pending_evaluator_evaluation(&step, index(1)).is_ok());
+    }
+
+    #[test]
+    fn resolve_evaluator_evaluation_already_complete_after_step_advances() {
+        // SM moved past the evaluation phase: any straggler evaluation job
+        // should resolve AlreadyComplete instead of StorageUnavailable.
+        assert!(matches!(
+            resolve_pending_evaluator_evaluation(
+                &Step::SetupConsumed {
+                    deposit_id: mosaic_cac_types::DepositId::from([0u8; 32]),
+                    success: true,
+                },
+                index(1)
+            ),
+            Err(CircuitError::AlreadyComplete)
+        ));
+    }
+
+    #[test]
+    fn resolve_evaluator_evaluation_already_complete_for_aborted_setup() {
+        assert!(matches!(
+            resolve_pending_evaluator_evaluation(
+                &Step::Aborted {
+                    reason: "test".into(),
+                },
+                index(1)
+            ),
+            Err(CircuitError::AlreadyComplete)
+        ));
+    }
+
+    #[test]
+    fn resolve_evaluator_evaluation_storage_unavailable_before_evaluation_step() {
+        // SetupComplete precedes EvaluatingTables (evaluation only starts
+        // when a deposit dispute arrives): state genuinely missing, retry
+        // is correct.
+        assert!(matches!(
+            resolve_pending_evaluator_evaluation(&Step::SetupComplete, index(1)),
+            Err(CircuitError::StorageUnavailable)
+        ));
+    }
+
+    #[test]
+    fn resolve_evaluator_evaluation_setup_failed_for_index_not_in_eval_indices() {
+        // Eval indices are 1..=N_EVAL_CIRCUITS; the next index up is a
+        // valid Index but not an eval circuit.
+        let step = evaluation_step(&[false; N_EVAL_CIRCUITS]);
+        assert!(matches!(
+            resolve_pending_evaluator_evaluation(&step, index(N_EVAL_CIRCUITS + 1)),
+            Err(CircuitError::SetupFailed(_))
+        ));
+    }
 
     /// Scripted `PayloadStream` for tests. Each `read_with_timeout` call pops
     /// from the front of the queue; an empty queue returns `Closed` (FIN).

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -499,6 +499,45 @@ pub(crate) async fn handle_complete_adaptor_signatures<SP: StorageProvider, TS: 
 // Circuit session setup (called by MosaicExecutor trait impls)
 // ============================================================================
 
+/// Classify a `GenerateTableCommitment` job against the garbler root state.
+///
+/// Commitment jobs must be idempotent: after a restart, restore may
+/// re-emit commitment actions whose completions were already recorded, and
+/// duplicate jobs can also be queued while an earlier one is in flight.
+/// A duplicate that runs to completion is rejected by the STF as
+/// `duplicate_action` — classifying it here skips the (expensive) garbling
+/// pass entirely.
+///
+/// - [`CircuitError::AlreadyComplete`] — the SM has already recorded this commitment, or has moved
+///   past the commitment step entirely. The coordinator drops the job.
+/// - [`CircuitError::StorageUnavailable`] — the SM hasn't reached the commitment step yet; the STF
+///   will write the state shortly. Retry.
+pub(crate) fn resolve_pending_garbler_commitment(
+    step: &Step,
+    index: Index,
+) -> Result<(), CircuitError> {
+    let generated = match step {
+        Step::GeneratingTableCommitments { generated, .. } => generated,
+        step if step.phase() > StepPhase::GeneratingTableCommitments => {
+            return Err(CircuitError::AlreadyComplete);
+        }
+        // Steps before the commitment phase. In practice unreachable — the
+        // STF only emits commitment actions while in the commitment step
+        // and the SM never moves backward — but kept as defense: if a job
+        // did arrive early, retrying until the SM advances is correct.
+        _ => return Err(CircuitError::StorageUnavailable),
+    };
+
+    // Circuit indices are 1-based (`Index::MIN == 1`, max `N_CIRCUITS`);
+    // `generated` is indexed by `index - 1`, matching the STF's completion
+    // handler. Out-of-range values are unrepresentable by `Index`.
+    if generated[index.get() - 1] {
+        return Err(CircuitError::AlreadyComplete);
+    }
+
+    Ok(())
+}
+
 /// Classify a `TransferGarblingTable` job against the garbler root state.
 ///
 /// Transfer jobs must be idempotent: the evaluator may legitimately
@@ -731,7 +770,8 @@ async fn write_with_timeout(
 #[cfg(test)]
 mod tests {
     use mosaic_cac_types::{EvalGarblingSeeds, EvalGarblingTableCommitments};
-    use mosaic_common::constants::N_EVAL_CIRCUITS;
+    use mosaic_common::constants::{N_CIRCUITS, N_EVAL_CIRCUITS};
+    use mosaic_vs3::Index;
 
     use super::*;
 
@@ -745,6 +785,14 @@ mod tests {
             eval_seeds: EvalGarblingSeeds::new(|i| seed(i as u8)),
             eval_commitments: EvalGarblingTableCommitments::new(|i| [i as u8; 32].into()),
             transferred: HeapArray::new(|i| transferred_mask[i]),
+        }
+    }
+
+    fn commitment_step(generated_mask: &[bool]) -> Step {
+        assert_eq!(generated_mask.len(), N_CIRCUITS);
+        Step::GeneratingTableCommitments {
+            generated: HeapArray::new(|i| generated_mask[i]),
+            seeds: mosaic_cac_types::AllGarblingSeeds::new(|i| seed(i as u8)),
         }
     }
 
@@ -800,6 +848,100 @@ mod tests {
         assert!(matches!(
             resolve_pending_transfer(&step, &seed(200)),
             Err(CircuitError::SetupFailed(_))
+        ));
+    }
+
+    // Tests for resolve_pending_garbler_commitment
+
+    /// Circuit indices are 1-based; helper for readable tests.
+    fn index(i: usize) -> Index {
+        Index::new(i).expect("test index in range")
+    }
+
+    #[test]
+    fn resolve_garbler_commitment_proceeds_for_ungenerated_circuit() {
+        let step = commitment_step(&[false; N_CIRCUITS]);
+        assert!(
+            resolve_pending_garbler_commitment(&step, index(N_CIRCUITS)).is_ok(),
+            "should proceed for valid index during commitment step"
+        );
+    }
+
+    #[test]
+    fn resolve_garbler_commitment_already_complete_for_generated_circuit() {
+        // The STF already recorded this circuit's commitment: a duplicate
+        // job resolves AlreadyComplete while others still proceed.
+        let mut mask = [false; N_CIRCUITS];
+        mask[N_CIRCUITS - 1] = true;
+        let step = commitment_step(&mask);
+        assert!(matches!(
+            resolve_pending_garbler_commitment(&step, index(N_CIRCUITS)),
+            Err(CircuitError::AlreadyComplete)
+        ));
+        assert!(resolve_pending_garbler_commitment(&step, index(1)).is_ok());
+    }
+
+    #[test]
+    fn resolve_garbler_commitment_already_complete_after_step_advances() {
+        // SM moved past the commitment phase: any straggler commitment job
+        // should resolve AlreadyComplete instead of StorageUnavailable.
+        assert!(matches!(
+            resolve_pending_garbler_commitment(&Step::SetupComplete, index(1)),
+            Err(CircuitError::AlreadyComplete)
+        ));
+        assert!(matches!(
+            resolve_pending_garbler_commitment(
+                &Step::TransferringGarblingTables {
+                    eval_seeds: EvalGarblingSeeds::new(|i| seed(i as u8)),
+                    eval_commitments: EvalGarblingTableCommitments::new(|i| [i as u8; 32].into()),
+                    transferred: HeapArray::new(|_| false),
+                },
+                index(1)
+            ),
+            Err(CircuitError::AlreadyComplete)
+        ));
+    }
+
+    #[test]
+    fn resolve_garbler_commitment_already_complete_for_aborted_setup() {
+        // Aborted phases after the commitment step in the variant order:
+        // stale jobs for an aborted setup must drop, not retry forever.
+        assert!(matches!(
+            resolve_pending_garbler_commitment(
+                &Step::Aborted {
+                    reason: "test".into(),
+                },
+                index(1)
+            ),
+            Err(CircuitError::AlreadyComplete)
+        ));
+    }
+
+    #[test]
+    fn resolve_transfer_already_complete_for_aborted_setup() {
+        assert!(matches!(
+            resolve_pending_transfer(
+                &Step::Aborted {
+                    reason: "test".into(),
+                },
+                &seed(0)
+            ),
+            Err(CircuitError::AlreadyComplete)
+        ));
+    }
+
+    #[test]
+    fn resolve_garbler_commitment_storage_unavailable_before_commitment_step() {
+        // SM not yet at the commitment step: state genuinely missing,
+        // retry is correct.
+        assert!(matches!(
+            resolve_pending_garbler_commitment(
+                &Step::GeneratingShares {
+                    generated: HeapArray::new(|_| false),
+                },
+                index(1)
+            ),
+            Err(CircuitError::StorageUnavailable)
         ));
     }
 }

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -527,6 +527,10 @@ fn resolve_pending_transfer(
         step if step.phase() > StepPhase::TransferringGarblingTables => {
             return Err(CircuitError::AlreadyComplete);
         }
+        // Steps before the transfer phase. In practice unreachable — the
+        // STF only emits transfer actions while in the transfer step and
+        // the SM never moves backward — but kept as defense: if a job
+        // did arrive early, retrying until the SM advances is correct.
         _ => return Err(CircuitError::StorageUnavailable),
     };
 

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -530,8 +530,13 @@ pub(crate) fn resolve_pending_garbler_commitment(
 
     // Circuit indices are 1-based (`Index::MIN == 1`, max `N_CIRCUITS`);
     // `generated` is indexed by `index - 1`, matching the STF's completion
-    // handler. Out-of-range values are unrepresentable by `Index`.
-    if generated[index.get() - 1] {
+    // handler. Reject `Index::reserved()` (0) so the subtraction below
+    // cannot underflow — a jobs entry-path for the reserved index is a
+    // programming error.
+    let idx = index.get().checked_sub(1).ok_or(CircuitError::SetupFailed(
+        "reserved index (0) in commitment job".into(),
+    ))?;
+    if generated[idx] {
         return Err(CircuitError::AlreadyComplete);
     }
 
@@ -942,6 +947,18 @@ mod tests {
                 index(1)
             ),
             Err(CircuitError::StorageUnavailable)
+        ));
+    }
+
+    #[test]
+    fn resolve_garbler_commitment_setup_failed_for_reserved_index() {
+        // Index::reserved() (0) would cause `index.get() - 1` to underflow.
+        // Guard it with a checked_sub and return a permanent error instead
+        // of panicking — a reserved-index job is a programming error.
+        let step = commitment_step(&[false; N_CIRCUITS]);
+        assert!(matches!(
+            resolve_pending_garbler_commitment(&step, Index::reserved()),
+            Err(CircuitError::SetupFailed(_))
         ));
     }
 }

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -10,11 +10,12 @@ use futures::{
 };
 use mosaic_cac_types::{
     AllPolynomials, CommitMsgChunk, CompletedSignatures, DepositAdaptors, DepositInputs,
-    GarblingSeed, InputPolynomials, OutputPolynomial, PubKey, ReservedDepositInputShares,
-    ReservedInputShares, ReservedWithdrawalInputShares, Seed, WideLabelWireShares,
-    WithdrawalAdaptors,
+    GarblingSeed, GarblingTableCommitment, InputPolynomials, OutputPolynomial, PubKey,
+    ReservedDepositInputShares, ReservedInputShares, ReservedWithdrawalInputShares, Seed,
+    WideLabelWireShares, WithdrawalAdaptors,
     state_machine::garbler::{
-        ActionId, ActionResult, GeneratedPolynomialCommitments, StateRead as _, Step, Wire,
+        ActionId, ActionResult, GeneratedPolynomialCommitments, StateRead as _, Step, StepPhase,
+        Wire,
     },
 };
 use mosaic_common::constants::{
@@ -498,6 +499,49 @@ pub(crate) async fn handle_complete_adaptor_signatures<SP: StorageProvider, TS: 
 // Circuit session setup (called by MosaicExecutor trait impls)
 // ============================================================================
 
+/// Classify a `TransferGarblingTable` job against the garbler root state.
+///
+/// Transfer jobs must be idempotent: the evaluator may legitimately
+/// re-request a table it hasn't receipted (see the garbler STF), so
+/// duplicate jobs for the same table are expected. Returns the
+/// eval-circuit position and expected commitment when the transfer should
+/// proceed, otherwise:
+///
+/// - [`CircuitError::AlreadyComplete`] — the evaluator has receipted this table (a receipt is only
+///   sent after the table is durably stored, so it will never be legitimately re-requested), or the
+///   SM has moved past the transfer step entirely. The coordinator drops the job.
+/// - [`CircuitError::StorageUnavailable`] — the SM hasn't reached the transfer step yet; the STF
+///   will write the state shortly. Retry.
+/// - [`CircuitError::SetupFailed`] — the seed is unknown (programming error; the STF only emits
+///   transfer actions for seeds it selected).
+fn resolve_pending_transfer(
+    step: &Step,
+    seed: &GarblingSeed,
+) -> Result<(usize, GarblingTableCommitment), CircuitError> {
+    let (eval_seeds, eval_commitments, transferred) = match step {
+        Step::TransferringGarblingTables {
+            eval_seeds,
+            eval_commitments,
+            transferred,
+        } => (eval_seeds, eval_commitments, transferred),
+        step if step.phase() > StepPhase::TransferringGarblingTables => {
+            return Err(CircuitError::AlreadyComplete);
+        }
+        _ => return Err(CircuitError::StorageUnavailable),
+    };
+
+    let pos = eval_seeds
+        .iter()
+        .position(|s| s == seed)
+        .ok_or(CircuitError::SetupFailed("seed not in eval_seeds".into()))?;
+
+    if transferred[pos] {
+        return Err(CircuitError::AlreadyComplete);
+    }
+
+    Ok((pos, eval_commitments[pos]))
+}
+
 /// Set up a [`TransferSession`] for G8 (`TransferGarblingTable`).
 ///
 /// Performs all setup work (load shares, resolve seed → commitment, create
@@ -522,20 +566,7 @@ pub(crate) async fn setup_transfer_session<SP: StorageProvider, TS: TableStore>(
         .flatten()
         .ok_or(CircuitError::StorageUnavailable)?;
 
-    let (eval_seeds, eval_commitments) = match &root_state.step {
-        Step::TransferringGarblingTables {
-            eval_seeds,
-            eval_commitments,
-            ..
-        } => (eval_seeds.clone(), eval_commitments.clone()),
-        _ => return Err(CircuitError::StorageUnavailable),
-    };
-
-    let pos = eval_seeds
-        .iter()
-        .position(|s| *s == seed)
-        .ok_or(CircuitError::SetupFailed("seed not in eval_seeds".into()))?;
-    let commitment = eval_commitments[pos];
+    let (pos, commitment) = resolve_pending_transfer(&root_state.step, &seed)?;
 
     // Derive the circuit index from challenge indices.
     let challenge_indices = garb_state
@@ -690,5 +721,81 @@ async fn write_with_timeout(
     pin_mut!(delay);
     match select(write, delay).await {
         Either::Left((r, _)) | Either::Right((r, _)) => r,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mosaic_cac_types::{EvalGarblingSeeds, EvalGarblingTableCommitments};
+    use mosaic_common::constants::N_EVAL_CIRCUITS;
+
+    use super::*;
+
+    fn seed(byte: u8) -> GarblingSeed {
+        GarblingSeed::from([byte; 32])
+    }
+
+    fn transfer_step(transferred_mask: &[bool]) -> Step {
+        assert_eq!(transferred_mask.len(), N_EVAL_CIRCUITS);
+        Step::TransferringGarblingTables {
+            eval_seeds: EvalGarblingSeeds::new(|i| seed(i as u8)),
+            eval_commitments: EvalGarblingTableCommitments::new(|i| [i as u8; 32].into()),
+            transferred: HeapArray::new(|i| transferred_mask[i]),
+        }
+    }
+
+    #[test]
+    fn resolve_proceeds_for_untransferred_table() {
+        let last = N_EVAL_CIRCUITS - 1;
+        let step = transfer_step(&[false; N_EVAL_CIRCUITS]);
+        let (pos, commitment) =
+            resolve_pending_transfer(&step, &seed(last as u8)).expect("should proceed");
+        assert_eq!(pos, last);
+        assert_eq!(commitment, [last as u8; 32].into());
+    }
+
+    #[test]
+    fn resolve_already_complete_for_receipted_table() {
+        // The evaluator receipted the last table — a duplicate job for it
+        // must resolve AlreadyComplete, while other tables still proceed.
+        let last = N_EVAL_CIRCUITS - 1;
+        let mut mask = [false; N_EVAL_CIRCUITS];
+        mask[last] = true;
+        let step = transfer_step(&mask);
+        assert!(matches!(
+            resolve_pending_transfer(&step, &seed(last as u8)),
+            Err(CircuitError::AlreadyComplete)
+        ));
+        assert!(resolve_pending_transfer(&step, &seed(0)).is_ok());
+    }
+
+    #[test]
+    fn resolve_already_complete_after_setup_complete() {
+        // SM moved past the transfer step: any straggler job resolves
+        // AlreadyComplete instead of StorageUnavailable (which would
+        // retry forever).
+        assert!(matches!(
+            resolve_pending_transfer(&Step::SetupComplete, &seed(0)),
+            Err(CircuitError::AlreadyComplete)
+        ));
+    }
+
+    #[test]
+    fn resolve_storage_unavailable_before_transfer_step() {
+        // SM not yet at the transfer step: state genuinely missing,
+        // retry is correct.
+        assert!(matches!(
+            resolve_pending_transfer(&Step::WaitingForChallenge, &seed(0)),
+            Err(CircuitError::StorageUnavailable)
+        ));
+    }
+
+    #[test]
+    fn resolve_setup_failed_for_unknown_seed() {
+        let step = transfer_step(&[false; N_EVAL_CIRCUITS]);
+        assert!(matches!(
+            resolve_pending_transfer(&step, &seed(200)),
+            Err(CircuitError::SetupFailed(_))
+        ));
     }
 }

--- a/crates/job/executors/src/lib.rs
+++ b/crates/job/executors/src/lib.rs
@@ -216,6 +216,21 @@ impl<SP: StorageProvider, TS: TableStore> ExecuteGarblerJob for MosaicExecutor<S
                 .garbler_state(&peer_id)
                 .await
                 .map_err(|_| CircuitError::StorageUnavailable)?;
+
+            // Idempotency guard: skip the (expensive) garbling pass for
+            // circuits the STF has already recorded, and drop stragglers
+            // whose step has advanced or aborted. Shares persist across
+            // step advances, so without this a stale job would run the
+            // full pass only for its completion to be discarded.
+            let root_state = garb_state
+                .get_root_state()
+                .await
+                .ok()
+                .flatten()
+                .ok_or(CircuitError::StorageUnavailable)?;
+
+            garbler::resolve_pending_garbler_commitment(&root_state.step, index)?;
+
             let input_shares = garb_state
                 .get_input_shares_for_circuit(&index)
                 .await
@@ -333,6 +348,19 @@ impl<SP: StorageProvider, TS: TableStore> ExecuteEvaluatorJob for MosaicExecutor
                 .evaluator_state(&peer_id)
                 .await
                 .map_err(|_| CircuitError::StorageUnavailable)?;
+
+            // Idempotency guard: skip the (expensive) re-garbling pass for
+            // circuits the STF has already recorded as verified, and drop
+            // stragglers whose step has advanced or aborted.
+            let root_state = eval_state
+                .get_root_state()
+                .await
+                .ok()
+                .flatten()
+                .ok_or(CircuitError::StorageUnavailable)?;
+
+            evaluator::resolve_pending_evaluator_commitment(&root_state.step, index)?;
+
             let challenge_indices = eval_state
                 .get_challenge_indices()
                 .await

--- a/crates/job/scheduler/src/garbling/mod.rs
+++ b/crates/job/scheduler/src/garbling/mod.rs
@@ -460,6 +460,19 @@ async fn coordinator_loop(
                             session,
                         });
                     }
+                    Err(CircuitError::AlreadyComplete) => {
+                        // The state machine has already recorded this work
+                        // as done (e.g. a duplicate transfer job for a
+                        // table the evaluator receipted). Idempotent
+                        // success — drop the job. No completion is sent:
+                        // the SM treats these completions as informational
+                        // and has already moved on.
+                        tracing::info!(
+                            peer = ?job.peer_id,
+                            action = ?job.action,
+                            "action already complete per state machine — dropping job"
+                        );
+                    }
                     Err(CircuitError::StorageUnavailable) => {
                         // Transient — data not yet written by STF. Keep for retry.
                         tracing::debug!(

--- a/crates/job/scheduler/src/garbling/mod.rs
+++ b/crates/job/scheduler/src/garbling/mod.rs
@@ -461,16 +461,17 @@ async fn coordinator_loop(
                         });
                     }
                     Err(CircuitError::AlreadyComplete) => {
-                        // The state machine has already recorded this work
-                        // as done (e.g. a duplicate transfer job for a
-                        // table the evaluator receipted). Idempotent
-                        // success — drop the job. No completion is sent:
-                        // the SM treats these completions as informational
-                        // and has already moved on.
+                        // The state machine no longer needs this work —
+                        // either it already recorded it as done (e.g. a
+                        // duplicate transfer job for a table the evaluator
+                        // receipted) or it has moved past the step (incl.
+                        // aborted setups). Idempotent success — drop the
+                        // job. No completion is sent: the SM treats these
+                        // completions as informational and has moved on.
                         tracing::info!(
                             peer = ?job.peer_id,
                             action = ?job.action,
-                            "action already complete per state machine — dropping job"
+                            "action no longer required per state machine — dropping job"
                         );
                     }
                     Err(CircuitError::StorageUnavailable) => {


### PR DESCRIPTION
Closes the garbling-coordinator live-lock observed on testnet (`no sessions created, pending=8` looping every 500ms while real transfers starved).

## Problem

The garbler STF deliberately re-emits `TransferGarblingTable` whenever the evaluator re-requests a table, so duplicate jobs are expected. But once the evaluator had receipted the table — or the SM had moved past `TransferringGarblingTables` entirely — a queued duplicate failed session setup with `StorageUnavailable`, which the coordinator treats as transient and retries forever. The coordinator drains its retry list first, bounded by `max_concurrent`: with `max_concurrent` permanently-stale jobs, every pass batch is 100% stale retries and the submission channel is never drained. New legitimate work starves indefinitely.

The E8 evaluation path had the same defect via a different route: after a deposit consumed the setup (`SetupConsumed`), a stale evaluation job resolved `StorageUnavailable` forever. G3/E3 commitment jobs did not retry forever, but a stale duplicate ran a full garbling pass (up to ~43 GB of ciphertext generation) only for the STF to reject its completion as `duplicate_action`.

## Fix

Jobs are idempotent. Each of the four coordinator session types now classifies itself against the SM root state before setup, via a pure resolver function over `(Step, index/seed)`:

- **Proceed** — the SM is in the expected step and the per-circuit bitmap (`generated` / `verified` / `transferred` / `evaluated`) says the work is still needed.
- **`CircuitError::AlreadyComplete`** (new variant) — the bitmap says the work is recorded, or the SM has moved past the step (including `Aborted` / `SetupConsumed`). The coordinator logs at info and drops the job. No completion is sent; these completions are informational to the SM, which has already moved on. Verified: fasm has no persisted action ledger — restore is state-derived and only re-emits actions for bitmap bits that are false, so dropping a recorded job can never strand required work.
- **`StorageUnavailable`** — the SM hasn't reached the step yet (unreachable in practice since the STF only emits in-step and never moves backward; kept as defense, where retrying is correct).
- **`SetupFailed`** — unknown seed/index (programming error; coordinator drops at error level, unchanged).

Resolvers: `resolve_pending_transfer` and `resolve_pending_garbler_commitment` (garbler.rs), `resolve_pending_evaluator_commitment` and `resolve_pending_evaluator_evaluation` (evaluator.rs). The E3 index lookup mirrors the STF's `binary_search` over the sorted `opened_indices`.

## Testing

- Unit tests for every classification of all four resolvers (23 tests), including receipted/generated/verified/evaluated bitmap hits, step-advanced, `Aborted`, pre-step, unknown index/seed, and non-contiguous opened indices.
- Pass under both circuit configurations (default and `reduced-circuits` feature unification).
- `cargo test --release --workspace --lib --tests`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt` all clean.