### PR TITLE
job,storage: per-stage garbling instrumentation (circuit.pass, table.upload/receive/store)

### DIFF
--- a/crates/job/executors/src/circuit_sessions.rs
+++ b/crates/job/executors/src/circuit_sessions.rs
@@ -379,27 +379,12 @@ pub struct TransferSession {
     output_wire_ids: Vec<u32>,
     /// Reusable buffer for ciphertext bytes per block.
     ct_buffer: Vec<u8>,
-    /// Heartbeat progress tracker for operator visibility.
-    heartbeat: HeartbeatTracker,
-    /// Cumulative ciphertext bytes garbled and enqueued to the outbox.
-    /// Wire progress trails this by at most the outbox depth.
-    bytes_sent: u64,
     /// Outbox depth in garbled chunks, applied when the drain spawns.
     outbox_depth: usize,
-    /// Expected total ciphertext bytes (AND gates × 16); also the total for
-    /// the drain's `table.wire` meter.
-    total_bytes: u64,
-    /// Producer-side stage attribution: `compute` (garbling) vs
-    /// `outbox_full` (parked because the peer is a full outbox behind).
-    /// The wire itself is timed by the drain's [`WireMeter`].
-    stages: StageBreakdown,
-    /// Set while an outbox `send` is parked. The worker drops the chunk
-    /// future at that await when the stall-strike budget runs out, so the
-    /// code after the `send` never runs; holding the start time here lets
-    /// [`abort`](CircuitSession::abort) reconcile the parked interval into
-    /// `outbox_full` instead of losing it — without it, the evicted
-    /// transfer's summary would look CPU-bound or idle.
-    send_parked_since: Option<Instant>,
+    /// Producer-side observability (`table.upload`). All logging state and
+    /// timing logic lives behind this meter; the fields above are the
+    /// operational state.
+    meter: UploadMeter,
 }
 
 /// Bounded outbox between garbling and the wire, plus the drain task's
@@ -505,6 +490,99 @@ impl WireMeter {
     /// clean flush, write failure, and cancellation alike.
     fn finish(mut self) {
         self.heartbeat.done_staged(self.bytes, &self.stages);
+    }
+}
+
+/// Producer-side stage meter for a transfer session, logged as
+/// `table.upload`.
+///
+/// Owns every observability field of [`TransferSession`] so the operational
+/// code only calls the named hooks below. `compute` is time garbling blocks;
+/// `outbox_full` is time parked in the outbox `send` — sustained
+/// peer-induced backpressure, since `send` only parks once the peer has
+/// fallen a full outbox behind. The wire itself is timed by the drain's
+/// [`WireMeter`].
+struct UploadMeter {
+    heartbeat: HeartbeatTracker,
+    stages: StageBreakdown,
+    /// Cumulative ciphertext bytes garbled and enqueued to the outbox.
+    /// Wire progress trails this by at most the outbox depth.
+    bytes_enqueued: u64,
+    /// Set while an outbox `send` is parked. The worker drops the chunk
+    /// future at that await when the stall-strike budget runs out, so
+    /// [`time_send`](Self::time_send) never resumes; [`summary`](Self::summary)
+    /// reconciles the interval into `outbox_full` instead of losing it —
+    /// without this, an evicted transfer would look CPU-bound or idle.
+    send_parked_since: Option<Instant>,
+    /// Expected total ciphertext bytes (AND gates × 16); also the total for
+    /// the drain's `table.wire` meter.
+    total_bytes: u64,
+}
+
+impl UploadMeter {
+    fn new(id: String, total_bytes: u64) -> Self {
+        Self {
+            heartbeat: HeartbeatTracker::new(
+                "table.upload",
+                id,
+                Some(total_bytes),
+                ProgressUnit::Bytes,
+                HEARTBEAT_PERIOD,
+            ),
+            stages: StageBreakdown::default(),
+            bytes_enqueued: 0,
+            send_parked_since: None,
+            total_bytes,
+        }
+    }
+
+    /// Time a synchronous garbling step into `compute`.
+    fn time_compute<T>(&mut self, f: impl FnOnce() -> T) -> T {
+        let started = Instant::now();
+        let out = f();
+        self.stages.compute += started.elapsed();
+        out
+    }
+
+    /// Drive an outbox `send`, timing the parked interval into `outbox_full`
+    /// and counting `n` bytes as enqueued on success. Cancellation-tolerant:
+    /// if the future is dropped mid-`send`, the interval is reconciled by
+    /// [`summary`](Self::summary).
+    async fn time_send<T, E>(
+        &mut self,
+        n: u64,
+        send: impl Future<Output = Result<T, E>>,
+    ) -> Result<T, E> {
+        self.send_parked_since = Some(Instant::now());
+        let res = send.await;
+        if let Some(parked) = self.send_parked_since.take() {
+            self.stages.outbox_full += parked.elapsed();
+        }
+        if res.is_ok() {
+            self.bytes_enqueued = self.bytes_enqueued.saturating_add(n);
+        }
+        res
+    }
+
+    /// Periodic heartbeat tick — call once per processed chunk.
+    fn on_chunk_done(&mut self) {
+        self.heartbeat
+            .maybe_log_staged(self.bytes_enqueued, &self.stages);
+    }
+
+    /// Emit the final attribution line, first reconciling any parked
+    /// interval left behind by a chunk future dropped mid-`send`.
+    fn summary(&mut self) {
+        if let Some(parked) = self.send_parked_since.take() {
+            self.stages.outbox_full += parked.elapsed();
+        }
+        self.heartbeat
+            .done_staged(self.bytes_enqueued, &self.stages);
+    }
+
+    /// Mint the drain-side wire meter for this transfer.
+    fn mint_wire_meter(&self, id: String) -> WireMeter {
+        WireMeter::new(id, self.total_bytes)
     }
 }
 
@@ -640,13 +718,7 @@ impl TransferSession {
     ) -> Self {
         // Each AND gate emits 16 ciphertext bytes on the wire.
         let total_bytes = total_and_gates.saturating_mul(16);
-        let heartbeat = HeartbeatTracker::new(
-            "table.upload",
-            short_id(commitment.as_ref()),
-            Some(total_bytes),
-            ProgressUnit::Bytes,
-            HEARTBEAT_PERIOD,
-        );
+        let meter = UploadMeter::new(short_id(commitment.as_ref()), total_bytes);
         Self {
             session,
             stream: Some(stream),
@@ -655,12 +727,8 @@ impl TransferSession {
             commitment,
             output_wire_ids,
             ct_buffer: Vec::new(),
-            heartbeat,
-            bytes_sent: 0,
             outbox_depth,
-            total_bytes,
-            stages: StageBreakdown::default(),
-            send_parked_since: None,
+            meter,
         }
     }
 
@@ -682,7 +750,9 @@ impl TransferSession {
         let (recycle_tx, recycle_rx) = mpsc_light::bounded::<Vec<u8>>(self.outbox_depth);
         let (done_tx, done_rx) = oneshot::oneshot();
         let (abort_tx, abort_rx) = oneshot::oneshot();
-        let meter = WireMeter::new(short_id(self.commitment.as_ref()), self.total_bytes);
+        let meter = self
+            .meter
+            .mint_wire_meter(short_id(self.commitment.as_ref()));
 
         let drain = async move {
             let result = drain_transfer_outbox(
@@ -733,9 +803,11 @@ impl CircuitSession for TransferSession {
             // full outbox behind.
             for block in &chunk.blocks {
                 self.ct_buffer.clear();
-                let garble_start = Instant::now();
-                process_owned_block_garble(&mut self.session.instance, block, &mut self.ct_buffer);
-                self.stages.compute += garble_start.elapsed();
+                let session = &mut self.session;
+                let ct_buffer = &mut self.ct_buffer;
+                self.meter.time_compute(|| {
+                    process_owned_block_garble(&mut session.instance, block, ct_buffer)
+                });
                 if !self.ct_buffer.is_empty() {
                     if self.outbox.is_none() {
                         self.spawn_drain();
@@ -744,24 +816,14 @@ impl CircuitSession for TransferSession {
 
                     let n = self.ct_buffer.len() as u64;
                     let out = std::mem::take(&mut self.ct_buffer);
-                    // `send` returns immediately while the outbox has room and
-                    // parks only once the peer has fallen a full outbox behind,
-                    // so time here is *sustained* peer-induced backpressure.
-                    // The wire itself is timed by the drain's `table.wire`
-                    // meter, which sees every write. The interval is recorded
-                    // before the error check (and reconciled by `abort` on
-                    // future drop) so an eviction keeps its parked time.
-                    self.send_parked_since = Some(Instant::now());
-                    let send_res = outbox.ct_tx.send(out).await;
-                    if let Some(parked) = self.send_parked_since.take() {
-                        self.stages.outbox_full += parked.elapsed();
-                    }
-                    send_res.map_err(|_| {
-                        CircuitError::ChunkFailed(
-                            "transfer drain closed — peer write failed".to_string(),
-                        )
-                    })?;
-                    self.bytes_sent = self.bytes_sent.saturating_add(n);
+                    self.meter
+                        .time_send(n, outbox.ct_tx.send(out))
+                        .await
+                        .map_err(|_| {
+                            CircuitError::ChunkFailed(
+                                "transfer drain closed — peer write failed".to_string(),
+                            )
+                        })?;
 
                     // Reuse a spent buffer when the drain has returned one.
                     if let Ok(spent) = outbox.recycle_rx.try_recv() {
@@ -769,21 +831,15 @@ impl CircuitSession for TransferSession {
                     }
                 }
             }
-            self.heartbeat
-                .maybe_log_staged(self.bytes_sent, &self.stages);
+            self.meter.on_chunk_done();
             Ok(())
         })
     }
 
     fn abort(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         // Eviction is a normal path under the strike budget — emit the final
-        // attribution line for the work that did happen before teardown. A
-        // chunk future dropped mid-`send` never recorded its parked interval;
-        // reconcile it first so the stall shows up as outbox_full.
-        if let Some(parked) = self.send_parked_since.take() {
-            self.stages.outbox_full += parked.elapsed();
-        }
-        self.heartbeat.done_staged(self.bytes_sent, &self.stages);
+        // attribution line for the work that did happen before teardown.
+        self.meter.summary();
         Box::pin(async move {
             let Some(outbox) = self.outbox.take() else {
                 // No drain was spawned. Dropping the session below closes
@@ -822,7 +878,7 @@ impl CircuitSession for TransferSession {
         // NB: this summary marks "garbling done, all ciphertext enqueued".
         // The outbox tail may still be in flight; the drain's `table.wire`
         // summary marks bytes-on-wire FIN.
-        self.heartbeat.done_staged(self.bytes_sent, &self.stages);
+        self.meter.summary();
         Box::pin(async move {
             // Finalize the garbling session to properly release the ~1 GB
             // working space. We discard the output — the commitment was

--- a/crates/job/executors/src/circuit_sessions.rs
+++ b/crates/job/executors/src/circuit_sessions.rs
@@ -488,6 +488,12 @@ impl WireMeter {
         self.heartbeat.maybe_log_staged(self.bytes, &self.stages);
     }
 
+    /// A write that stalled until timeout/cancel is the most peer-blocked
+    /// moment of the transfer — attribute it even though no bytes landed.
+    fn on_stalled_write(&mut self, wrote: Duration) {
+        self.stages.net_blocked += wrote;
+    }
+
     /// Emit the final attribution line. Called on every drain exit —
     /// clean flush, write failure, and cancellation alike.
     fn finish(mut self) {
@@ -576,7 +582,10 @@ async fn drain_transfer_outbox<S: OutboxStream>(
                 meter.on_write(write_started.elapsed(), len);
                 let _ = recycle_tx.try_send(spent);
             }
-            Err(error) => break Err(error),
+            Err(error) => {
+                meter.on_stalled_write(write_started.elapsed());
+                break Err(error);
+            }
         }
     };
     meter.finish();

--- a/crates/job/executors/src/circuit_sessions.rs
+++ b/crates/job/executors/src/circuit_sessions.rs
@@ -393,6 +393,13 @@ pub struct TransferSession {
     /// `outbox_full` (parked because the peer is a full outbox behind).
     /// The wire itself is timed by the drain's [`WireMeter`].
     stages: StageBreakdown,
+    /// Set while an outbox `send` is parked. The worker drops the chunk
+    /// future at that await when the stall-strike budget runs out, so the
+    /// code after the `send` never runs; holding the start time here lets
+    /// [`abort`](CircuitSession::abort) reconcile the parked interval into
+    /// `outbox_full` instead of losing it — without it, the evicted
+    /// transfer's summary would look CPU-bound or idle.
+    send_parked_since: Option<Instant>,
 }
 
 /// Bounded outbox between garbling and the wire, plus the drain task's
@@ -653,6 +660,7 @@ impl TransferSession {
             outbox_depth,
             total_bytes,
             stages: StageBreakdown::default(),
+            send_parked_since: None,
         }
     }
 
@@ -740,14 +748,19 @@ impl CircuitSession for TransferSession {
                     // parks only once the peer has fallen a full outbox behind,
                     // so time here is *sustained* peer-induced backpressure.
                     // The wire itself is timed by the drain's `table.wire`
-                    // meter, which sees every write.
-                    let send_start = Instant::now();
-                    outbox.ct_tx.send(out).await.map_err(|_| {
+                    // meter, which sees every write. The interval is recorded
+                    // before the error check (and reconciled by `abort` on
+                    // future drop) so an eviction keeps its parked time.
+                    self.send_parked_since = Some(Instant::now());
+                    let send_res = outbox.ct_tx.send(out).await;
+                    if let Some(parked) = self.send_parked_since.take() {
+                        self.stages.outbox_full += parked.elapsed();
+                    }
+                    send_res.map_err(|_| {
                         CircuitError::ChunkFailed(
                             "transfer drain closed — peer write failed".to_string(),
                         )
                     })?;
-                    self.stages.outbox_full += send_start.elapsed();
                     self.bytes_sent = self.bytes_sent.saturating_add(n);
 
                     // Reuse a spent buffer when the drain has returned one.
@@ -764,7 +777,12 @@ impl CircuitSession for TransferSession {
 
     fn abort(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         // Eviction is a normal path under the strike budget — emit the final
-        // attribution line for the work that did happen before teardown.
+        // attribution line for the work that did happen before teardown. A
+        // chunk future dropped mid-`send` never recorded its parked interval;
+        // reconcile it first so the stall shows up as outbox_full.
+        if let Some(parked) = self.send_parked_since.take() {
+            self.stages.outbox_full += parked.elapsed();
+        }
         self.heartbeat.done_staged(self.bytes_sent, &self.stages);
         Box::pin(async move {
             let Some(outbox) = self.outbox.take() else {

--- a/crates/job/executors/src/circuit_sessions.rs
+++ b/crates/job/executors/src/circuit_sessions.rs
@@ -16,7 +16,12 @@
 //! different session types per role into a single `type Session` for the
 //! `ExecuteGarblerJob` / `ExecuteEvaluatorJob` traits.
 
-use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use ark_ff::PrimeField;
 use blake3::Hasher;
@@ -52,12 +57,12 @@ use mosaic_vs3::{Index, Scalar, Share};
 
 use crate::{
     garbling::{GarblingSession, GarblingSetup, compute_commitment, hash_garbling_params},
-    progress::{HEARTBEAT_PERIOD, HeartbeatTracker, ProgressUnit},
+    progress::{HEARTBEAT_PERIOD, HeartbeatTracker, ProgressUnit, StageBreakdown},
 };
 
 /// Short-id helper used to label progress logs. Renders the first 4 bytes
 /// of a digest as `0x........`. Truncates gracefully if shorter.
-fn short_id(digest: &[u8]) -> String {
+pub(crate) fn short_id(digest: &[u8]) -> String {
     let mut s = String::from("0x");
     for b in digest.iter().take(4) {
         s.push_str(&format!("{b:02x}"));
@@ -381,6 +386,13 @@ pub struct TransferSession {
     bytes_sent: u64,
     /// Outbox depth in garbled chunks, applied when the drain spawns.
     outbox_depth: usize,
+    /// Expected total ciphertext bytes (AND gates × 16); also the total for
+    /// the drain's `table.wire` meter.
+    total_bytes: u64,
+    /// Producer-side stage attribution: `compute` (garbling) vs
+    /// `outbox_full` (parked because the peer is a full outbox behind).
+    /// The wire itself is timed by the drain's [`WireMeter`].
+    stages: StageBreakdown,
 }
 
 /// Bounded outbox between garbling and the wire, plus the drain task's
@@ -435,6 +447,53 @@ const TRANSFER_CHUNK_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 /// Under the coordinator's per-worker finish window; on expiry the table
 /// retries (idempotent — a receipted table drops as `AlreadyComplete`).
 const DRAIN_FINISH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Wire-side stage meter owned by the outbox drain, logged as `table.wire`.
+///
+/// The outbox decouples garbling from the wire: the producer's
+/// `table.upload` line reports enqueue pace, and its `outbox_full` stage
+/// only accrues once the peer is a full outbox behind. This meter reports
+/// the wire truth from the drain itself — `net_blocked` is time inside the
+/// stream write (the peer's pace), `feed_wait` is time waiting on the
+/// garbler for the next buffer. Whichever dominates names the side that
+/// set this transfer's pace.
+struct WireMeter {
+    heartbeat: HeartbeatTracker,
+    stages: StageBreakdown,
+    bytes: u64,
+}
+
+impl WireMeter {
+    fn new(id: String, total_bytes: u64) -> Self {
+        Self {
+            heartbeat: HeartbeatTracker::new(
+                "table.wire",
+                id,
+                Some(total_bytes),
+                ProgressUnit::Bytes,
+                HEARTBEAT_PERIOD,
+            ),
+            stages: StageBreakdown::default(),
+            bytes: 0,
+        }
+    }
+
+    fn on_recv(&mut self, waited: Duration) {
+        self.stages.feed_wait += waited;
+    }
+
+    fn on_write(&mut self, wrote: Duration, len: usize) {
+        self.stages.net_blocked += wrote;
+        self.bytes = self.bytes.saturating_add(len as u64);
+        self.heartbeat.maybe_log_staged(self.bytes, &self.stages);
+    }
+
+    /// Emit the final attribution line. Called on every drain exit —
+    /// clean flush, write failure, and cancellation alike.
+    fn finish(mut self) {
+        self.heartbeat.done_staged(self.bytes, &self.stages);
+    }
+}
 
 /// Stream surface used by the outbox drain.
 ///
@@ -494,9 +553,11 @@ async fn drain_transfer_outbox<S: OutboxStream>(
     recycle_tx: mpsc_light::Sender<Vec<u8>>,
     abort_rx: oneshot::Receiver<()>,
     write_timeout: Duration,
+    mut meter: WireMeter,
 ) -> Result<(), String> {
     pin_mut!(abort_rx);
     let result = loop {
+        let recv_started = Instant::now();
         let recv = ct_rx.recv();
         pin_mut!(recv);
         let buf = match select(abort_rx.as_mut(), recv).await {
@@ -504,16 +565,21 @@ async fn drain_transfer_outbox<S: OutboxStream>(
             Either::Right((Some(buf), _)) => buf,
             Either::Right((None, _)) => break Ok(()),
         };
+        meter.on_recv(recv_started.elapsed());
 
+        let len = buf.len();
+        let write_started = Instant::now();
         match write_outbox_chunk(&mut stream, buf, write_timeout, abort_rx.as_mut()).await {
             // Hand the spent buffer back for reuse; if the recycle lane is
             // full or its receiver is gone, just drop it.
             Ok(spent) => {
+                meter.on_write(write_started.elapsed(), len);
                 let _ = recycle_tx.try_send(spent);
             }
             Err(error) => break Err(error),
         }
     };
+    meter.finish();
 
     match result {
         Ok(()) => {
@@ -576,6 +642,8 @@ impl TransferSession {
             heartbeat,
             bytes_sent: 0,
             outbox_depth,
+            total_bytes,
+            stages: StageBreakdown::default(),
         }
     }
 
@@ -597,6 +665,7 @@ impl TransferSession {
         let (recycle_tx, recycle_rx) = mpsc_light::bounded::<Vec<u8>>(self.outbox_depth);
         let (done_tx, done_rx) = oneshot::oneshot();
         let (abort_tx, abort_rx) = oneshot::oneshot();
+        let meter = WireMeter::new(short_id(self.commitment.as_ref()), self.total_bytes);
 
         let drain = async move {
             let result = drain_transfer_outbox(
@@ -605,6 +674,7 @@ impl TransferSession {
                 recycle_tx,
                 abort_rx,
                 TRANSFER_CHUNK_WRITE_TIMEOUT,
+                meter,
             )
             .await;
             let _ = done_tx.send(result);
@@ -646,7 +716,9 @@ impl CircuitSession for TransferSession {
             // full outbox behind.
             for block in &chunk.blocks {
                 self.ct_buffer.clear();
+                let garble_start = Instant::now();
                 process_owned_block_garble(&mut self.session.instance, block, &mut self.ct_buffer);
+                self.stages.compute += garble_start.elapsed();
                 if !self.ct_buffer.is_empty() {
                     if self.outbox.is_none() {
                         self.spawn_drain();
@@ -655,11 +727,18 @@ impl CircuitSession for TransferSession {
 
                     let n = self.ct_buffer.len() as u64;
                     let out = std::mem::take(&mut self.ct_buffer);
+                    // `send` returns immediately while the outbox has room and
+                    // parks only once the peer has fallen a full outbox behind,
+                    // so time here is *sustained* peer-induced backpressure.
+                    // The wire itself is timed by the drain's `table.wire`
+                    // meter, which sees every write.
+                    let send_start = Instant::now();
                     outbox.ct_tx.send(out).await.map_err(|_| {
                         CircuitError::ChunkFailed(
                             "transfer drain closed — peer write failed".to_string(),
                         )
                     })?;
+                    self.stages.outbox_full += send_start.elapsed();
                     self.bytes_sent = self.bytes_sent.saturating_add(n);
 
                     // Reuse a spent buffer when the drain has returned one.
@@ -668,12 +747,16 @@ impl CircuitSession for TransferSession {
                     }
                 }
             }
-            self.heartbeat.maybe_log(self.bytes_sent);
+            self.heartbeat
+                .maybe_log_staged(self.bytes_sent, &self.stages);
             Ok(())
         })
     }
 
     fn abort(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        // Eviction is a normal path under the strike budget — emit the final
+        // attribution line for the work that did happen before teardown.
+        self.heartbeat.done_staged(self.bytes_sent, &self.stages);
         Box::pin(async move {
             let Some(outbox) = self.outbox.take() else {
                 // No drain was spawned. Dropping the session below closes
@@ -709,11 +792,10 @@ impl CircuitSession for TransferSession {
     }
 
     fn finish(mut self: Box<Self>) -> Pin<Box<dyn Future<Output = HandlerOutcome> + Send>> {
-        // NB: the summary log fires here, before the returned future runs and
-        // the stream is FIN'd on drop. For multi-minute uploads the gap is
-        // negligible, but the log marks "session work done" rather than
-        // "bytes-on-wire FIN".
-        self.heartbeat.done(self.bytes_sent);
+        // NB: this summary marks "garbling done, all ciphertext enqueued".
+        // The outbox tail may still be in flight; the drain's `table.wire`
+        // summary marks bytes-on-wire FIN.
+        self.heartbeat.done_staged(self.bytes_sent, &self.stages);
         Box::pin(async move {
             // Finalize the garbling session to properly release the ~1 GB
             // working space. We discard the output — the commitment was
@@ -1107,6 +1189,7 @@ mod tests {
                 recycle_tx,
                 abort_rx,
                 Duration::from_secs(1),
+                WireMeter::new("0xtest".to_string(), 0),
             ))
         })
         .join()
@@ -1143,6 +1226,7 @@ mod tests {
                 recycle_tx,
                 abort_rx,
                 Duration::from_millis(10),
+                WireMeter::new("0xtest".to_string(), 0),
             ))
         })
         .join()
@@ -1181,6 +1265,7 @@ mod tests {
                 recycle_tx,
                 abort_rx,
                 Duration::from_secs(60),
+                WireMeter::new("0xtest".to_string(), 0),
             ))
         });
 

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -33,8 +33,9 @@ use tracing::{debug, error, warn};
 
 use super::MosaicExecutor;
 use crate::{
-    circuit_sessions::{CiphertextReaderAdapter, EvaluationSession},
+    circuit_sessions::{CiphertextReaderAdapter, EvaluationSession, short_id},
     garbling::{compute_commitment, hash_garbling_params},
+    progress::{HEARTBEAT_PERIOD, HeartbeatTracker, ProgressUnit, StageBreakdown},
 };
 
 const BULK_OPEN_WARN_AFTER: Duration = Duration::from_secs(5);
@@ -303,6 +304,53 @@ enum DrainOutcome {
     ReadTimedOut,
 }
 
+/// Receive-side stage meter owned by [`drain_table_payload`].
+///
+/// This leg was previously unmetered, which made a slow object store
+/// indistinguishable from a slow peer: the writer feeds a bounded channel, so
+/// when the upload falls behind `write_ciphertext` blocks, the drain loop
+/// stops reading, and the backpressure surfaces on the *garbler's* rate
+/// instead of here. Splitting `net_wait` (peer has not sent) from
+/// `store_blocked` (our upload is behind) names the side that is actually
+/// responsible. The meter lives inside the drain helper so every exit path —
+/// timeout, oversize, write failure — emits its final attribution line,
+/// which is precisely when the split matters most.
+struct ReceiveMeter {
+    heartbeat: HeartbeatTracker,
+    stages: StageBreakdown,
+    bytes: u64,
+}
+
+impl ReceiveMeter {
+    fn new(peer_id: &PeerId) -> Self {
+        Self {
+            heartbeat: HeartbeatTracker::new(
+                "table.receive",
+                short_id(peer_id.as_ref()),
+                None,
+                ProgressUnit::Bytes,
+                HEARTBEAT_PERIOD,
+            ),
+            stages: StageBreakdown::default(),
+            bytes: 0,
+        }
+    }
+
+    fn on_read(&mut self, waited: Duration, len: usize) {
+        self.stages.net_wait += waited;
+        self.bytes = self.bytes.saturating_add(len as u64);
+        self.heartbeat.maybe_log_staged(self.bytes, &self.stages);
+    }
+
+    fn on_store(&mut self, blocked: Duration) {
+        self.stages.store_blocked += blocked;
+    }
+
+    fn finish(mut self) {
+        self.heartbeat.done_staged(self.bytes, &self.stages);
+    }
+}
+
 /// Consume a bulk stream carrying translation bytes followed by ciphertext
 /// bytes, hashing each domain and forwarding the ciphertext to `writer`.
 ///
@@ -324,6 +372,39 @@ async fn drain_table_payload<S, W>(
     read_warn_after: Duration,
     peer_id: &PeerId,
     index: Index,
+) -> DrainOutcome
+where
+    S: PayloadStream,
+    W: mosaic_storage_api::table_store::TableWriter,
+{
+    let mut meter = ReceiveMeter::new(peer_id);
+    let outcome = drain_table_payload_inner(
+        stream,
+        writer,
+        translation_size,
+        expected_ciphertext_bytes,
+        read_timeout,
+        read_warn_after,
+        peer_id,
+        index,
+        &mut meter,
+    )
+    .await;
+    meter.finish();
+    outcome
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drain_table_payload_inner<S, W>(
+    stream: &mut S,
+    writer: &mut W,
+    translation_size: usize,
+    expected_ciphertext_bytes: usize,
+    read_timeout: Duration,
+    read_warn_after: Duration,
+    peer_id: &PeerId,
+    index: Index,
+    meter: &mut ReceiveMeter,
 ) -> DrainOutcome
 where
     S: PayloadStream,
@@ -354,6 +435,8 @@ where
             Err(BulkReadError::Closed(_)) => break,
         };
 
+        meter.on_read(read_started.elapsed(), chunk.len());
+
         if chunk.is_empty() {
             break;
         }
@@ -378,7 +461,10 @@ where
                 }
                 ciphertext_bytes_received = next_ciphertext_bytes;
                 ct_hasher.update(ct_part);
-                if writer.write_ciphertext(ct_part).await.is_err() {
+                let write_started = Instant::now();
+                let write_res = writer.write_ciphertext(ct_part).await;
+                meter.on_store(write_started.elapsed());
+                if write_res.is_err() {
                     return DrainOutcome::WriteFailed {
                         during_translation_overflow: true,
                     };
@@ -398,7 +484,10 @@ where
             }
             ciphertext_bytes_received = next_ciphertext_bytes;
             ct_hasher.update(&chunk);
-            if writer.write_ciphertext(&chunk).await.is_err() {
+            let write_started = Instant::now();
+            let write_res = writer.write_ciphertext(&chunk).await;
+            meter.on_store(write_started.elapsed());
+            if write_res.is_err() {
                 return DrainOutcome::WriteFailed {
                     during_translation_overflow: false,
                 };

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -336,8 +336,15 @@ impl ReceiveMeter {
         }
     }
 
-    fn on_read(&mut self, waited: Duration, len: usize) {
+    /// A read wait with no delivered chunk — the timeout that kills the
+    /// transfer, or the tail wait for FIN. Counting it keeps `net_wait`
+    /// honest on exactly the paths where the attribution matters most.
+    fn on_read_wait(&mut self, waited: Duration) {
         self.stages.net_wait += waited;
+    }
+
+    fn on_read(&mut self, waited: Duration, len: usize) {
+        self.on_read_wait(waited);
         self.bytes = self.bytes.saturating_add(len as u64);
         self.heartbeat.maybe_log_staged(self.bytes, &self.stages);
     }
@@ -431,8 +438,14 @@ where
                 }
                 data
             }
-            Err(BulkReadError::TimedOut) => return DrainOutcome::ReadTimedOut,
-            Err(BulkReadError::Closed(_)) => break,
+            Err(BulkReadError::TimedOut) => {
+                meter.on_read_wait(read_started.elapsed());
+                return DrainOutcome::ReadTimedOut;
+            }
+            Err(BulkReadError::Closed(_)) => {
+                meter.on_read_wait(read_started.elapsed());
+                break;
+            }
         };
 
         meter.on_read(read_started.elapsed(), chunk.len());

--- a/crates/job/executors/src/progress.rs
+++ b/crates/job/executors/src/progress.rs
@@ -28,6 +28,60 @@ pub enum ProgressUnit {
     Blocks,
 }
 
+/// Cumulative time a phase spent in each of its sub-stages.
+///
+/// A phase's throughput alone cannot say *why* it is slow: a table transfer
+/// that reports 2 MB/s may be starved by local CPU, by a peer that is not
+/// draining its stream, or by an object store that is not keeping up. Call
+/// sites accumulate the time spent blocked in each stage and pass this
+/// alongside the byte count; the emitted line then attributes the elapsed
+/// wall-clock to the stage responsible.
+///
+/// Fields are cumulative for the phase and only the non-zero ones are printed.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StageBreakdown {
+    /// Local CPU work — garbling gates, hashing.
+    pub compute: Duration,
+    /// Blocked writing to a peer (their receive window is full — backpressure).
+    pub net_blocked: Duration,
+    /// Blocked reading from a peer (waiting for it to send, plus the
+    /// transfer time of the data itself).
+    pub net_wait: Duration,
+    /// Blocked writing to durable storage (object-store upload not keeping up).
+    pub store_blocked: Duration,
+    /// Producer parked because the transfer outbox is full — the peer has
+    /// fallen a full outbox behind (sustained backpressure).
+    pub outbox_full: Duration,
+    /// Wire drain waiting on the local producer for the next buffer —
+    /// compute, not the peer, is the constraint.
+    pub feed_wait: Duration,
+}
+
+impl StageBreakdown {
+    /// Render the non-zero stages as ` name=<dur>(<pct of elapsed>%)` pairs.
+    ///
+    /// The percentage is the actionable part: it names which stage owns the
+    /// wall-clock without the reader having to do arithmetic.
+    fn fmt_nonzero(&self, elapsed: Duration) -> String {
+        let total = elapsed.as_secs_f64().max(1e-3);
+        [
+            ("compute", self.compute),
+            ("net_blocked", self.net_blocked),
+            ("net_wait", self.net_wait),
+            ("store_blocked", self.store_blocked),
+            ("outbox_full", self.outbox_full),
+            ("feed_wait", self.feed_wait),
+        ]
+        .iter()
+        .filter(|(_, d)| !d.is_zero())
+        .map(|(name, d)| {
+            let pct = d.as_secs_f64() * 100.0 / total;
+            format!(" {}={}({:.0}%)", name, fmt_duration(*d), pct)
+        })
+        .collect()
+    }
+}
+
 /// Tracks progress through a long-running phase and emits periodic INFO
 /// heartbeat logs.
 ///
@@ -77,22 +131,35 @@ impl HeartbeatTracker {
     /// If [`HEARTBEAT_PERIOD`] has elapsed since the last log (or since
     /// construction), emit an INFO heartbeat. Cheap on the not-yet-time path.
     pub fn maybe_log(&mut self, current: u64) {
-        let now = Instant::now();
-        if now.duration_since(self.last_log_at) < self.period {
-            return;
-        }
-        self.emit(current, now, /* final = */ false);
-        self.last_log_at = now;
-        self.last_log_progress = current;
+        self.maybe_log_staged(current, &StageBreakdown::default());
     }
 
     /// Emit a final summary line. Always logs regardless of last_log_at.
     pub fn done(&mut self, current: u64) {
-        let now = Instant::now();
-        self.emit(current, now, /* final = */ true);
+        self.done_staged(current, &StageBreakdown::default());
     }
 
-    fn emit(&mut self, current: u64, now: Instant, is_final: bool) {
+    /// As [`maybe_log`](Self::maybe_log), but also attributes elapsed wall-clock
+    /// to the sub-stages in `stages`. Use where a phase can be starved by more
+    /// than one resource and the throughput number alone is ambiguous.
+    /// A default (all-zero) breakdown renders nothing.
+    pub fn maybe_log_staged(&mut self, current: u64, stages: &StageBreakdown) {
+        let now = Instant::now();
+        if now.duration_since(self.last_log_at) < self.period {
+            return;
+        }
+        self.emit(current, now, /* final = */ false, stages);
+        self.last_log_at = now;
+        self.last_log_progress = current;
+    }
+
+    /// As [`done`](Self::done), with a final stage-time attribution.
+    pub fn done_staged(&mut self, current: u64, stages: &StageBreakdown) {
+        let now = Instant::now();
+        self.emit(current, now, /* final = */ true, stages);
+    }
+
+    fn emit(&mut self, current: u64, now: Instant, is_final: bool, stages: &StageBreakdown) {
         let elapsed = now.duration_since(self.started_at);
         let interval = now.duration_since(self.last_log_at);
         let delta = current.saturating_sub(self.last_log_progress);
@@ -106,6 +173,7 @@ impl HeartbeatTracker {
             .map(|t| (current as f64) * 100.0 / (t as f64));
 
         let event_label = if is_final { "summary" } else { "progress" };
+        let stage_str = stages.fmt_nonzero(elapsed);
 
         match self.unit {
             ProgressUnit::Bytes => {
@@ -125,7 +193,7 @@ impl HeartbeatTracker {
                     target: "mosaic_progress",
                     phase = self.label,
                     id = %self.short_id,
-                    "{} {} id={} done={}{} inst={}/s avg={}/s elapsed={}{}",
+                    "{} {} id={} done={}{} inst={}/s avg={}/s elapsed={}{}{}",
                     self.label,
                     event_label,
                     self.short_id,
@@ -135,6 +203,7 @@ impl HeartbeatTracker {
                     fmt_rate(avg_rate),
                     fmt_duration(elapsed),
                     eta_str,
+                    stage_str,
                 );
             }
             ProgressUnit::Blocks => {
@@ -146,12 +215,13 @@ impl HeartbeatTracker {
                     target: "mosaic_progress",
                     phase = self.label,
                     id = %self.short_id,
-                    "{} {} id={}{} elapsed={}",
+                    "{} {} id={}{} elapsed={}{}",
                     self.label,
                     event_label,
                     self.short_id,
                     pct_str,
                     fmt_duration(elapsed),
+                    stage_str,
                 );
             }
         }

--- a/crates/job/scheduler/src/garbling/mod.rs
+++ b/crates/job/scheduler/src/garbling/mod.rs
@@ -568,8 +568,8 @@ async fn run_pass(
     let n_workers = workers.len();
 
     // Passes are class-homogeneous (see collect_batch); the lead session
-    // names the class on the pass progress line, since barrier_wait means
-    // "slow peer/store" in an I/O pass but "slow CPU" in a compute pass.
+    // names the class on the pass progress line, since a barrier-gated pass
+    // means "slow peer/store" for I/O but "slow CPU" for compute.
     let class_label = match sessions.first().map(|s| session_class(&s.job.action)) {
         Some(SessionClass::Compute) => "compute",
         Some(SessionClass::Io) => "io",
@@ -648,11 +648,10 @@ async fn run_pass(
 
     // ── Pass-level time attribution ──────────────────────────────────
     // The read is pipelined against the barrier below, so the pass advances
-    // at max(read, barrier) per chunk and the two raw busy totals overlap —
-    // they cannot be read as shares of wall-clock. The meter therefore also
-    // tracks each side's per-chunk *excess* over the other, which is
-    // additive and names the resource that actually set the pace (see
-    // [`PassMeter`]).
+    // at max(read, barrier) per chunk and the per-side busy totals overlap.
+    // The meter therefore also tracks each side's per-chunk *excess* over
+    // the other — the additive numbers that name what actually set the pace
+    // (see [`PassMeter`] for the busy-vs-gated reading).
     let mut meter = PassMeter::new(class_label, session_count);
 
     // ── Read blocks and broadcast to workers (pipelined) ─────────────
@@ -733,12 +732,15 @@ const PASS_PROGRESS_PERIOD: Duration = Duration::from_secs(30);
 /// Pass-level wall-clock attribution across the pipelined read/barrier loop,
 /// logged as `circuit.pass` on the `mosaic_progress` target.
 ///
-/// `disk_read` and `barrier_wait` are each side's raw busy time; under
-/// pipelining they overlap and can sum past 100% of elapsed. `read_gated` /
-/// `barrier_gated` are the per-chunk excess of one side over the other —
-/// additive shares of wall-clock, so whichever dominates names the resource
-/// that set this pass's pace ("our circuit volume is too slow" vs "a session
-/// — and so a peer, or that peer's object store — gates every table").
+/// The two pairs answer different questions. `read_gated` / `barrier_gated`
+/// are *attribution*: each side's per-chunk excess over the other, additive
+/// shares of wall-clock — whichever dominates names what paces the pass
+/// ("our circuit volume is too slow" vs "a session — and so a peer, or that
+/// peer's object store — gates every table"), and its value is the
+/// first-order win from fixing that side. `read_busy` / `barrier_busy` are
+/// *utilization*: each side's raw busy time, overlapped under pipelining
+/// (together they can approach 200% of elapsed) — they say how loaded each
+/// side already is, i.e. the floor you hit after fixing the current gate.
 /// `straggler` names the worker that most often kept the barrier waiting.
 struct PassMeter {
     /// Session class this pass serves (passes are class-homogeneous).
@@ -747,8 +749,8 @@ struct PassMeter {
     started: Instant,
     last_log: Instant,
     bytes_read: u64,
-    disk_read: Duration,
-    barrier_wait: Duration,
+    read_busy: Duration,
+    barrier_busy: Duration,
     read_gated: Duration,
     barrier_gated: Duration,
     /// Cumulative in-order report wait per worker (see
@@ -765,8 +767,8 @@ impl PassMeter {
             started: now,
             last_log: now,
             bytes_read: 0,
-            disk_read: Duration::ZERO,
-            barrier_wait: Duration::ZERO,
+            read_busy: Duration::ZERO,
+            barrier_busy: Duration::ZERO,
             read_gated: Duration::ZERO,
             barrier_gated: Duration::ZERO,
             worker_wait: HashMap::new(),
@@ -776,7 +778,7 @@ impl PassMeter {
     /// The first read has no barrier to hide behind — it gates the pass in
     /// full.
     fn on_initial_read(&mut self, read: Duration) {
-        self.disk_read += read;
+        self.read_busy += read;
         self.read_gated += read;
     }
 
@@ -794,8 +796,8 @@ impl PassMeter {
     /// thread, so CPU spent by one (convert) can inflate the other's
     /// elapsed — noise next to the I/O both sides spend their time in.
     fn on_joined(&mut self, read: Duration, barrier: Duration) {
-        self.disk_read += read;
-        self.barrier_wait += barrier;
+        self.read_busy += read;
+        self.barrier_busy += barrier;
         self.read_gated += read.saturating_sub(barrier);
         self.barrier_gated += barrier.saturating_sub(read);
     }
@@ -828,7 +830,7 @@ impl PassMeter {
             phase = "circuit.pass",
             "circuit.pass {} class={} sessions={} read={:.1}GiB avg={:.1}MB/s elapsed={:.0}s \
              read_gated={:.0}s({:.0}%) barrier_gated={:.0}s({:.0}%) \
-             disk_read={:.0}s({:.0}%) barrier_wait={:.0}s({:.0}%){}",
+             read_busy={:.0}s({:.0}%) barrier_busy={:.0}s({:.0}%){}",
             event,
             self.class,
             self.sessions,
@@ -839,10 +841,10 @@ impl PassMeter {
             pct(self.read_gated),
             self.barrier_gated.as_secs_f64(),
             pct(self.barrier_gated),
-            self.disk_read.as_secs_f64(),
-            pct(self.disk_read),
-            self.barrier_wait.as_secs_f64(),
-            pct(self.barrier_wait),
+            self.read_busy.as_secs_f64(),
+            pct(self.read_busy),
+            self.barrier_busy.as_secs_f64(),
+            pct(self.barrier_busy),
             straggler,
         );
     }

--- a/crates/job/scheduler/src/garbling/mod.rs
+++ b/crates/job/scheduler/src/garbling/mod.rs
@@ -55,7 +55,7 @@ use std::{
     panic::{AssertUnwindSafe, catch_unwind},
     path::PathBuf,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use ckt_fmtv5_types::v5::c::{Block, ReaderV5c, get_block_num_gates};
@@ -567,6 +567,16 @@ async fn run_pass(
 ) {
     let n_workers = workers.len();
 
+    // Passes are class-homogeneous (see collect_batch); the lead session
+    // names the class on the pass progress line, since barrier_wait means
+    // "slow peer/store" in an I/O pass but "slow CPU" in a compute pass.
+    let class_label = match sessions.first().map(|s| session_class(&s.job.action)) {
+        Some(SessionClass::Compute) => "compute",
+        Some(SessionClass::Io) => "io",
+        None => "none",
+    };
+    let session_count = sessions.len();
+
     // ── Distribute sessions round-robin (spread-first) ──────────────
     // With 7 sessions across 4 workers: [2, 2, 2, 1] sessions each.
     let mut assignments: Vec<Vec<ActiveSession>> = (0..n_workers).map(|_| Vec::new()).collect();
@@ -636,6 +646,15 @@ async fn run_pass(
         .max_chunk_stall_duration()
         .saturating_add(Duration::from_secs(5));
 
+    // ── Pass-level time attribution ──────────────────────────────────
+    // The read is pipelined against the barrier below, so the pass advances
+    // at max(read, barrier) per chunk and the two raw busy totals overlap —
+    // they cannot be read as shares of wall-clock. The meter therefore also
+    // tracks each side's per-chunk *excess* over the other, which is
+    // additive and names the resource that actually set the pace (see
+    // [`PassMeter`]).
+    let mut meter = PassMeter::new(class_label, session_count);
+
     // ── Read blocks and broadcast to workers (pipelined) ─────────────
     //
     // The read+convert of chunk N+1 overlaps the barrier wait for chunk N:
@@ -643,9 +662,13 @@ async fn run_pass(
     // wait to have the next broadcast ready the moment the barrier clears.
     // Without the overlap, disk latency and worker latency were paid in
     // series on every chunk of the pass.
+    let read_started = Instant::now();
     let mut next_chunk = read_next_chunk(&mut reader, total_gates, &mut block_idx).await;
+    meter.on_initial_read(read_started.elapsed());
 
     while let Some(shared) = next_chunk.take() {
+        meter.on_chunk(&shared);
+
         // Broadcast chunk to all active workers.
         for &wid in &active_worker_ids {
             if !workers[wid]
@@ -657,25 +680,39 @@ async fn run_pass(
         }
 
         // ── Prefetch next chunk while the barrier waits ──────────────
-        let (prefetched, still_active) = futures::future::join(
-            read_next_chunk(&mut reader, total_gates, &mut block_idx),
-            collect_chunk_reports(
+        let read = async {
+            let started = Instant::now();
+            let chunk = read_next_chunk(&mut reader, total_gates, &mut block_idx).await;
+            (chunk, started.elapsed())
+        };
+        let barrier = async {
+            let started = Instant::now();
+            let still_active = collect_chunk_reports(
                 &active_worker_ids,
                 &mut active_jobs_by_worker,
                 workers,
                 report_timeout,
                 pending_retry,
-            ),
-        )
-        .await;
+                &mut meter.worker_wait,
+            )
+            .await;
+            (still_active, started.elapsed())
+        };
+        let ((prefetched, read_elapsed), (still_active, barrier_elapsed)) =
+            futures::future::join(read, barrier).await;
         next_chunk = prefetched;
         active_worker_ids = still_active;
+        meter.on_joined(read_elapsed, barrier_elapsed);
+        meter.maybe_log();
 
         if active_worker_ids.is_empty() {
             tracing::warn!("all workers idle — ending pass early");
+            meter.summary();
             return;
         }
     }
+
+    meter.summary();
 
     // ── Finalize surviving sessions ──────────────────────────────────
     collect_finish_reports_with_timeout(
@@ -690,6 +727,127 @@ async fn run_pass(
     .await;
 }
 
+/// Minimum interval between pass-level progress lines.
+const PASS_PROGRESS_PERIOD: Duration = Duration::from_secs(30);
+
+/// Pass-level wall-clock attribution across the pipelined read/barrier loop,
+/// logged as `circuit.pass` on the `mosaic_progress` target.
+///
+/// `disk_read` and `barrier_wait` are each side's raw busy time; under
+/// pipelining they overlap and can sum past 100% of elapsed. `read_gated` /
+/// `barrier_gated` are the per-chunk excess of one side over the other —
+/// additive shares of wall-clock, so whichever dominates names the resource
+/// that set this pass's pace ("our circuit volume is too slow" vs "a session
+/// — and so a peer, or that peer's object store — gates every table").
+/// `straggler` names the worker that most often kept the barrier waiting.
+struct PassMeter {
+    /// Session class this pass serves (passes are class-homogeneous).
+    class: &'static str,
+    sessions: usize,
+    started: Instant,
+    last_log: Instant,
+    bytes_read: u64,
+    disk_read: Duration,
+    barrier_wait: Duration,
+    read_gated: Duration,
+    barrier_gated: Duration,
+    /// Cumulative in-order report wait per worker (see
+    /// [`collect_chunk_reports`]).
+    worker_wait: HashMap<usize, Duration>,
+}
+
+impl PassMeter {
+    fn new(class: &'static str, sessions: usize) -> Self {
+        let now = Instant::now();
+        Self {
+            class,
+            sessions,
+            started: now,
+            last_log: now,
+            bytes_read: 0,
+            disk_read: Duration::ZERO,
+            barrier_wait: Duration::ZERO,
+            read_gated: Duration::ZERO,
+            barrier_gated: Duration::ZERO,
+            worker_wait: HashMap::new(),
+        }
+    }
+
+    /// The first read has no barrier to hide behind — it gates the pass in
+    /// full.
+    fn on_initial_read(&mut self, read: Duration) {
+        self.disk_read += read;
+        self.read_gated += read;
+    }
+
+    fn on_chunk(&mut self, chunk: &OwnedChunk) {
+        self.bytes_read = self.bytes_read.saturating_add(
+            chunk
+                .blocks
+                .iter()
+                .map(|b| (b.gate_data.len() + b.gate_types.len()) as u64)
+                .sum::<u64>(),
+        );
+    }
+
+    /// Record one pipelined read/barrier pair. Both sides poll on one
+    /// thread, so CPU spent by one (convert) can inflate the other's
+    /// elapsed — noise next to the I/O both sides spend their time in.
+    fn on_joined(&mut self, read: Duration, barrier: Duration) {
+        self.disk_read += read;
+        self.barrier_wait += barrier;
+        self.read_gated += read.saturating_sub(barrier);
+        self.barrier_gated += barrier.saturating_sub(read);
+    }
+
+    fn maybe_log(&mut self) {
+        if self.last_log.elapsed() < PASS_PROGRESS_PERIOD {
+            return;
+        }
+        self.emit("progress");
+        self.last_log = Instant::now();
+    }
+
+    fn summary(&self) {
+        self.emit("summary");
+    }
+
+    fn emit(&self, event: &str) {
+        let secs = self.started.elapsed().as_secs_f64().max(1e-3);
+        let pct = |d: Duration| d.as_secs_f64() * 100.0 / secs;
+
+        let straggler = self
+            .worker_wait
+            .iter()
+            .max_by_key(|(_, d)| **d)
+            .map(|(wid, d)| format!(" straggler=worker{}({:.0}s)", wid, d.as_secs_f64()))
+            .unwrap_or_default();
+
+        tracing::info!(
+            target: "mosaic_progress",
+            phase = "circuit.pass",
+            "circuit.pass {} class={} sessions={} read={:.1}GiB avg={:.1}MB/s elapsed={:.0}s \
+             read_gated={:.0}s({:.0}%) barrier_gated={:.0}s({:.0}%) \
+             disk_read={:.0}s({:.0}%) barrier_wait={:.0}s({:.0}%){}",
+            event,
+            self.class,
+            self.sessions,
+            self.bytes_read as f64 / (1024.0 * 1024.0 * 1024.0),
+            self.bytes_read as f64 / secs / 1.0e6,
+            secs,
+            self.read_gated.as_secs_f64(),
+            pct(self.read_gated),
+            self.barrier_gated.as_secs_f64(),
+            pct(self.barrier_gated),
+            self.disk_read.as_secs_f64(),
+            pct(self.disk_read),
+            self.barrier_wait.as_secs_f64(),
+            pct(self.barrier_wait),
+            straggler,
+        );
+    }
+}
+
 /// Collect chunk-phase reports from all active workers.
 ///
 /// Returns the set of workers that still have active sessions after processing
@@ -700,11 +858,19 @@ async fn collect_chunk_reports(
     workers: &mut [WorkerHandle],
     report_timeout: Duration,
     pending_retry: &mut Vec<PendingCircuitJob>,
+    worker_wait: &mut HashMap<usize, Duration>,
 ) -> Vec<usize> {
     let mut still_active: Vec<usize> = Vec::with_capacity(active_worker_ids.len());
 
     for &wid in active_worker_ids {
-        match workers[wid].recv_report(report_timeout).await {
+        // Reports are awaited in order, so this is not a clean per-worker
+        // service time — a worker that finished while we waited on an earlier
+        // one records ~0. Accumulated across the pass it still identifies the
+        // worker that repeatedly makes the barrier wait, i.e. the straggler.
+        let wait_started = Instant::now();
+        let report = workers[wid].recv_report(report_timeout).await;
+        *worker_wait.entry(wid).or_default() += wait_started.elapsed();
+        match report {
             Some(WorkerReport::ChunkDone(report)) => {
                 pending_retry.extend(report.evicted_jobs);
                 if report.remaining_jobs.is_empty() {
@@ -1564,6 +1730,7 @@ mod tests {
                 &mut workers,
                 Duration::from_millis(1),
                 &mut pending_retry,
+                &mut HashMap::new(),
             )
             .await;
 

--- a/crates/storage/s3/src/writer.rs
+++ b/crates/storage/s3/src/writer.rs
@@ -6,7 +6,10 @@
 //! visible only once the live commit marker is published during
 //! [`finish`](S3TableWriter::finish).
 
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use bytes::Bytes;
 use mosaic_storage_api::table_store::{TableMetadata, TableWriter};
@@ -139,6 +142,35 @@ async fn background_writer(
     }
 }
 
+/// Minimum interval between object-store upload progress lines.
+const STORE_PROGRESS_PERIOD: Duration = Duration::from_secs(30);
+
+/// Emit one object-store upload progress line.
+///
+/// `put` is the throughput achieved while actually inside `put_part` — the
+/// store's own speed — whereas `avg` is measured against wall-clock and so is
+/// additionally diluted by time spent waiting for the producer to supply data.
+/// `put` well above `avg` means we are starved upstream; the two converging
+/// means the store is the constraint.
+fn log_store_progress(event: &str, parts: u64, bytes_put: u64, started: Instant, in_put: Duration) {
+    let wall = started.elapsed().as_secs_f64().max(1e-3);
+    let put_secs = in_put.as_secs_f64().max(1e-3);
+    tracing::info!(
+        target: "mosaic_progress",
+        phase = "table.store",
+        "table.store {} parts={} uploaded={:.1}GiB put={:.1}MB/s avg={:.1}MB/s \
+         elapsed={:.0}s in_put={:.0}s({:.0}%)",
+        event,
+        parts,
+        bytes_put as f64 / (1024.0 * 1024.0 * 1024.0),
+        bytes_put as f64 / put_secs / 1.0e6,
+        bytes_put as f64 / wall / 1.0e6,
+        wall,
+        in_put.as_secs_f64(),
+        in_put.as_secs_f64() * 100.0 / wall,
+    );
+}
+
 async fn background_writer_inner(
     store: &Arc<dyn ObjectStore>,
     root_paths: &TableRootPaths,
@@ -148,6 +180,18 @@ async fn background_writer_inner(
     // Start a multipart upload for the ciphertext object.
     let mut upload = store.put_multipart(&version_paths.ciphertexts).await?;
     let mut buffer = Vec::with_capacity(PART_BUFFER_SIZE);
+
+    // Upload-side progress. Parts are uploaded one at a time (each `put_part`
+    // is awaited before the next begins), so `in_put` is the true serialized
+    // cost of shipping this table to the object store. When it approaches the
+    // wall-clock, the store — not the peer or the CPU — is what is pacing the
+    // transfer, and the backpressure surfaces upstream through the bounded
+    // command channel.
+    let upload_started = Instant::now();
+    let mut last_log = upload_started;
+    let mut parts: u64 = 0;
+    let mut bytes_put: u64 = 0;
+    let mut in_put = Duration::ZERO;
 
     loop {
         let cmd = match cmd_rx.recv().await {
@@ -168,7 +212,17 @@ async fn background_writer_inner(
                 // Upload complete parts when the buffer is large enough.
                 while buffer.len() >= PART_BUFFER_SIZE {
                     let part: Vec<u8> = buffer.drain(..PART_BUFFER_SIZE).collect();
+                    let n = part.len() as u64;
+                    let put_started = Instant::now();
                     upload.put_part(Bytes::from(part).into()).await?;
+                    in_put += put_started.elapsed();
+                    parts += 1;
+                    bytes_put += n;
+                }
+
+                if last_log.elapsed() >= STORE_PROGRESS_PERIOD {
+                    log_store_progress("progress", parts, bytes_put, upload_started, in_put);
+                    last_log = Instant::now();
                 }
             }
 
@@ -179,11 +233,18 @@ async fn background_writer_inner(
                 // Upload any remaining buffered ciphertext as the final part.
                 if !buffer.is_empty() {
                     let final_part = std::mem::take(&mut buffer);
+                    let n = final_part.len() as u64;
+                    let put_started = Instant::now();
                     upload.put_part(Bytes::from(final_part).into()).await?;
+                    in_put += put_started.elapsed();
+                    parts += 1;
+                    bytes_put += n;
                 }
 
                 // Complete the multipart upload.
                 upload.complete().await?;
+
+                log_store_progress("summary", parts, bytes_put, upload_started, in_put);
 
                 // Upload translation material as a single object under the staged version.
                 store

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,123 @@
+# Garbling Progress Logs
+
+Long-running garbling phases emit periodic INFO heartbeats on the
+`mosaic_progress` tracing target. Filter with `RUST_LOG=mosaic_progress=info`
+or grep for the target string. Each phase emits `progress` lines (throttled to
+one per 30 s) and a final `summary` line on every exit — clean finish,
+eviction, timeout, and failure alike — so summaries are available for
+post-mortems. Sole exception: `table.store` emits no summary when the upload
+itself fails; its error log covers that case.
+
+Every line attributes elapsed wall-clock to named stages as
+`stage=<duration>(<percent of elapsed>)`. The `table.*` lines omit zero
+stages; `circuit.pass` always prints all four of its pairs.
+
+## Common fields (`table.upload` / `table.wire` / `table.receive`)
+
+| Field | Meaning |
+|---|---|
+| `id=` | Work-item short id: commitment hash for upload/wire, sender peer id for receive |
+| `done=` | Cumulative bytes, with `/total` when the total is known |
+| `pct=` | `done` as a percentage of the total |
+| `inst=` / `avg=` | Throughput since the last line / since phase start |
+| `elapsed=` | Time since phase start |
+| `eta=` | Remaining time at the current `inst` rate |
+
+## `circuit.pass` — the coordinator's read/barrier loop
+
+One line per pass. The circuit read of chunk N+1 is pipelined against the
+barrier (all workers finishing chunk N), so the pass advances at
+`max(read, barrier)` per chunk.
+
+| Field | Meaning |
+|---|---|
+| `class=` | Session class of this pass, `compute` or `io` (passes are class-homogeneous) |
+| `sessions=` | Sessions served by the pass |
+| `read=` / `avg=` | Converted circuit bytes broadcast so far, and their rate |
+| `read_gated=` | Wall-clock where the barrier was done but the read was still running |
+| `barrier_gated=` | Wall-clock where the read was done but workers were still processing |
+| `read_busy=` | Raw busy time of the read+convert side |
+| `barrier_busy=` | Raw busy time of the barrier side |
+| `straggler=` | Worker that accumulated the most barrier wait (in-order skew: a slow worker early in the list can mask later ones) |
+
+```text
+circuit.pass progress class=io sessions=5 read=84.4GiB avg=50.3MB/s elapsed=1800s read_gated=12s(1%) barrier_gated=1493s(83%) read_busy=289s(16%) barrier_busy=1782s(99%) straggler=worker2(1102s)
+```
+
+**Reading the two pairs.** The `*_gated` values are *attribution*: additive
+shares of wall-clock, so whichever dominates names what paces the pass, and
+its value is the first-order win from fixing that side. The `*_busy` values
+are *utilization*: they overlap under pipelining (together they can approach
+200% of elapsed) and say how loaded each side already is — i.e. the floor you
+hit after fixing the current gate. Example: `barrier_gated=10%` with
+`read_busy=90%` means the barrier paces the pass, but fixing it only buys 10%
+before the read becomes the gate.
+
+## `table.upload` — garbler, producer side (G8)
+
+The garbler garbles blocks and enqueues ciphertext into a bounded outbox; a
+drain thread owns the wire. `done`/rates measure **enqueue** pace — wire
+progress trails by at most one outbox (~a few MiB).
+
+| Stage | Meaning |
+|---|---|
+| `compute=` | Garbling gates (local CPU) |
+| `outbox_full=` | Parked in the outbox `send` — the peer has fallen a full outbox behind (sustained backpressure). Preserved even when the session is evicted mid-send |
+
+```text
+table.upload progress id=0x3fa2c81d done=12.4GiB/40.1GiB pct=30.9% inst=52MB/s avg=51MB/s elapsed=4m22s eta=10m13s compute=3m30s(80%) outbox_full=31s(12%)
+```
+
+## `table.wire` — garbler, drain side (G8)
+
+The wire truth for the same transfer (same `id` as its `table.upload`):
+bytes actually written to the peer.
+
+| Stage | Meaning |
+|---|---|
+| `net_blocked=` | Inside the stream write — the peer's receive pace. Includes writes that stalled to timeout/cancel |
+| `feed_wait=` | Waiting on the garbler for the next buffer — compute, not the wire, is the constraint |
+
+```text
+table.wire progress id=0x3fa2c81d done=12.4GiB/40.1GiB pct=30.9% inst=45MB/s avg=50MB/s elapsed=4m24s eta=11m49s net_blocked=4m01s(91%) feed_wait=15s(6%)
+```
+
+## `table.receive` — evaluator ingest (E4)
+
+Consumes a peer's bulk stream and forwards ciphertext to the table store.
+
+| Stage | Meaning |
+|---|---|
+| `net_wait=` | Waiting for the peer to send (plus transfer time of the data). Includes reads that expired the read timeout |
+| `store_blocked=` | Blocked in `write_ciphertext` — the object-store upload is not keeping up |
+
+```text
+table.receive summary id=0x9b41d7aa done=40.1GiB inst=41MB/s avg=42MB/s elapsed=17m05s net_wait=12m40s(74%) store_blocked=3m22s(20%)
+```
+
+## `table.store` — object-store upload
+
+Emitted by the S3 background writer while shipping a received table.
+
+| Field | Meaning |
+|---|---|
+| `parts=` / `uploaded=` | Multipart parts and bytes uploaded |
+| `put=` | Throughput while actually inside `put_part` — the store's own speed |
+| `avg=` | Throughput against wall-clock, diluted by waiting for the producer |
+| `in_put=` | Serialized time inside `put_part` |
+
+```text
+table.store progress parts=806 uploaded=6.3GiB put=118.7MB/s avg=37.6MB/s elapsed=180s in_put=57s(32%)
+```
+
+`put` well above `avg` means the writer is starved upstream; the two
+converging means the store is the constraint.
+
+## Diagnosis recipe
+
+A slow transfer names its bottleneck by which stage dominates, and the lines
+corroborate each other across nodes: sender `outbox_full`/`net_blocked` high →
+look at that receiver's `table.receive`; there, `store_blocked` high → look at
+its `table.store` `put` rate. `circuit.pass barrier_gated` high in an `io`
+pass means some session — and so some peer, or that peer's store — gates
+every table in the pass; `straggler` says which worker to inspect first.


### PR DESCRIPTION
## What

Adds per-stage wall-clock attribution to the garbling pipeline, all on the existing `mosaic_progress` log target. No behavioral changes. Field-by-field reference with sample lines: `docs/observability.md`.

| Meter | Splits | Answers |
|---|---|---|
| `circuit.pass` | `read_gated` / `barrier_gated` (+ `read_busy` / `barrier_busy`, `straggler`, `class`) | is a slow pass the circuit read, the barrier, or one worker? |
| `table.upload` | `compute` / `outbox_full` | is the sender garbling slowly, or parked because the peer is a full outbox behind? |
| `table.wire` | `net_blocked` / `feed_wait` | from the drain: is the wire paced by the peer or starved by the garbler? |
| `table.receive` | `net_wait` / `store_blocked` (per sender peer id) | is the receiver starved by the peer or by its own store? |
| `table.store` | `put` vs `avg`, `in_put` | is the object store the constraint? |

With #326's pipelining the pass read overlaps the barrier, so the raw `*_busy` totals can sum to as much as ~200% of elapsed — they are utilization (how loaded each side is, and the floor you hit after fixing the current gate). `read_gated` / `barrier_gated` are each side's per-chunk excess over the other: additive (≤100%) shares of wall-clock that name the pacing resource and the first-order win from fixing it.

## Why

This instrumentation produced the STR-4026 garbling-bottleneck RCA and the STR-4121 half-hardware falsification run on the 5-operator optimus rig: it's what attributed 80%+ of transfer wall-clock to barrier/starvation, measured compute at 2-11%, disk at ~0%, and located the per-receiver ~33-44 MB/s path ceiling. It also directly measures what STR-4132 (full-garbling timing run) asks to capture. RCA: https://app.notion.com/p/3aa901ba000f81b9adf8de0ea845bd24

## Notes for review

- Rebased on main after #326 and redesigned where its architecture moved the measured awaits: `table.upload` meters the producer (garble + outbox backpressure), the new `table.wire` meters the drain thread that owns the stream, and `circuit.pass` gained the gated/busy split for the pipelined read. 101 lib tests green across executors/scheduler/s3.
- Stall attribution survives the failure paths that matter most: an evicted transfer's parked send (chunk future dropped at the await), a drain write that stalls to timeout/cancel, and a receive that expires the read timeout all keep their blocked intervals, and every meter emits a final summary on every exit — finish, abort, timeout, and failure alike (sole exception: `table.store` on upload error, where the error log covers it).
- All timing state lives behind meter types (`UploadMeter`, `WireMeter`, `ReceiveMeter`, `PassMeter`); operational code only calls named hooks, and `drain_table_payload` constructs its own meter so its signature and error handling are untouched.
- One pre-existing test call updated for the straggler-map argument to `collect_chunk_reports`; the three drain tests pass a stub `WireMeter`.
- Deliberate gaps, as follow-ups: the concurrent session-creation phase (potentially minutes before the first chunk) is unmetered, and sender-side per-peer attribution remains open — `table.wire` covers the wire half of the RCA's `table.upload` naming wart.
