### PR TITLE
fix(mosaic): use aws s3 irsa creds from env

### DIFF
--- a/bin/mosaic/src/main.rs
+++ b/bin/mosaic/src/main.rs
@@ -161,7 +161,12 @@ where
             virtual_hosted_style_request,
             ..
         } => {
-            let mut builder = AmazonS3Builder::new()
+            // from_env() is required for IRSA: since object_store 0.14, build() no
+            // longer reads AWS_* env vars itself. When config credentials are
+            // omitted, resolution falls through to web-identity → ECS task →
+            // EKS pod identity → instance profile. Explicit settings below
+            // override anything taken from the environment.
+            let mut builder = AmazonS3Builder::from_env()
                 .with_bucket_name(bucket)
                 .with_region(region)
                 .with_allow_http(*allow_http)
@@ -182,8 +187,6 @@ where
                 builder = builder.with_secret_access_key(secret_access_key);
             }
 
-            // When credentials are omitted the builder falls through to the
-            // AWS credential chain: IRSA web-identity → ECS task → instance profile.
             if let Some(endpoint) = endpoint {
                 builder = builder.with_endpoint(endpoint);
             }


### PR DESCRIPTION
## Description

After object_store version bump, AmazonS3Builder needs explicit from_env to use AWS_* credentials from environment

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] If this PR touches the wire-visible protocol surface — message types in `crates/cac/types`, garbler/evaluator STF semantics peers depend on in `crates/cac/protocol`, or net-svc framing/priorities — I bumped `PROTOCOL_VERSION` in `crates/net/svc-api/src/handshake.rs`.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
