### PR TITLE
feat(observability): peer-attribute garbling instrumentation for cross-node joins

### DIFF
--- a/bin/mosaic/src/main.rs
+++ b/bin/mosaic/src/main.rs
@@ -18,7 +18,6 @@ use config::{MosaicConfig, TableStoreBackend};
 use mimalloc::MiMalloc;
 use mosaic_cac_types::state_machine::{evaluator, garbler};
 // dependency to pass feature flag
-use mosaic_common as _;
 use mosaic_job_executors::MosaicExecutor;
 use mosaic_job_scheduler::JobScheduler;
 use mosaic_net_client::NetClient;
@@ -39,6 +38,12 @@ fn main() -> Result<()> {
     let config_path = config_path_from_args()?;
     let config = MosaicConfig::from_file(&config_path)?;
     init_tracing(&config.logging.filter)?;
+    // CaC variant for log analysis.
+    tracing::info!(
+        n_circuits = mosaic_common::constants::N_CIRCUITS,
+        n_open_circuits = mosaic_common::constants::N_OPEN_CIRCUITS,
+        "mosaic starting"
+    );
     config.validate()?;
 
     let _fdb_network = unsafe { foundationdb::boot() };

--- a/crates/job/api/src/lib.rs
+++ b/crates/job/api/src/lib.rs
@@ -37,9 +37,19 @@ mod hint;
 mod priority;
 mod submission;
 
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::{future::Future, pin::Pin, sync::Arc, time::Instant};
 
 pub use hint::{HintKey, HintKind};
+
+/// Short-id helper used to label progress logs. Renders the first 4 bytes
+/// of a digest as `0x........`. Truncates gracefully if shorter.
+pub fn short_id(digest: &[u8]) -> String {
+    let mut s = String::from("0x");
+    for b in digest.iter().take(4) {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
 
 /// Return type for [`SessionFactory::create_session`].
 ///
@@ -226,6 +236,26 @@ pub struct PendingCircuitJob {
     /// Critical withdrawal-dispute evaluation does not queue behind
     /// setup work.
     pub priority: Priority,
+    /// When this job last entered the queue: set at submission, reset by
+    /// the coordinator when a bounced job re-enters the backlog. Drives
+    /// the `queue_wait` field of pass-assignment log lines.
+    pub queued_at: Instant,
+    /// Times this job has bounced back to the backlog (eviction, transient
+    /// create failure, finish retry). 0 on first submission.
+    pub attempts: u32,
+}
+
+impl PendingCircuitJob {
+    /// Create a freshly submitted job (`queued_at` = now, `attempts` = 0).
+    pub fn new(peer_id: PeerId, action: CircuitAction, priority: Priority) -> Self {
+        Self {
+            peer_id,
+            action,
+            priority,
+            queued_at: Instant::now(),
+            attempts: 0,
+        }
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/crates/job/executors/src/circuit_sessions.rs
+++ b/crates/job/executors/src/circuit_sessions.rs
@@ -19,7 +19,10 @@
 use std::{
     future::Future,
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicIsize, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -48,10 +51,12 @@ use mosaic_cac_types::{
         },
     },
 };
+pub(crate) use mosaic_job_api::short_id;
 use mosaic_job_api::{
     ActionCompletion, CircuitError, CircuitSession, HandlerOutcome, OwnedBlock, OwnedChunk,
 };
 use mosaic_net_client::BulkSender;
+use mosaic_net_svc_api::PeerId;
 use mosaic_storage_api::table_store::TableReader;
 use mosaic_vs3::{Index, Scalar, Share};
 
@@ -59,16 +64,6 @@ use crate::{
     garbling::{GarblingSession, GarblingSetup, compute_commitment, hash_garbling_params},
     progress::{HEARTBEAT_PERIOD, HeartbeatTracker, ProgressUnit, StageBreakdown},
 };
-
-/// Short-id helper used to label progress logs. Renders the first 4 bytes
-/// of a digest as `0x........`. Truncates gracefully if shorter.
-pub(crate) fn short_id(digest: &[u8]) -> String {
-    let mut s = String::from("0x");
-    for b in digest.iter().take(4) {
-        s.push_str(&format!("{b:02x}"));
-    }
-    s
-}
 
 // ════════════════════════════════════════════════════════════════════════════
 // Gate parsing helpers for OwnedBlock
@@ -244,6 +239,7 @@ impl CommitmentSession {
     pub fn new(
         setup: GarblingSetup,
         output_wire_ids: Vec<u32>,
+        peer_id: &PeerId,
         index: Index,
         is_garbler: bool,
         total_gates: u64,
@@ -256,7 +252,7 @@ impl CommitmentSession {
         };
         let heartbeat = HeartbeatTracker::new(
             label,
-            format!("ckt{index}"),
+            format!("peer={} circuit_index={index}", short_id(peer_id.as_ref())),
             Some(total_gates),
             ProgressUnit::Blocks,
             HEARTBEAT_PERIOD,
@@ -453,24 +449,32 @@ struct WireMeter {
     heartbeat: HeartbeatTracker,
     stages: StageBreakdown,
     bytes: u64,
+    /// Live outbox occupancy, shared with the producer's [`UploadMeter`].
+    /// Decremented here on every buffer the drain takes off the queue, so
+    /// the producer's high-water mark reads true queue depth. Signed: the
+    /// two sides race with `Relaxed` ordering, so the count may transiently
+    /// dip below zero; the producer clamps when reading.
+    outbox_occupancy: Arc<AtomicIsize>,
 }
 
 impl WireMeter {
-    fn new(id: String, total_bytes: u64) -> Self {
+    fn new(ids: String, total_bytes: u64, outbox_occupancy: Arc<AtomicIsize>) -> Self {
         Self {
             heartbeat: HeartbeatTracker::new(
                 "table.wire",
-                id,
+                ids,
                 Some(total_bytes),
                 ProgressUnit::Bytes,
                 HEARTBEAT_PERIOD,
             ),
             stages: StageBreakdown::default(),
             bytes: 0,
+            outbox_occupancy,
         }
     }
 
     fn on_recv(&mut self, waited: Duration) {
+        self.outbox_occupancy.fetch_sub(1, Ordering::Relaxed);
         self.stages.feed_wait += waited;
     }
 
@@ -517,14 +521,23 @@ struct UploadMeter {
     /// Expected total ciphertext bytes (AND gates × 16); also the total for
     /// the drain's `table.wire` meter.
     total_bytes: u64,
+    /// Configured outbox depth, printed next to the high-water mark.
+    outbox_depth: usize,
+    /// Live outbox occupancy: incremented on enqueue here, decremented by
+    /// the drain's [`WireMeter::on_recv`]. `None` until the drain spawns.
+    outbox_occupancy: Option<Arc<AtomicIsize>>,
+    /// Highest occupancy observed, in buffers. Answers whether the
+    /// configured depth was actually used — `outbox_full` alone cannot
+    /// distinguish a near-full outbox from an empty one.
+    outbox_hwm: usize,
 }
 
 impl UploadMeter {
-    fn new(id: String, total_bytes: u64) -> Self {
+    fn new(ids: String, total_bytes: u64, outbox_depth: usize) -> Self {
         Self {
             heartbeat: HeartbeatTracker::new(
                 "table.upload",
-                id,
+                ids,
                 Some(total_bytes),
                 ProgressUnit::Bytes,
                 HEARTBEAT_PERIOD,
@@ -533,7 +546,16 @@ impl UploadMeter {
             bytes_enqueued: 0,
             send_parked_since: None,
             total_bytes,
+            outbox_depth,
+            outbox_occupancy: None,
+            outbox_hwm: 0,
         }
+    }
+
+    /// Wire up the occupancy counter shared with the drain. Called when the
+    /// drain spawns (first non-empty block).
+    fn attach_outbox(&mut self, occupancy: Arc<AtomicIsize>) {
+        self.outbox_occupancy = Some(occupancy);
     }
 
     /// Time a synchronous garbling step into `compute`.
@@ -560,6 +582,12 @@ impl UploadMeter {
         }
         if res.is_ok() {
             self.bytes_enqueued = self.bytes_enqueued.saturating_add(n);
+            if let Some(occupancy) = &self.outbox_occupancy {
+                // One Relaxed RMW per ~346 KiB block; the clamp covers the
+                // benign race with the drain's decrement.
+                let now = occupancy.fetch_add(1, Ordering::Relaxed) + 1;
+                self.outbox_hwm = self.outbox_hwm.max(now.max(0) as usize);
+            }
         }
         res
     }
@@ -572,17 +600,31 @@ impl UploadMeter {
 
     /// Emit the final attribution line, first reconciling any parked
     /// interval left behind by a chunk future dropped mid-`send`.
+    ///
+    /// The outbox high-water mark is formatted here, once — the per-chunk
+    /// path only tracks the integer.
     fn summary(&mut self) {
         if let Some(parked) = self.send_parked_since.take() {
             self.stages.outbox_full += parked.elapsed();
+        }
+        if self.outbox_occupancy.is_some() {
+            self.heartbeat.set_extra(format!(
+                "outbox_hwm={}/{}",
+                self.outbox_hwm, self.outbox_depth
+            ));
         }
         self.heartbeat
             .done_staged(self.bytes_enqueued, &self.stages);
     }
 
-    /// Mint the drain-side wire meter for this transfer.
-    fn mint_wire_meter(&self, id: String) -> WireMeter {
-        WireMeter::new(id, self.total_bytes)
+    /// Mint the drain-side wire meter for this transfer, sharing the
+    /// producer's identity string and occupancy counter.
+    fn mint_wire_meter(&self, occupancy: Arc<AtomicIsize>) -> WireMeter {
+        WireMeter::new(
+            self.heartbeat.ids().to_string(),
+            self.total_bytes,
+            occupancy,
+        )
     }
 }
 
@@ -707,9 +749,12 @@ impl TransferSession {
     /// `stream` is an open bulk transfer stream to the evaluator.
     /// `outbox_depth` sets the capacity of the bounded outbox, in garbled
     /// chunks.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         session: GarblingSession,
         stream: BulkSender,
+        peer_id: &PeerId,
+        circuit_index: Index,
         seed: GarblingSeed,
         commitment: GarblingTableCommitment,
         output_wire_ids: Vec<u32>,
@@ -718,7 +763,14 @@ impl TransferSession {
     ) -> Self {
         // Each AND gate emits 16 ciphertext bytes on the wire.
         let total_bytes = total_and_gates.saturating_mul(16);
-        let meter = UploadMeter::new(short_id(commitment.as_ref()), total_bytes);
+        let meter = UploadMeter::new(
+            format!(
+                "peer={} circuit_index={circuit_index}",
+                short_id(peer_id.as_ref())
+            ),
+            total_bytes,
+            outbox_depth,
+        );
         Self {
             session,
             stream: Some(stream),
@@ -750,9 +802,9 @@ impl TransferSession {
         let (recycle_tx, recycle_rx) = mpsc_light::bounded::<Vec<u8>>(self.outbox_depth);
         let (done_tx, done_rx) = oneshot::oneshot();
         let (abort_tx, abort_rx) = oneshot::oneshot();
-        let meter = self
-            .meter
-            .mint_wire_meter(short_id(self.commitment.as_ref()));
+        let occupancy = Arc::new(AtomicIsize::new(0));
+        self.meter.attach_outbox(Arc::clone(&occupancy));
+        let meter = self.meter.mint_wire_meter(occupancy);
 
         let drain = async move {
             let result = drain_transfer_outbox(
@@ -1013,9 +1065,11 @@ impl EvaluationSession {
     ///
     /// All setup (share interpolation, label translation, instance creation,
     /// table reader opening) is done by the caller before constructing this.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         instance: ckt_gobble::EvaluationInstance,
         ct_reader: Box<dyn DynCiphertextReader>,
+        peer_id: &PeerId,
         index: Index,
         commitment: GarblingTableCommitment,
         output_wire_ids: Vec<u32>,
@@ -1024,7 +1078,7 @@ impl EvaluationSession {
     ) -> Self {
         let heartbeat = HeartbeatTracker::new(
             "table.eval",
-            short_id(commitment.as_ref()),
+            format!("peer={} circuit_index={index}", short_id(peer_id.as_ref())),
             Some(total_gates),
             ProgressUnit::Blocks,
             HEARTBEAT_PERIOD,
@@ -1272,7 +1326,7 @@ mod tests {
                 recycle_tx,
                 abort_rx,
                 Duration::from_secs(1),
-                WireMeter::new("0xtest".to_string(), 0),
+                WireMeter::new("0xtest".to_string(), 0, Arc::new(AtomicIsize::new(0))),
             ))
         })
         .join()
@@ -1309,7 +1363,7 @@ mod tests {
                 recycle_tx,
                 abort_rx,
                 Duration::from_millis(10),
-                WireMeter::new("0xtest".to_string(), 0),
+                WireMeter::new("0xtest".to_string(), 0, Arc::new(AtomicIsize::new(0))),
             ))
         })
         .join()
@@ -1348,7 +1402,7 @@ mod tests {
                 recycle_tx,
                 abort_rx,
                 Duration::from_secs(60),
-                WireMeter::new("0xtest".to_string(), 0),
+                WireMeter::new("0xtest".to_string(), 0, Arc::new(AtomicIsize::new(0))),
             ))
         });
 

--- a/crates/job/executors/src/evaluator.rs
+++ b/crates/job/executors/src/evaluator.rs
@@ -322,12 +322,12 @@ struct ReceiveMeter {
 }
 
 impl ReceiveMeter {
-    fn new(peer_id: &PeerId) -> Self {
+    fn new(peer_id: &PeerId, index: Index, total_bytes: u64) -> Self {
         Self {
             heartbeat: HeartbeatTracker::new(
                 "table.receive",
-                short_id(peer_id.as_ref()),
-                None,
+                format!("peer={} circuit_index={index}", short_id(peer_id.as_ref())),
+                Some(total_bytes),
                 ProgressUnit::Bytes,
                 HEARTBEAT_PERIOD,
             ),
@@ -384,7 +384,9 @@ where
     S: PayloadStream,
     W: mosaic_storage_api::table_store::TableWriter,
 {
-    let mut meter = ReceiveMeter::new(peer_id);
+    // The stream carries translation bytes first, then ciphertext.
+    let total_bytes = (translation_size + expected_ciphertext_bytes) as u64;
+    let mut meter = ReceiveMeter::new(peer_id, index, total_bytes);
     let outcome = drain_table_payload_inner(
         stream,
         writer,
@@ -1341,6 +1343,7 @@ pub(crate) async fn setup_evaluation_session<SP: StorageProvider, TS: TableStore
     Ok(EvaluationSession::new(
         instance,
         ct_reader,
+        peer_id,
         index,
         commitment,
         outputs,

--- a/crates/job/executors/src/garbler.rs
+++ b/crates/job/executors/src/garbler.rs
@@ -682,7 +682,7 @@ pub(crate) async fn setup_transfer_session<SP: StorageProvider, TS: TableStore>(
     pin_mut!(delay);
     let hint_delivered = matches!(select(send, delay).await, Either::Left((Ok(()), _)));
     if !hint_delivered {
-        tracing::debug!(peer = ?peer_id, "scheduler hint send failed or timed out; proceeding");
+        tracing::debug!(peer = %peer_id, "scheduler hint send failed or timed out; proceeding");
     }
     // Small gap between the hint and the bulk open so the peer's scheduler
     // has a chance to promote before the bulk stream lands on their net-svc.
@@ -735,6 +735,8 @@ pub(crate) async fn setup_transfer_session<SP: StorageProvider, TS: TableStore>(
     Ok(TransferSession::new(
         setup.session,
         stream,
+        peer_id,
+        circuit_index,
         seed,
         commitment,
         outputs,

--- a/crates/job/executors/src/lib.rs
+++ b/crates/job/executors/src/lib.rs
@@ -271,6 +271,7 @@ impl<SP: StorageProvider, TS: TableStore> ExecuteGarblerJob for MosaicExecutor<S
                 Box::new(circuit_sessions::CommitmentSession::new(
                     setup,
                     outputs,
+                    &peer_id,
                     index,
                     true,
                     header.total_gates(),
@@ -409,6 +410,7 @@ impl<SP: StorageProvider, TS: TableStore> ExecuteEvaluatorJob for MosaicExecutor
                 Box::new(circuit_sessions::CommitmentSession::new(
                     setup,
                     outputs,
+                    &peer_id,
                     index,
                     false,
                     header.total_gates(),

--- a/crates/job/executors/src/progress.rs
+++ b/crates/job/executors/src/progress.rs
@@ -90,7 +90,12 @@ impl StageBreakdown {
 #[derive(Debug)]
 pub struct HeartbeatTracker {
     label: &'static str,
-    short_id: String,
+    /// Pre-formatted identity fields, e.g. `"peer=0x1a2b3c4d circuit_index=5"`.
+    /// Built once at phase start; printed verbatim on every line.
+    ids: String,
+    /// Optional pre-formatted trailing fields (e.g. `"outbox_hwm=12/256"`).
+    /// Set via [`set_extra`](Self::set_extra); appended after the stages.
+    extra: String,
     total: Option<u64>,
     unit: ProgressUnit,
     started_at: Instant,
@@ -103,14 +108,15 @@ impl HeartbeatTracker {
     /// Create a new tracker.
     ///
     /// `label` is the phase name printed in the log (e.g. `"table.upload"`).
-    /// `short_id` is a stable identifier the caller chose for this work item
-    /// (e.g. a commitment short-hash, or a circuit index).
+    /// `ids` is a pre-formatted `key=value` identity string for this work
+    /// item; use full field names (`peer=`, `circuit_index=`,
+    /// `commitment=`) so lines are joinable across phases and nodes.
     /// `total` is the expected final count if known; `None` suppresses
     /// percent/ETA in the output. `period` is the minimum interval between
     /// emissions; pass [`HEARTBEAT_PERIOD`] for the default.
     pub fn new(
         label: &'static str,
-        short_id: String,
+        ids: String,
         total: Option<u64>,
         unit: ProgressUnit,
         period: Duration,
@@ -118,7 +124,8 @@ impl HeartbeatTracker {
         let now = Instant::now();
         Self {
             label,
-            short_id,
+            ids,
+            extra: String::new(),
             total,
             unit,
             started_at: now,
@@ -126,6 +133,18 @@ impl HeartbeatTracker {
             last_log_progress: 0,
             period,
         }
+    }
+
+    /// The identity string this tracker prints on every line.
+    pub fn ids(&self) -> &str {
+        &self.ids
+    }
+
+    /// Set trailing `key=value` fields appended to subsequent lines. Callers
+    /// should format lazily — ideally once, right before a summary — so the
+    /// per-chunk path stays formatting-free.
+    pub fn set_extra(&mut self, extra: String) {
+        self.extra = extra;
     }
 
     /// If [`HEARTBEAT_PERIOD`] has elapsed since the last log (or since
@@ -174,6 +193,11 @@ impl HeartbeatTracker {
 
         let event_label = if is_final { "summary" } else { "progress" };
         let stage_str = stages.fmt_nonzero(elapsed);
+        let extra_str = if self.extra.is_empty() {
+            String::new()
+        } else {
+            format!(" {}", self.extra)
+        };
 
         match self.unit {
             ProgressUnit::Bytes => {
@@ -192,11 +216,10 @@ impl HeartbeatTracker {
                 tracing::info!(
                     target: "mosaic_progress",
                     phase = self.label,
-                    id = %self.short_id,
-                    "{} {} id={} done={}{} inst={}/s avg={}/s elapsed={}{}{}",
+                    "{} {} {} done={}{} inst={}/s avg={}/s elapsed={}{}{}{}",
                     self.label,
                     event_label,
-                    self.short_id,
+                    self.ids,
                     done_str,
                     pct_str,
                     fmt_rate(inst_rate),
@@ -204,6 +227,7 @@ impl HeartbeatTracker {
                     fmt_duration(elapsed),
                     eta_str,
                     stage_str,
+                    extra_str,
                 );
             }
             ProgressUnit::Blocks => {
@@ -214,14 +238,14 @@ impl HeartbeatTracker {
                 tracing::info!(
                     target: "mosaic_progress",
                     phase = self.label,
-                    id = %self.short_id,
-                    "{} {} id={}{} elapsed={}{}",
+                    "{} {} {}{} elapsed={}{}{}",
                     self.label,
                     event_label,
-                    self.short_id,
+                    self.ids,
                     pct_str,
                     fmt_duration(elapsed),
                     stage_str,
+                    extra_str,
                 );
             }
         }

--- a/crates/job/scheduler/src/garbling/mod.rs
+++ b/crates/job/scheduler/src/garbling/mod.rs
@@ -61,7 +61,7 @@ use std::{
 use ckt_fmtv5_types::v5::c::{Block, ReaderV5c, get_block_num_gates};
 use mosaic_job_api::{
     CircuitAction, CircuitError, CircuitSession, HandlerOutcome, JobCompletion, OwnedBlock,
-    OwnedChunk, PendingCircuitJob, SessionFactory,
+    OwnedChunk, PendingCircuitJob, SessionFactory, short_id,
 };
 use mosaic_net_svc_api::PeerId;
 use tracing::Instrument;
@@ -191,7 +191,12 @@ struct ActiveSession {
 /// Commands sent from the main coordinator thread to worker threads.
 enum WorkerCommand {
     /// Assign sessions for the upcoming pass. Replaces any previous sessions.
-    AssignSessions(Vec<ActiveSession>),
+    AssignSessions {
+        /// Coordinator-wide pass sequence number, echoed in worker logs so
+        /// strike/eviction warns join the pass's `circuit.pass` lines.
+        pass: u64,
+        sessions: Vec<ActiveSession>,
+    },
     /// Process this chunk for all assigned sessions.
     ProcessChunk(Arc<OwnedChunk>),
     /// All blocks processed — finalize sessions and report completions.
@@ -214,6 +219,11 @@ struct ChunkReport {
     evicted_jobs: Vec<PendingCircuitJob>,
     /// Jobs whose sessions remain active on this worker after the chunk.
     remaining_jobs: Vec<PendingCircuitJob>,
+    /// Wall-clock each session spent in `process_chunk` for this chunk
+    /// (including just-evicted sessions). The coordinator accumulates these
+    /// per peer to name the pass straggler; deltas — not cumulative totals —
+    /// so nothing is lost when a session is evicted mid-pass.
+    peer_busy: Vec<(PeerId, Duration)>,
 }
 
 /// Sent after finalizing all sessions at end of pass.
@@ -471,6 +481,11 @@ async fn coordinator_loop(
         // full retry set starve new submissions indefinitely.
         let mut backlog: VecDeque<PendingCircuitJob> = VecDeque::new();
 
+        // Monotonic pass counter. Included in every pass-scoped log line
+        // (`circuit.pass`, strike/eviction warns) so within-node joins are
+        // exact rather than timestamp-based.
+        let mut pass_seq: u64 = 0;
+
         loop {
             // ── 1. Collect a batch of jobs ───────────────────────────────
             let Some(jobs) = collect_batch(
@@ -513,8 +528,10 @@ async fn coordinator_loop(
 
             // ── 3. Run the pass ──────────────────────────────────────────
             let session_count = sessions.len();
+            pass_seq += 1;
             run_pass(
                 &config,
+                pass_seq,
                 sessions,
                 &mut workers,
                 &completion_tx,
@@ -523,6 +540,7 @@ async fn coordinator_loop(
             )
             .instrument(tracing::info_span!(
                 "job_scheduler.garbling_pass",
+                pass = pass_seq,
                 sessions = session_count
             ))
             .await;
@@ -559,6 +577,7 @@ async fn coordinator_loop(
 /// Surviving sessions are finalized by workers; completions go to the SM.
 async fn run_pass(
     config: &GarblingConfig,
+    pass_seq: u64,
     sessions: Vec<ActiveSession>,
     workers: &mut [WorkerHandle],
     completion_tx: &kanal::AsyncSender<JobCompletion>,
@@ -589,16 +608,18 @@ async fn run_pass(
     let mut active_jobs_by_worker: HashMap<usize, Vec<PendingCircuitJob>> = HashMap::new();
     for (wid, assignment) in assignments.into_iter().enumerate() {
         if !assignment.is_empty() {
-            let count = assignment.len();
             let tracked_jobs: Vec<PendingCircuitJob> =
                 assignment.iter().map(|active| active.job.clone()).collect();
             if workers[wid]
-                .send(WorkerCommand::AssignSessions(assignment))
+                .send(WorkerCommand::AssignSessions {
+                    pass: pass_seq,
+                    sessions: assignment,
+                })
                 .await
             {
                 active_worker_ids.push(wid);
+                log_pass_assignment(pass_seq, class_label, wid, &tracked_jobs);
                 active_jobs_by_worker.insert(wid, tracked_jobs);
-                tracing::debug!(worker = wid, sessions = count, "assigned sessions");
             } else {
                 tracing::error!(worker = wid, "failed to assign sessions — worker dead");
                 pending_retry.extend(tracked_jobs);
@@ -652,7 +673,7 @@ async fn run_pass(
     // The meter therefore also tracks each side's per-chunk *excess* over
     // the other — the additive numbers that name what actually set the pace
     // (see [`PassMeter`] for the busy-vs-gated reading).
-    let mut meter = PassMeter::new(class_label, session_count);
+    let mut meter = PassMeter::new(pass_seq, class_label, session_count);
 
     // ── Read blocks and broadcast to workers (pipelined) ─────────────
     //
@@ -692,7 +713,7 @@ async fn run_pass(
                 workers,
                 report_timeout,
                 pending_retry,
-                &mut meter.worker_wait,
+                &mut meter.peer_busy,
             )
             .await;
             (still_active, started.elapsed())
@@ -729,6 +750,49 @@ async fn run_pass(
 /// Minimum interval between pass-level progress lines.
 const PASS_PROGRESS_PERIOD: Duration = Duration::from_secs(30);
 
+/// Log one `circuit.pass assign` line per session at pass start: the pass's
+/// composition (who shares the batch with whom, on which worker), each job's
+/// bounce count and how long it waited in the queue. Runs once per pass, off
+/// the chunk path.
+fn log_pass_assignment(pass_seq: u64, class: &str, worker: usize, jobs: &[PendingCircuitJob]) {
+    for job in jobs {
+        tracing::info!(
+            target: "mosaic_progress",
+            phase = "circuit.pass",
+            "circuit.pass assign pass={} class={} worker={} peer={} {} attempts={} queue_wait={}s",
+            pass_seq,
+            class,
+            worker,
+            short_id(job.peer_id.as_ref()),
+            action_log_fields(&job.action),
+            job.attempts,
+            job.queued_at.elapsed().as_secs(),
+        );
+    }
+}
+
+/// Render a [`CircuitAction`]'s identity as `key=value` log fields.
+///
+/// `(peer, circuit_index)` identifies a table, so assignment lines join
+/// against the executor-side meters on those two alone. Garbling seeds are
+/// protocol secrets and never appear here, not even shortened — a
+/// transfer's `circuit_index` lands moments later on its `table.upload`
+/// line.
+fn action_log_fields(action: &CircuitAction) -> String {
+    match action {
+        CircuitAction::GarblerCommitment { index, .. } => {
+            format!("action=garbler_commitment circuit_index={index}")
+        }
+        CircuitAction::GarblerTransfer { .. } => "action=garbler_transfer".to_string(),
+        CircuitAction::EvaluatorCommitment { index, .. } => {
+            format!("action=evaluator_commitment circuit_index={index}")
+        }
+        CircuitAction::EvaluatorEvaluation { index, .. } => {
+            format!("action=evaluator_evaluation circuit_index={index}")
+        }
+    }
+}
+
 /// Pass-level wall-clock attribution across the pipelined read/barrier loop,
 /// logged as `circuit.pass` on the `mosaic_progress` target.
 ///
@@ -741,8 +805,11 @@ const PASS_PROGRESS_PERIOD: Duration = Duration::from_secs(30);
 /// *utilization*: each side's raw busy time, overlapped under pipelining
 /// (together they can approach 200% of elapsed) — they say how loaded each
 /// side already is, i.e. the floor you hit after fixing the current gate.
-/// `straggler` names the worker that most often kept the barrier waiting.
+/// `straggler_peer` names the peer whose session accumulated the most
+/// busy time processing chunks — the session that held the barrier longest.
 struct PassMeter {
+    /// Coordinator-wide pass sequence number.
+    pass: u64,
     /// Session class this pass serves (passes are class-homogeneous).
     class: &'static str,
     sessions: usize,
@@ -753,15 +820,18 @@ struct PassMeter {
     barrier_busy: Duration,
     read_gated: Duration,
     barrier_gated: Duration,
-    /// Cumulative in-order report wait per worker (see
-    /// [`collect_chunk_reports`]).
-    worker_wait: HashMap<usize, Duration>,
+    /// Cumulative per-peer busy time in `process_chunk`, accumulated from
+    /// worker [`ChunkReport`]s (see [`collect_chunk_reports`]). Measured
+    /// inside the worker per session, so it is free of the coordinator's
+    /// in-order report-collection skew.
+    peer_busy: HashMap<PeerId, Duration>,
 }
 
 impl PassMeter {
-    fn new(class: &'static str, sessions: usize) -> Self {
+    fn new(pass: u64, class: &'static str, sessions: usize) -> Self {
         let now = Instant::now();
         Self {
+            pass,
             class,
             sessions,
             started: now,
@@ -771,7 +841,7 @@ impl PassMeter {
             barrier_busy: Duration::ZERO,
             read_gated: Duration::ZERO,
             barrier_gated: Duration::ZERO,
-            worker_wait: HashMap::new(),
+            peer_busy: HashMap::new(),
         }
     }
 
@@ -819,19 +889,26 @@ impl PassMeter {
         let pct = |d: Duration| d.as_secs_f64() * 100.0 / secs;
 
         let straggler = self
-            .worker_wait
+            .peer_busy
             .iter()
             .max_by_key(|(_, d)| **d)
-            .map(|(wid, d)| format!(" straggler=worker{}({:.0}s)", wid, d.as_secs_f64()))
+            .map(|(peer_id, d)| {
+                format!(
+                    " straggler_peer={}({:.0}s)",
+                    short_id(peer_id.as_ref()),
+                    d.as_secs_f64()
+                )
+            })
             .unwrap_or_default();
 
         tracing::info!(
             target: "mosaic_progress",
             phase = "circuit.pass",
-            "circuit.pass {} class={} sessions={} read={:.1}GiB avg={:.1}MB/s elapsed={:.0}s \
+            "circuit.pass {} pass={} class={} sessions={} read={:.1}GiB avg={:.1}MB/s elapsed={:.0}s \
              read_gated={:.0}s({:.0}%) barrier_gated={:.0}s({:.0}%) \
              read_busy={:.0}s({:.0}%) barrier_busy={:.0}s({:.0}%){}",
             event,
+            self.pass,
             self.class,
             self.sessions,
             self.bytes_read as f64 / (1024.0 * 1024.0 * 1024.0),
@@ -860,20 +937,19 @@ async fn collect_chunk_reports(
     workers: &mut [WorkerHandle],
     report_timeout: Duration,
     pending_retry: &mut Vec<PendingCircuitJob>,
-    worker_wait: &mut HashMap<usize, Duration>,
+    peer_busy: &mut HashMap<PeerId, Duration>,
 ) -> Vec<usize> {
     let mut still_active: Vec<usize> = Vec::with_capacity(active_worker_ids.len());
 
     for &wid in active_worker_ids {
-        // Reports are awaited in order, so this is not a clean per-worker
-        // service time — a worker that finished while we waited on an earlier
-        // one records ~0. Accumulated across the pass it still identifies the
-        // worker that repeatedly makes the barrier wait, i.e. the straggler.
-        let wait_started = Instant::now();
         let report = workers[wid].recv_report(report_timeout).await;
-        *worker_wait.entry(wid).or_default() += wait_started.elapsed();
         match report {
             Some(WorkerReport::ChunkDone(report)) => {
+                // Workers measure each session's chunk busy time in place,
+                // so this attribution has no report-ordering skew.
+                for (peer_id, busy) in report.peer_busy {
+                    *peer_busy.entry(peer_id).or_default() += busy;
+                }
                 pending_retry.extend(report.evicted_jobs);
                 if report.remaining_jobs.is_empty() {
                     active_jobs_by_worker.remove(&wid);
@@ -1135,7 +1211,13 @@ fn requeue_bounced(
     while let Ok(Some(job)) = submit_rx.try_recv() {
         backlog.push_back(job);
     }
-    backlog.extend(bounced.drain(..));
+    backlog.extend(bounced.drain(..).map(|mut job| {
+        // Each bounce is a fresh queue stint: `queue_wait` on the next
+        // assignment line measures this stint, `attempts` counts the bounces.
+        job.attempts += 1;
+        job.queued_at = Instant::now();
+        job
+    }));
 }
 
 /// Create live sessions for a batch, concurrently.
@@ -1168,11 +1250,7 @@ async fn create_sessions(
             Ok(session) => {
                 sessions.push(ActiveSession {
                     peer_id: job.peer_id,
-                    job: PendingCircuitJob {
-                        peer_id: job.peer_id,
-                        action: job.action.clone(),
-                        priority: job.priority,
-                    },
+                    job,
                     session,
                 });
             }
@@ -1184,7 +1262,7 @@ async fn create_sessions(
                 // — drop the job. No completion is sent: the SM treats
                 // these completions as informational and has moved on.
                 tracing::info!(
-                    peer = ?job.peer_id,
+                    peer = %job.peer_id,
                     action = ?job.action,
                     "action no longer required per state machine — dropping job"
                 );
@@ -1192,7 +1270,7 @@ async fn create_sessions(
             Err(CircuitError::StorageUnavailable) => {
                 // Transient — data not yet written by STF. Keep for retry.
                 tracing::debug!(
-                    peer = ?job.peer_id,
+                    peer = %job.peer_id,
                     action = ?job.action,
                     "session storage unavailable — will retry next pass"
                 );
@@ -1201,7 +1279,7 @@ async fn create_sessions(
             Err(CircuitError::TransientFailure(reason)) => {
                 // Transient — e.g. peer not ready for bulk stream. Keep for retry.
                 tracing::debug!(
-                    peer = ?job.peer_id,
+                    peer = %job.peer_id,
                     action = ?job.action,
                     reason,
                     "transient setup failure — will retry next pass"
@@ -1213,7 +1291,7 @@ async fn create_sessions(
                 // This is a programming error — the action cannot be retried.
                 tracing::error!(
                     ?e,
-                    peer = ?job.peer_id,
+                    peer = %job.peer_id,
                     action = ?job.action,
                     "permanent session creation failure — action dropped"
                 );
@@ -1262,17 +1340,23 @@ async fn create_sessions(
 /// extend the budget *without* cancelling.
 async fn process_chunk_on_sessions(
     worker_id: usize,
+    pass: u64,
     sessions: &mut [ActiveSession],
     chunk: &Arc<OwnedChunk>,
     chunk_timeout: Duration,
     stall_strikes: u32,
-) -> Vec<usize> {
+) -> (Vec<usize>, Vec<(PeerId, Duration)>) {
     let stall_strikes = stall_strikes.max(1);
     let results =
         futures::future::join_all(sessions.iter_mut().enumerate().map(|(index, active)| {
             let peer_id = active.peer_id;
             let session = &mut active.session;
             async move {
+                // Wall-clock until this session's future completes,
+                // measured from the shared chunk start. The slowest
+                // session's time is what held the barrier; two `Instant`
+                // reads per session per ~4 MiB chunk is noise.
+                let started = Instant::now();
                 let mut fut = session.process_chunk(chunk);
                 let mut strikes = 0u32;
                 let result = loop {
@@ -1287,7 +1371,8 @@ async fn process_chunk_on_sessions(
                             }
                             tracing::warn!(
                                 worker = worker_id,
-                                peer = ?peer_id,
+                                pass,
+                                peer = %peer_id,
                                 strikes,
                                 budget = stall_strikes,
                                 timeout_ms = chunk_timeout.as_millis(),
@@ -1296,20 +1381,23 @@ async fn process_chunk_on_sessions(
                         }
                     }
                 };
-                (index, peer_id, result)
+                (index, peer_id, result, started.elapsed())
             }
         }))
         .await;
 
     let mut evicted_indices = Vec::new();
-    for (index, peer_id, result) in results {
+    let mut peer_busy = Vec::with_capacity(results.len());
+    for (index, peer_id, result, busy) in results {
+        peer_busy.push((peer_id, busy));
         match result {
             Some(Ok(())) => { /* session keeping up */ }
             Some(Err(e)) => {
                 tracing::warn!(
                     worker = worker_id,
+                    pass,
                     ?e,
-                    peer = ?peer_id,
+                    peer = %peer_id,
                     "session error — evicting for retry"
                 );
                 evicted_indices.push(index);
@@ -1317,7 +1405,8 @@ async fn process_chunk_on_sessions(
             None => {
                 tracing::warn!(
                     worker = worker_id,
-                    peer = ?peer_id,
+                    pass,
+                    peer = %peer_id,
                     strikes = stall_strikes,
                     "session exhausted its stall budget on one chunk — evicting for retry"
                 );
@@ -1330,7 +1419,7 @@ async fn process_chunk_on_sessions(
     // do; sorting keeps that invariant local rather than resting on the
     // ordering guarantees of a dependency.
     evicted_indices.sort_unstable();
-    evicted_indices
+    (evicted_indices, peer_busy)
 }
 
 /// Finalize a worker's sessions concurrently, splitting the outcomes into
@@ -1418,6 +1507,7 @@ async fn worker_loop(
         );
 
         let mut sessions: Vec<ActiveSession> = Vec::new();
+        let mut current_pass: u64 = 0;
 
         loop {
             let command = match command_rx.recv().await {
@@ -1426,18 +1516,24 @@ async fn worker_loop(
             };
 
             match command {
-                WorkerCommand::AssignSessions(new_sessions) => {
+                WorkerCommand::AssignSessions {
+                    pass,
+                    sessions: new_sessions,
+                } => {
                     tracing::debug!(
                         worker = id,
+                        pass,
                         count = new_sessions.len(),
                         "received session assignment"
                     );
                     sessions = new_sessions;
+                    current_pass = pass;
                 }
 
                 WorkerCommand::ProcessChunk(chunk) => {
-                    let evicted_indices = process_chunk_on_sessions(
+                    let (evicted_indices, peer_busy) = process_chunk_on_sessions(
                         id,
+                        current_pass,
                         &mut sessions,
                         &chunk,
                         chunk_timeout,
@@ -1457,6 +1553,7 @@ async fn worker_loop(
                     let report = WorkerReport::ChunkDone(ChunkReport {
                         evicted_jobs,
                         remaining_jobs: sessions.iter().map(|active| active.job.clone()).collect(),
+                        peer_busy,
                     });
                     if report_tx.send(report).await.is_err() {
                         tracing::error!(worker = id, "report channel closed — exiting");
@@ -1641,13 +1738,13 @@ mod tests {
     }
 
     fn sample_job_with_priority(peer_byte: u8, priority: Priority) -> PendingCircuitJob {
-        PendingCircuitJob {
-            peer_id: PeerId::from([peer_byte; 32]),
-            action: CircuitAction::GarblerTransfer {
+        PendingCircuitJob::new(
+            PeerId::from([peer_byte; 32]),
+            CircuitAction::GarblerTransfer {
                 seed: GarblingSeed::from([peer_byte; 32]),
             },
             priority,
-        }
+        )
     }
 
     fn sample_completion(peer_id: PeerId) -> JobCompletion {
@@ -1697,6 +1794,7 @@ mod tests {
                     chunk_timeout: Duration::from_millis(1),
                     chunk_stall_strikes: 1,
                 },
+                1,
                 sessions,
                 &mut workers,
                 &completion_tx,
@@ -1861,13 +1959,13 @@ mod tests {
             }];
             let mut active_jobs_by_worker = HashMap::from([(
                 0usize,
-                vec![PendingCircuitJob {
+                vec![PendingCircuitJob::new(
                     peer_id,
-                    action: CircuitAction::GarblerTransfer {
+                    CircuitAction::GarblerTransfer {
                         seed: GarblingSeed::from([5; 32]),
                     },
-                    priority: Priority::Normal,
-                }],
+                    Priority::Normal,
+                )],
             )]);
             let mut pending_retry = Vec::new();
 
@@ -2023,8 +2121,9 @@ mod tests {
                 .map(|i| active_session(i, probe(&active, &peak)))
                 .collect();
 
-            let evicted = process_chunk_on_sessions(
+            let (evicted, _peer_busy) = process_chunk_on_sessions(
                 0,
+                1,
                 &mut sessions,
                 &empty_chunk(),
                 Duration::from_secs(5),
@@ -2057,8 +2156,9 @@ mod tests {
             ];
 
             let started = std::time::Instant::now();
-            let evicted =
-                process_chunk_on_sessions(0, &mut sessions, &empty_chunk(), CHUNK_TIMEOUT, 1).await;
+            let (evicted, _peer_busy) =
+                process_chunk_on_sessions(0, 1, &mut sessions, &empty_chunk(), CHUNK_TIMEOUT, 1)
+                    .await;
             let elapsed = started.elapsed();
 
             assert_eq!(evicted, vec![1, 3], "only the stalled sessions are evicted");
@@ -2176,14 +2276,14 @@ mod tests {
     }
 
     fn sample_compute_job(peer_byte: u8) -> PendingCircuitJob {
-        PendingCircuitJob {
-            peer_id: PeerId::from([peer_byte; 32]),
-            action: CircuitAction::GarblerCommitment {
+        PendingCircuitJob::new(
+            PeerId::from([peer_byte; 32]),
+            CircuitAction::GarblerCommitment {
                 index: Index::new(1).expect("valid index"),
                 seed: GarblingSeed::from([peer_byte; 32]),
             },
-            priority: Priority::Normal,
-        }
+            Priority::Normal,
+        )
     }
 
     #[test]
@@ -2508,8 +2608,9 @@ mod tests {
                 let _ = ready_tx.to_sync().send(());
             });
 
-            let evicted = process_chunk_on_sessions(
+            let (evicted, _peer_busy) = process_chunk_on_sessions(
                 0,
+                1,
                 &mut sessions,
                 &empty_chunk(),
                 Duration::from_millis(100),
@@ -2538,8 +2639,9 @@ mod tests {
         run_monoio(async {
             let mut sessions = vec![active_session(0, Box::new(StalledSession))];
             let started = std::time::Instant::now();
-            let evicted = process_chunk_on_sessions(
+            let (evicted, _peer_busy) = process_chunk_on_sessions(
                 0,
+                1,
                 &mut sessions,
                 &empty_chunk(),
                 Duration::from_millis(100),
@@ -2567,8 +2669,9 @@ mod tests {
                 active_session(3, Box::new(FailingSession)),
             ];
 
-            let evicted = process_chunk_on_sessions(
+            let (evicted, _peer_busy) = process_chunk_on_sessions(
                 0,
+                1,
                 &mut sessions,
                 &empty_chunk(),
                 Duration::from_secs(5),

--- a/crates/job/scheduler/src/pool/mod.rs
+++ b/crates/job/scheduler/src/pool/mod.rs
@@ -98,6 +98,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobThreadPool<D> {
     /// Spawns worker threads immediately. Each worker runs its own monoio
     /// runtime and pulls jobs from the shared queue.
     pub(crate) fn new(
+        name: &'static str,
         config: PoolConfig,
         dispatcher: Arc<D>,
         completion_tx: kanal::AsyncSender<JobCompletion>,
@@ -111,6 +112,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobThreadPool<D> {
         let workers: Vec<Worker<D>> = (0..config.threads)
             .map(|id| {
                 Worker::spawn(
+                    name,
                     id,
                     Arc::clone(&dispatcher),
                     Arc::clone(&queue),

--- a/crates/job/scheduler/src/pool/worker.rs
+++ b/crates/job/scheduler/src/pool/worker.rs
@@ -17,7 +17,7 @@
 use std::{
     panic::{AssertUnwindSafe, catch_unwind},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use mosaic_cac_types::state_machine::{
@@ -37,6 +37,13 @@ const RETRY_BACKOFF_BASE: Duration = Duration::from_millis(100);
 /// Maximum backoff delay. Caps the exponential growth so a persistently
 /// failing job doesn't wait unreasonably long between attempts.
 const RETRY_BACKOFF_MAX: Duration = Duration::from_secs(10);
+
+/// Permit wait beyond which the pool counts as saturated and worth a warn
+/// (provided jobs are actually queued behind the busy slots).
+const SLOT_WAIT_WARN_THRESHOLD: Duration = Duration::from_secs(5);
+
+/// Minimum interval between saturation warns per worker.
+const SLOT_WAIT_WARN_PERIOD: Duration = Duration::from_secs(30);
 
 /// Compute exponential backoff with cap: `min(base * 2^attempts, max)`.
 ///
@@ -150,6 +157,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> Worker<D> {
     /// Each pulled job is spawned as a local monoio task, bounded by
     /// `concurrency`.
     pub(crate) fn spawn(
+        pool: &'static str,
         id: usize,
         dispatcher: Arc<D>,
         queue: Arc<JobQueue>,
@@ -157,7 +165,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> Worker<D> {
         fault_tx: kanal::AsyncSender<SchedulerFault>,
         concurrency: usize,
     ) -> Self {
-        let thread_name = format!("worker-{id}");
+        let thread_name = format!("{pool}-worker-{id}");
         let handle = std::thread::Builder::new()
             .name(thread_name.clone())
             .spawn(move || {
@@ -167,6 +175,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> Worker<D> {
                         .build()
                         .expect("failed to build monoio runtime")
                         .block_on(worker_loop(
+                            pool,
                             id,
                             dispatcher,
                             Arc::clone(&queue),
@@ -231,6 +240,7 @@ fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
 /// This ensures the worker only pulls from the shared queue when it has
 /// capacity to run the job — other workers can grab jobs in the meantime.
 async fn worker_loop<D: ExecuteGarblerJob + ExecuteEvaluatorJob>(
+    pool: &'static str,
     id: usize,
     dispatcher: Arc<D>,
     queue: Arc<JobQueue>,
@@ -252,9 +262,12 @@ async fn worker_loop<D: ExecuteGarblerJob + ExecuteEvaluatorJob>(
     let (task_done_tx, task_done_rx) = kanal::unbounded_async();
 
     async move {
-        tracing::info!(concurrency, "worker started");
+        tracing::info!(pool, concurrency, "worker started");
 
         let mut active_tasks = 0usize;
+        // Throttle for the saturation warn below: a saturated pool would
+        // otherwise warn on every job pull.
+        let mut last_slot_warn: Option<Instant> = None;
         loop {
             // Keep the count current during normal operation. Notifications
             // are unbounded and one-to-one with spawned tasks.
@@ -263,9 +276,30 @@ async fn worker_loop<D: ExecuteGarblerJob + ExecuteEvaluatorJob>(
             }
 
             // 1. Wait for capacity — blocks if all permits are held by in-flight tasks.
+            // Two `Instant` reads per job pull; everything else below is on
+            // the already-saturated path.
+            let permit_wait_started = Instant::now();
             if permit_rx.recv().await.is_err() {
                 tracing::debug!("permit channel closed; worker exiting");
                 break;
+            }
+            let permit_waited = permit_wait_started.elapsed();
+            // All slots were busy for a while AND work is queued behind
+            // them — the visible symptom of pool saturation (e.g. table
+            // receives holding light-pool slots for minutes).
+            if permit_waited >= SLOT_WAIT_WARN_THRESHOLD
+                && !queue.is_empty()
+                && last_slot_warn.is_none_or(|at| at.elapsed() >= SLOT_WAIT_WARN_PERIOD)
+            {
+                tracing::warn!(
+                    pool,
+                    worker = id,
+                    concurrency,
+                    waited_ms = permit_waited.as_millis(),
+                    queued = queue.len(),
+                    "pool at capacity — queued jobs delayed waiting for a free slot"
+                );
+                last_slot_warn = Some(Instant::now());
             }
             let permit = PermitGuard::new(permit_tx.clone());
 
@@ -348,7 +382,7 @@ async fn worker_loop<D: ExecuteGarblerJob + ExecuteEvaluatorJob>(
                 .instrument(tracing::debug_span!(
                     "job_scheduler.worker_job",
                     worker = id,
-                    peer = ?peer_id,
+                    peer = %peer_id,
                     role,
                     attempts
                 )),
@@ -766,6 +800,7 @@ mod tests {
             // Concurrency of 1: the retrying job and the completing job
             // compete for the same slot.
             let worker = monoio::spawn(worker_loop(
+                "test",
                 0,
                 dispatcher,
                 Arc::clone(&queue),
@@ -834,6 +869,7 @@ mod tests {
             let (fault_tx, _fault_rx) = kanal::bounded_async(1);
 
             let worker = monoio::spawn(worker_loop(
+                "test",
                 0,
                 dispatcher,
                 Arc::clone(&queue),
@@ -895,6 +931,7 @@ mod tests {
             drop(completion_rx);
 
             let worker = monoio::spawn(worker_loop(
+                "test",
                 0,
                 dispatcher,
                 Arc::clone(&queue),

--- a/crates/job/scheduler/src/scheduler.rs
+++ b/crates/job/scheduler/src/scheduler.rs
@@ -182,12 +182,14 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
         let factory: Arc<dyn SessionFactory> = Arc::clone(&executor) as Arc<dyn SessionFactory>;
 
         let light = JobThreadPool::new(
+            "light",
             config.light,
             Arc::clone(&executor),
             completion_tx.clone(),
             fault_tx.clone(),
         );
         let heavy = JobThreadPool::new(
+            "heavy",
             config.heavy,
             Arc::clone(&executor),
             completion_tx.clone(),
@@ -319,7 +321,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
                         Ok(SchedulerFault::CompletionChannelClosed { source, peer_id }) => {
                             tracing::error!(
                                 source,
-                                peer = ?peer_id,
+                                peer = %peer_id,
                                 "job scheduler completion delivery failed; shutting down fail-closed"
                             );
                             break;
@@ -360,7 +362,7 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
         };
         let span = tracing::debug_span!(
             "job_scheduler.dispatch_batch",
-            peer = ?peer_id,
+            peer = %peer_id,
             role,
             actions = action_count
         );
@@ -490,13 +492,13 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
         self.garbling
             .as_ref()
             .expect("garbling coordinator must exist while scheduler is running")
-            .submit(PendingCircuitJob {
+            .submit(PendingCircuitJob::new(
                 peer_id,
-                action: circuit_action,
-                priority: action.priority(),
-            })
+                circuit_action,
+                action.priority(),
+            ))
             .await;
-        tracing::debug!(peer = ?peer_id, action = ?action, "submitted garbler circuit action");
+        tracing::debug!(peer = %peer_id, action = ?action, "submitted garbler circuit action");
     }
 
     /// Build a [`PendingCircuitJob`] for an evaluator circuit action and
@@ -535,13 +537,13 @@ impl<D: ExecuteGarblerJob + ExecuteEvaluatorJob> JobScheduler<D> {
         self.garbling
             .as_ref()
             .expect("garbling coordinator must exist while scheduler is running")
-            .submit(PendingCircuitJob {
+            .submit(PendingCircuitJob::new(
                 peer_id,
-                action: circuit_action,
-                priority: action.priority(),
-            })
+                circuit_action,
+                action.priority(),
+            ))
             .await;
-        tracing::debug!(peer = ?peer_id, action = ?action, "submitted evaluator circuit action");
+        tracing::debug!(peer = %peer_id, action = ?action, "submitted evaluator circuit action");
     }
 
     /// Shut down all pools gracefully.

--- a/crates/storage/s3/src/writer.rs
+++ b/crates/storage/s3/src/writer.rs
@@ -152,15 +152,26 @@ const STORE_PROGRESS_PERIOD: Duration = Duration::from_secs(30);
 /// additionally diluted by time spent waiting for the producer to supply data.
 /// `put` well above `avg` means we are starved upstream; the two converging
 /// means the store is the constraint.
-fn log_store_progress(event: &str, parts: u64, bytes_put: u64, started: Instant, in_put: Duration) {
+fn log_store_progress(
+    event: &str,
+    path: &object_store::path::Path,
+    parts: u64,
+    bytes_put: u64,
+    started: Instant,
+    in_put: Duration,
+) {
     let wall = started.elapsed().as_secs_f64().max(1e-3);
     let put_secs = in_put.as_secs_f64().max(1e-3);
+    // The path embeds the sending peer's full hex id and the circuit index
+    // (`…/{peer_hex}/{index}/versions/…`), so concurrent receives on one
+    // node stay attributable to their table.
     tracing::info!(
         target: "mosaic_progress",
         phase = "table.store",
-        "table.store {} parts={} uploaded={:.1}GiB put={:.1}MB/s avg={:.1}MB/s \
+        "table.store {} path={} parts={} uploaded={:.1}GiB put={:.1}MB/s avg={:.1}MB/s \
          elapsed={:.0}s in_put={:.0}s({:.0}%)",
         event,
+        path,
         parts,
         bytes_put as f64 / (1024.0 * 1024.0 * 1024.0),
         bytes_put as f64 / put_secs / 1.0e6,
@@ -221,7 +232,14 @@ async fn background_writer_inner(
                 }
 
                 if last_log.elapsed() >= STORE_PROGRESS_PERIOD {
-                    log_store_progress("progress", parts, bytes_put, upload_started, in_put);
+                    log_store_progress(
+                        "progress",
+                        &version_paths.ciphertexts,
+                        parts,
+                        bytes_put,
+                        upload_started,
+                        in_put,
+                    );
                     last_log = Instant::now();
                 }
             }
@@ -244,7 +262,14 @@ async fn background_writer_inner(
                 // Complete the multipart upload.
                 upload.complete().await?;
 
-                log_store_progress("summary", parts, bytes_put, upload_started, in_put);
+                log_store_progress(
+                    "summary",
+                    &version_paths.ciphertexts,
+                    parts,
+                    bytes_put,
+                    upload_started,
+                    in_put,
+                );
 
                 // Upload translation material as a single object under the staged version.
                 store

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -12,11 +12,37 @@ Every line attributes elapsed wall-clock to named stages as
 `stage=<duration>(<percent of elapsed>)`. The `table.*` lines omit zero
 stages; `circuit.pass` always prints all four of its pairs.
 
+At startup the binary logs the cut-and-choose variant it was built with —
+use it to bound deploy windows and confirm the CaC parameters from logs
+alone (the build revision itself comes from the deployed image's tag):
+
+```text
+mosaic starting n_circuits=5 n_open_circuits=3
+```
+
+## Identity fields (all phases)
+
+Every progress line carries explicit identity fields instead of a bare `id=`.
+Short hashes (`0x` + 8 hex chars) are prefixes of the full lowercase hex
+encoding, so grepping a short id also matches log fields carrying the full
+value.
+
+| Field | Meaning |
+|---|---|
+| `peer=` | The counterparty this work item serves: transfer/receive peer, or the peer a commitment/verification is being built for |
+| `circuit_index=` | The circuit index (1..=N_CIRCUITS) identifying the table within a pair |
+| `pass=` | Coordinator pass sequence number (pass-scoped lines only) |
+
+`(peer, circuit_index)` identifies a table. Cross-node join: the sender's
+`table.upload`/`table.wire` on node A (`peer=` naming B) matches the
+receiver's `table.receive` on node B (`peer=` naming A) at the same
+`circuit_index` — so a table can be followed sender → wire → receiver →
+store → evaluation without timestamp guesswork.
+
 ## Common fields (`table.upload` / `table.wire` / `table.receive`)
 
 | Field | Meaning |
 |---|---|
-| `id=` | Work-item short id: commitment hash for upload/wire, sender peer id for receive |
 | `done=` | Cumulative bytes, with `/total` when the total is known |
 | `pct=` | `done` as a percentage of the total |
 | `inst=` / `avg=` | Throughput since the last line / since phase start |
@@ -29,8 +55,24 @@ One line per pass. The circuit read of chunk N+1 is pipelined against the
 barrier (all workers finishing chunk N), so the pass advances at
 `max(read, barrier)` per chunk.
 
+At pass start, one `assign` line per session records the pass composition:
+
+```text
+circuit.pass assign pass=12 class=io worker=2 peer=0x9b41d7aa action=garbler_transfer attempts=0 queue_wait=4s
+```
+
 | Field | Meaning |
 |---|---|
+| `worker=` | Worker thread the session landed on (round-robin deal) |
+| `action=` | `garbler_commitment`, `garbler_transfer`, `evaluator_commitment`, or `evaluator_evaluation`, with `circuit_index=` where the action carries one. Garbling seeds are secrets and never logged; a transfer's `circuit_index` appears on its `table.upload` line instead |
+| `attempts=` | Times this job bounced back to the backlog (0 = first try) |
+| `queue_wait=` | Time the job spent queued since submission or its last bounce |
+
+`progress`/`summary` lines:
+
+| Field | Meaning |
+|---|---|
+| `pass=` | Pass sequence number, joins with `assign` lines and strike/evict warns |
 | `class=` | Session class of this pass, `compute` or `io` (passes are class-homogeneous) |
 | `sessions=` | Sessions served by the pass |
 | `read=` / `avg=` | Converted circuit bytes broadcast so far, and their rate |
@@ -38,10 +80,10 @@ barrier (all workers finishing chunk N), so the pass advances at
 | `barrier_gated=` | Wall-clock where the read was done but workers were still processing |
 | `read_busy=` | Raw busy time of the read+convert side |
 | `barrier_busy=` | Raw busy time of the barrier side |
-| `straggler=` | Worker that accumulated the most barrier wait (in-order skew: a slow worker early in the list can mask later ones) |
+| `straggler_peer=` | Peer whose session accumulated the most busy time processing chunks — the session that held the barrier longest. Measured per session inside the workers, so it has no report-ordering skew |
 
 ```text
-circuit.pass progress class=io sessions=5 read=84.4GiB avg=50.3MB/s elapsed=1800s read_gated=12s(1%) barrier_gated=1493s(83%) read_busy=289s(16%) barrier_busy=1782s(99%) straggler=worker2(1102s)
+circuit.pass progress pass=12 class=io sessions=5 read=84.4GiB avg=50.3MB/s elapsed=1800s read_gated=12s(1%) barrier_gated=1493s(83%) read_busy=289s(16%) barrier_busy=1782s(99%) straggler_peer=0x9b41d7aa(1102s)
 ```
 
 **Reading the two pairs.** The `*_gated` values are *attribution*: additive
@@ -52,6 +94,19 @@ are *utilization*: they overlap under pipelining (together they can approach
 hit after fixing the current gate. Example: `barrier_gated=10%` with
 `read_busy=90%` means the barrier paces the pass, but fixing it only buys 10%
 before the read becomes the gate.
+
+Strike and eviction warns (plain `warn` level, not `mosaic_progress`) carry
+`worker=`, `pass=`, and `peer=` (full hex), so they join against the same
+pass and peer.
+
+## `garbling.commit` / `garbling.verify` — commitment garbling (G3/E3)
+
+Block-unit heartbeats for commitment garbling (G3) and opened-table
+re-garbling verification (E3). Identity: `peer=` + `circuit_index=`.
+
+```text
+garbling.verify progress peer=0x9b41d7aa circuit_index=3 pct=~62% elapsed=2m10s
+```
 
 ## `table.upload` — garbler, producer side (G8)
 
@@ -64,14 +119,20 @@ progress trails by at most one outbox (~a few MiB).
 | `compute=` | Garbling gates (local CPU) |
 | `outbox_full=` | Parked in the outbox `send` — the peer has fallen a full outbox behind (sustained backpressure). Preserved even when the session is evicted mid-send |
 
+The summary line additionally reports `outbox_hwm=<peak>/<depth>` — the
+highest outbox occupancy observed, in buffers. It answers whether the
+configured `transfer_outbox_depth` was actually used: `outbox_full` alone
+cannot distinguish a near-full outbox from an empty one.
+
 ```text
-table.upload progress id=0x3fa2c81d done=12.4GiB/40.1GiB pct=30.9% inst=52MB/s avg=51MB/s elapsed=4m22s eta=10m13s compute=3m30s(80%) outbox_full=31s(12%)
+table.upload progress peer=0x9b41d7aa circuit_index=4 done=12.4GiB/40.1GiB pct=30.9% inst=52MB/s avg=51MB/s elapsed=4m22s eta=10m13s compute=3m30s(80%) outbox_full=31s(12%)
+table.upload summary peer=0x9b41d7aa circuit_index=4 done=40.1GiB/40.1GiB pct=100.0% inst=50MB/s avg=51MB/s elapsed=13m20s compute=10m41s(80%) outbox_full=1m10s(9%) outbox_hwm=137/256
 ```
 
 ## `table.wire` — garbler, drain side (G8)
 
-The wire truth for the same transfer (same `id` as its `table.upload`):
-bytes actually written to the peer.
+The wire truth for the same transfer (same identity fields as its
+`table.upload`): bytes actually written to the peer.
 
 | Stage | Meaning |
 |---|---|
@@ -79,12 +140,16 @@ bytes actually written to the peer.
 | `feed_wait=` | Waiting on the garbler for the next buffer — compute, not the wire, is the constraint |
 
 ```text
-table.wire progress id=0x3fa2c81d done=12.4GiB/40.1GiB pct=30.9% inst=45MB/s avg=50MB/s elapsed=4m24s eta=11m49s net_blocked=4m01s(91%) feed_wait=15s(6%)
+table.wire progress peer=0x9b41d7aa circuit_index=4 done=12.4GiB/40.1GiB pct=30.9% inst=45MB/s avg=50MB/s elapsed=4m24s eta=11m49s net_blocked=4m01s(91%) feed_wait=15s(6%)
 ```
 
 ## `table.receive` — evaluator ingest (E4)
 
 Consumes a peer's bulk stream and forwards ciphertext to the table store.
+`peer=` is the **sending** peer, so this line joins the sender's
+`table.upload`/`table.wire` at the same `circuit_index`. The total
+(translation + expected ciphertext) is known up front, so `pct=`/`eta=`
+are present.
 
 | Stage | Meaning |
 |---|---|
@@ -92,32 +157,56 @@ Consumes a peer's bulk stream and forwards ciphertext to the table store.
 | `store_blocked=` | Blocked in `write_ciphertext` — the object-store upload is not keeping up |
 
 ```text
-table.receive summary id=0x9b41d7aa done=40.1GiB inst=41MB/s avg=42MB/s elapsed=17m05s net_wait=12m40s(74%) store_blocked=3m22s(20%)
+table.receive summary peer=0x9b41d7aa circuit_index=4 done=40.1GiB/40.1GiB pct=100.0% inst=41MB/s avg=42MB/s elapsed=17m05s net_wait=12m40s(74%) store_blocked=3m22s(20%)
 ```
+
+## `table.eval` — evaluation of a stored table (E8)
+
+Block-unit heartbeat while a stored table is evaluated during a dispute.
+Identity: `peer=` + `circuit_index=`.
 
 ## `table.store` — object-store upload
 
-Emitted by the S3 background writer while shipping a received table.
+Emitted by the S3 background writer while shipping a received table. The
+`path=` embeds the sending peer's full hex id and the circuit index
+(`…/{peer_hex}/{circuit_index}/versions/…`), so concurrent receives on one
+node stay attributable.
 
 | Field | Meaning |
 |---|---|
+| `path=` | Ciphertext object path — the table's identity |
 | `parts=` / `uploaded=` | Multipart parts and bytes uploaded |
 | `put=` | Throughput while actually inside `put_part` — the store's own speed |
 | `avg=` | Throughput against wall-clock, diluted by waiting for the producer |
 | `in_put=` | Serialized time inside `put_part` |
 
 ```text
-table.store progress parts=806 uploaded=6.3GiB put=118.7MB/s avg=37.6MB/s elapsed=180s in_put=57s(32%)
+table.store progress path=tables/9b41…d7aa/4/versions/0000…0001/ciphertexts parts=806 uploaded=6.3GiB put=118.7MB/s avg=37.6MB/s elapsed=180s in_put=57s(32%)
 ```
 
 `put` well above `avg` means the writer is starved upstream; the two
 converging means the store is the constraint.
 
+## Pool saturation warns
+
+Pool workers warn (throttled to one per 30 s per worker) when all slots were
+busy for 5 s+ while jobs were queued behind them:
+
+```text
+pool at capacity — queued jobs delayed waiting for a free slot pool="light" worker=0 concurrency=512 waited_ms=6200 queued=17
+```
+
+On the light pool this is the signature of table receives holding slots for
+minutes while small protocol messages queue behind them (the reason
+production runs `concurrency_per_worker = 512`).
+
 ## Diagnosis recipe
 
 A slow transfer names its bottleneck by which stage dominates, and the lines
 corroborate each other across nodes: sender `outbox_full`/`net_blocked` high →
-look at that receiver's `table.receive`; there, `store_blocked` high → look at
-its `table.store` `put` rate. `circuit.pass barrier_gated` high in an `io`
-pass means some session — and so some peer, or that peer's store — gates
-every table in the pass; `straggler` says which worker to inspect first.
+find that receiver's `table.receive` for the sending peer at the same
+`circuit_index`; there, `store_blocked` high → look at its `table.store`
+`put` rate for the matching `path=`. `circuit.pass barrier_gated` high in an `io` pass means some
+session — and so some peer, or that peer's store — gates every table in the
+pass; `straggler_peer` names the peer directly, and the pass's `assign`
+lines list who else shared the batch (and so was coupled to it).


### PR DESCRIPTION
## Description
Adds peer attribution to all relevant logs and additional logs based on gaps seen during performance testing.

### What changed

**Identity on every line.** Work items are identified by `(peer, circuit_index)` instead of bare `id=` hashes, across `table.upload`/`table.wire`/`table.receive`/`table.eval` and `garbling.commit`/`verify`. Cross-node join: the sender's line on node A (`peer=` naming B) matches the receiver's line on node B (`peer=` naming A) at the same `circuit_index`. `table.receive` now also gets `pct=`/`eta=` from its known total.

**Pass structure.** A monotonic `pass=` appears on all pass-scoped lines, including strike/eviction warns. At pass start, one `circuit.pass assign` line per session records the batch composition: worker, peer, action, `attempts=` (bounce count) and `queue_wait=` (backed by new `queued_at`/`attempts` fields on `PendingCircuitJob`).

**Straggler by peer.** Workers now time each session's `process_chunk` in place and report per-peer busy-time deltas with each chunk report; the `circuit.pass` summary prints `straggler_peer=0x…(…s)`. This replaces the coordinator-side per worker report wait, which was collected in order and could record ~0 for a genuinely slow worker.

**Outbox visibility.** `table.upload` summaries report `outbox_hwm=<peak>/<depth>` — whether the configured `transfer_outbox_depth` was actually used, which `outbox_full` alone cannot distinguish. Tracked via one shared atomic between producer and drain.

**Others** 
* `table.store` lines carry the object `path=` (embeds sender peer + circuit index)
* pool workers emit a throttled warn when all slots are busy with jobs still queued (`pool="light"/"heavy"`)
* startup logs the CaC variant (`n_circuits`/`n_open_circuits`).


<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] If this PR touches the wire-visible protocol surface — message types in `crates/cac/types`, garbler/evaluator STF semantics peers depend on in `crates/cac/protocol`, or net-svc framing/priorities — I bumped `PROTOCOL_VERSION` in `crates/net/svc-api/src/handshake.rs`.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
