### PR TITLE
feat: double-buffer part uploads in the table writer

### DIFF
--- a/crates/storage/s3/src/lib.rs
+++ b/crates/storage/s3/src/lib.rs
@@ -40,8 +40,8 @@ pub const MIN_PART_SIZE: usize = 5 * 1024 * 1024;
 
 /// Default buffer size for ciphertext parts.
 ///
-/// Parts are uploaded when the buffer reaches this size. Parts upload
-/// serially, and single-stream S3 throughput scales with part size, so
+/// A full part uploads in the background while the next buffers (one part
+/// in flight). Single-stream S3 throughput scales with part size, so
 /// deployments can raise this via [`S3TableStore::with_part_buffer_size`]
 /// at the cost of ~2x the part size in memory per active upload.
 pub const DEFAULT_PART_BUFFER_SIZE: usize = 8 * 1024 * 1024;

--- a/crates/storage/s3/src/writer.rs
+++ b/crates/storage/s3/src/writer.rs
@@ -34,10 +34,10 @@ enum WriterCmd {
 
 /// Streams garbling table data to object storage via a background tokio task.
 ///
-/// Ciphertext chunks are buffered and uploaded as multipart parts when the
-/// buffer exceeds the store's configured part buffer size (default
-/// [`DEFAULT_PART_BUFFER_SIZE`](crate::DEFAULT_PART_BUFFER_SIZE)).
-/// Translation material and metadata are
+/// Ciphertext chunks fill fixed part-size buffers (default
+/// [`DEFAULT_PART_BUFFER_SIZE`](crate::DEFAULT_PART_BUFFER_SIZE)); a full
+/// part uploads in a background task while the next buffer fills (double
+/// buffering, one part in flight). Translation material and metadata are
 /// written under an immutable version prefix, then a live commit marker is
 /// published on [`finish`](Self::finish).
 ///
@@ -156,13 +156,42 @@ async fn background_writer(
 /// Minimum interval between object-store upload progress lines.
 const STORE_PROGRESS_PERIOD: Duration = Duration::from_secs(30);
 
+/// A part upload running in the background while the next buffer fills.
+struct InFlightPart {
+    /// Task driving the `put_part` future to completion.
+    handle: tokio::task::JoinHandle<Result<(), object_store::Error>>,
+    /// Size of the part being uploaded.
+    bytes: u64,
+}
+
+/// Wait for the in-flight part upload, if any, folding the time spent
+/// blocked here — the store failing to keep up with the producer — into
+/// `in_put`.
+async fn reap_in_flight(
+    in_flight: &mut Option<InFlightPart>,
+    parts: &mut u64,
+    bytes_put: &mut u64,
+    in_put: &mut Duration,
+) -> Result<(), S3Error> {
+    if let Some(f) = in_flight.take() {
+        let wait_started = Instant::now();
+        f.handle
+            .await
+            .map_err(|e| S3Error::StreamIo(format!("part upload task failed: {e}")))??;
+        *in_put += wait_started.elapsed();
+        *parts += 1;
+        *bytes_put += f.bytes;
+    }
+    Ok(())
+}
+
 /// Emit one object-store upload progress line.
 ///
-/// `put` is the throughput achieved while actually inside `put_part` — the
-/// store's own speed — whereas `avg` is measured against wall-clock and so is
-/// additionally diluted by time spent waiting for the producer to supply data.
-/// `put` well above `avg` means we are starved upstream; the two converging
-/// means the store is the constraint.
+/// `in_put` is the time the writer sat blocked on the store: waiting for a
+/// background part upload it could not overlap with buffering, plus the
+/// final flush. `avg` is measured against wall-clock. `put` well above
+/// `avg` means uploads are hiding behind the producer (we are starved
+/// upstream); the two converging means the store is the constraint.
 fn log_store_progress(
     event: &str,
     path: &object_store::path::Path,
@@ -204,12 +233,14 @@ async fn background_writer_inner(
     let mut upload = store.put_multipart(&version_paths.ciphertexts).await?;
     let mut buffer = Vec::with_capacity(part_buffer_size);
 
-    // Upload-side progress. Parts are uploaded one at a time (each `put_part`
-    // is awaited before the next begins), so `in_put` is the true serialized
-    // cost of shipping this table to the object store. When it approaches the
-    // wall-clock, the store — not the peer or the CPU — is what is pacing the
-    // transfer, and the backpressure surfaces upstream through the bounded
-    // command channel.
+    // Double buffering: one part uploads in a background task while the next
+    // buffer fills from the channel, so upload time hides behind the wait
+    // for the producer. The writer blocks only when a buffer fills before
+    // the previous part finished; `in_put` accumulates exactly that blocked
+    // time, so when it approaches the wall-clock the store — not the peer —
+    // is pacing the transfer, and the backpressure surfaces upstream through
+    // the bounded command channel.
+    let mut in_flight: Option<InFlightPart> = None;
     let upload_started = Instant::now();
     let mut last_log = upload_started;
     let mut parts: u64 = 0;
@@ -220,7 +251,11 @@ async fn background_writer_inner(
         let cmd = match cmd_rx.recv().await {
             Ok(cmd) => cmd,
             Err(_) => {
-                // Channel closed without Finish — abort the upload.
+                // Channel closed without Finish — settle any in-flight part
+                // (its result no longer matters), then abort the upload.
+                if let Some(f) = in_flight.take() {
+                    let _ = f.handle.await;
+                }
                 upload.abort().await?;
                 return Err(S3Error::StreamIo(
                     "writer dropped without calling finish".into(),
@@ -232,10 +267,8 @@ async fn background_writer_inner(
             WriterCmd::Write(data) => {
                 // Fill the buffer exactly to the part size and hand it off
                 // whole, splitting incoming chunks on part boundaries. The
-                // buffer never grows past its initial capacity (appending
-                // past it would double the allocation, which `drain` never
-                // returns), and moving it into `Bytes` avoids copying the
-                // part.
+                // buffer never grows past its initial capacity, and moving
+                // it into `Bytes` avoids copying the part.
                 let mut data = data.as_slice();
                 while !data.is_empty() {
                     let take = data.len().min(part_buffer_size - buffer.len());
@@ -243,14 +276,19 @@ async fn background_writer_inner(
                     data = &data[take..];
 
                     if buffer.len() == part_buffer_size {
+                        // Both buffers full: block until the previous part
+                        // finishes before starting the next one.
+                        reap_in_flight(&mut in_flight, &mut parts, &mut bytes_put, &mut in_put)
+                            .await?;
+
                         let part =
                             std::mem::replace(&mut buffer, Vec::with_capacity(part_buffer_size));
-                        let n = part.len() as u64;
-                        let put_started = Instant::now();
-                        upload.put_part(Bytes::from(part).into()).await?;
-                        in_put += put_started.elapsed();
-                        parts += 1;
-                        bytes_put += n;
+                        let bytes = part.len() as u64;
+                        let fut = upload.put_part(Bytes::from(part).into());
+                        in_flight = Some(InFlightPart {
+                            handle: tokio::task::spawn(fut),
+                            bytes,
+                        });
                     }
                 }
 
@@ -271,7 +309,9 @@ async fn background_writer_inner(
                 translation,
                 metadata_bytes,
             } => {
-                // Upload any remaining buffered ciphertext as the final part.
+                // Settle the in-flight part, then upload any remaining
+                // buffered ciphertext as the final part.
+                reap_in_flight(&mut in_flight, &mut parts, &mut bytes_put, &mut in_put).await?;
                 if !buffer.is_empty() {
                     let final_part = std::mem::take(&mut buffer);
                     let n = final_part.len() as u64;


### PR DESCRIPTION
## Description

Stacked on #334. Optional, and independent of the part-size change.

Until now the writer awaited each put_part inline. While a part was uploading it wasn't reading from the channel, so the network receive stalled every time, and the two legs added up: a table took receive time plus upload time. Run 4 showed how much that costs. Receives sat in store_blocked about 75% of wall time across the fleet, meaning the serialized upload leg was pacing table transfers, not the peer network.

With this change a full part uploads in a background task while the next buffer fills. The writer only blocks when a buffer fills before the previous part finished, so per-table throughput moves toward whichever leg is slower instead of the sum of both.

* Threading is unchanged. The spawned task runs on the same dedicated storage runtime, and there's no new config or API surface.
* Memory per active upload is still about 2x the part size. The difference is that both buffers are now hot, where before it was one buffer plus an in-flight copy.
* The in_put= field in table.store progress lines changed meaning: it now counts time the writer spent blocked on the store rather than time inside put_part. Reading the lines stays intuitive. If put= is far above avg=, uploads hid behind the producer entirely; if they converge, the store is the constraint.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] If this PR touches the wire-visible protocol surface — message types in `crates/cac/types`, garbler/evaluator STF semantics peers depend on in `crates/cac/protocol`, or net-svc framing/priorities — I bumped `PROTOCOL_VERSION` in `crates/net/svc-api/src/handshake.rs`.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
